### PR TITLE
JVECTOR-8

### DIFF
--- a/src/main/java/com/github/jbellis/jvector/disk/OnDiskGraphIndex.java
+++ b/src/main/java/com/github/jbellis/jvector/disk/OnDiskGraphIndex.java
@@ -62,7 +62,7 @@ public class OnDiskGraphIndex<T> implements GraphIndex<T>, AutoCloseable, Accoun
     }
 
     /** return a Graph that can be safely queried concurrently */
-    public GraphIndex.View<T> getView()
+    public OnDiskGraphIndex<T>.OnDiskView getView()
     {
         return new OnDiskView(readerSupplier.get());
     }

--- a/src/main/java/com/github/jbellis/jvector/graph/NodesIterator.java
+++ b/src/main/java/com/github/jbellis/jvector/graph/NodesIterator.java
@@ -37,6 +37,10 @@ public abstract class NodesIterator implements PrimitiveIterator.OfInt {
             this.nodes = nodes;
         }
 
+        public ArrayNodesIterator(int[] nodes) {
+            this(nodes, nodes.length);
+        }
+
         @Override
         public int nextInt() {
             if (!hasNext()) {

--- a/src/test/java/com/github/jbellis/jvector/TestUtil.java
+++ b/src/test/java/com/github/jbellis/jvector/TestUtil.java
@@ -1,9 +1,207 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.jbellis.jvector;
 
-import java.util.Random;
+import com.github.jbellis.jvector.graph.GraphIndex;
+import com.github.jbellis.jvector.graph.NodesIterator;
+
+import java.io.*;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
 
 public class TestUtil {
     public static int nextInt(Random random, int min, int max) {
         return min + random.nextInt(max - min);
+    }
+
+    public static DataOutputStream openFileForWriting(Path outputPath) throws IOException {
+        return new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(outputPath)));
+    }
+
+    /**
+     * Deletes target Path and its contents (if applicable). Never throws an exception. Only suitable for tests.
+     * Visits all levels of file tree and does not follow symlinks.
+     * Exceptions will terminate the walk and print errors on stderr.
+     * @param targetPath Path to delete
+     */
+    public static void deleteQuietly(Path targetPath) {
+        try {
+            Files.walkFileTree(targetPath, new FileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    System.err.println("deleteQuietly encountered an Exception when visiting file: " + exc.toString());
+                    return FileVisitResult.TERMINATE;
+
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    if (exc != null) {
+                        System.err.println("deleteQuietly encountered an Exception after visiting directory: " + exc.toString());
+                        return FileVisitResult.TERMINATE;
+                    }
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            System.err.println("deleteQuietly encountered an Exception: " + e.toString());
+        }
+    }
+
+    public static class FullyConnectedGraphIndex<T> implements GraphIndex<T> {
+
+        private final int entryNode;
+        private final int size;
+
+        public FullyConnectedGraphIndex(int entryNode, int size) {
+            this.entryNode = entryNode;
+            this.size = size;
+        }
+
+        @Override
+        public int size()
+        {
+            return size;
+        }
+
+        @Override
+        public NodesIterator getNodes() {
+            return new NodesIterator.ArrayNodesIterator(IntStream.range(0, size).toArray(),  size);
+        }
+
+        @Override
+        public View<T> getView() {
+            return new FullyConnectedGraphIndexView();
+        }
+
+        @Override
+        public int maxEdgesPerNode() {
+            return size;
+        }
+
+        private class FullyConnectedGraphIndexView implements View<T> {
+
+            @Override
+            public NodesIterator getNeighborsIterator(int node) {
+                return new NodesIterator.ArrayNodesIterator(IntStream.range(0, size).filter(i -> i != node).toArray() , size - 1);
+            }
+
+            @Override
+            public int size() {
+                return size;
+            }
+
+            @Override
+            public int entryNode() {
+                return entryNode;
+            }
+
+            @Override
+            public T getVector(int node) {
+                throw new UnsupportedOperationException("No vectors associated with FullyConnectedGraphIndex");
+            }
+        }
+    }
+
+    public static class RandomlyConnectedGraphIndex<T> implements GraphIndex<T> {
+
+        private final int size;
+        private final Map<Integer, int[]> nodes;
+        private final int entryNode;
+
+        public RandomlyConnectedGraphIndex(int size, int M, Random random) {
+            this.size = size;
+            this.nodes = new ConcurrentHashMap<>();
+
+            var maxNeighbors = Math.min(M, size - 1);
+            var nodeIds = new ArrayList<>(IntStream.range(0, size).boxed().toList());
+            Collections.shuffle(nodeIds, random);
+
+            for (int i = 0; i < size; i++) {
+                Set<Integer> neighborSet = new HashSet<>();
+                while (neighborSet.size() < maxNeighbors) {
+                    var neighborIdx = random.nextInt(size);
+                    if (neighborIdx != i) {
+                        neighborSet.add(nodeIds.get(neighborIdx));
+                    }
+                    nodes.put(nodeIds.get(i), neighborSet.stream().mapToInt(Integer::intValue).toArray());
+                }
+            }
+
+            this.entryNode = random.nextInt(size);
+        }
+
+        @Override
+        public int size()
+        {
+            return size;
+        }
+
+        @Override
+        public NodesIterator getNodes() {
+            return new NodesIterator.ArrayNodesIterator(IntStream.range(0, size).toArray(),  size);
+        }
+
+        @Override
+        public View<T> getView() {
+            return new RandomlyConnectedGraphIndexView();
+        }
+
+        @Override
+        public int maxEdgesPerNode() {
+            return nodes.get(0).length;
+        }
+
+        private class RandomlyConnectedGraphIndexView implements View<T> {
+
+            @Override
+            public NodesIterator getNeighborsIterator(int node) {
+                return new NodesIterator.ArrayNodesIterator(nodes.get(node));
+            }
+
+            @Override
+            public int size() {
+                return size;
+            }
+
+            @Override
+            public int entryNode() {
+                return entryNode;
+            }
+
+            @Override
+            public T getVector(int node) {
+                throw new UnsupportedOperationException("No vectors associated with RandomlyConnectedGraphIndex");
+            }
+        }
     }
 }

--- a/src/test/java/com/github/jbellis/jvector/graph/TestOnDiskGraphIndex.java
+++ b/src/test/java/com/github/jbellis/jvector/graph/TestOnDiskGraphIndex.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.jbellis.jvector.graph;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.github.jbellis.jvector.TestUtil;
+import com.github.jbellis.jvector.disk.CachingGraphIndex;
+import com.github.jbellis.jvector.disk.OnDiskGraphIndex;
+import com.github.jbellis.jvector.example.util.MappedRandomAccessReader;
+import org.junit.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class TestOnDiskGraphIndex extends RandomizedTest {
+
+    private Path testDirectory;
+
+    private TestUtil.FullyConnectedGraphIndex<float[]> fullyConnectedGraph;
+    private TestUtil.RandomlyConnectedGraphIndex<float[]> randomlyConnectedGraph;
+
+    @Before
+    public void setup() throws IOException {
+        fullyConnectedGraph = new TestUtil.FullyConnectedGraphIndex<>(0, 6);
+        randomlyConnectedGraph = new TestUtil.RandomlyConnectedGraphIndex<>(10, 4, getRandom());
+        testDirectory = Files.createTempDirectory(this.getClass().getSimpleName());
+    }
+
+    @After
+    public void tearDown() {
+        TestUtil.deleteQuietly(testDirectory);
+    }
+
+    private <T> void validateGraph(GraphIndex.View<T> expectedView, GraphIndex.View<T> actualView) throws Exception {
+        assertEquals(expectedView.size(), actualView.size());
+        assertEquals(expectedView.entryNode(), actualView.entryNode());
+
+        var nodes = expectedView.getSortedNodes();
+        assertArrayEquals(nodes, actualView.getSortedNodes());
+
+        // For each node, check its neighbors
+        for (int j : nodes) {
+            var expectedNeighbors = expectedView.getNeighborsIterator(j);
+            var actualNeighbors = actualView.getNeighborsIterator(j);
+            assertEquals(expectedNeighbors.size(), actualNeighbors.size());
+            while (expectedNeighbors.hasNext()) {
+                assertEquals(expectedNeighbors.nextInt(), actualNeighbors.nextInt());
+            }
+            assertFalse(actualNeighbors.hasNext());
+        }
+    }
+
+    private static <T> void writeGraph(GraphIndex<T> graph, RandomAccessVectorValues<T> vectors, Path outputPath) throws IOException {
+        try (var indexOutputWriter = TestUtil.openFileForWriting(outputPath))
+        {
+            OnDiskGraphIndex.write(graph, vectors, indexOutputWriter);
+            indexOutputWriter.flush();
+        }
+    }
+
+    private static OnDiskGraphIndex<float[]> createOnDiskGraph(Path graphPath) throws IOException {
+        var marr = new MappedRandomAccessReader(graphPath.toAbsolutePath().toString());
+        return new OnDiskGraphIndex<>(marr::duplicate, 0);
+    }
+
+    @Test
+    public void testSimpleGraphs() throws Exception {
+        var outputPath = testDirectory.resolve("test_graph");
+        for (var g : List.of(fullyConnectedGraph, randomlyConnectedGraph))
+        {
+            writeGraph(g, new GraphIndexTestCase.CircularFloatVectorValues(g.size()), outputPath);
+            try (var onDiskGraph = createOnDiskGraph(outputPath); var onDiskView = onDiskGraph.getView())
+            {
+                validateGraph(g.getView(), onDiskView);
+            }
+        }
+    }
+
+    @Test
+    public void testLargeGraph() throws Exception
+    {
+        var graph = new TestUtil.RandomlyConnectedGraphIndex<float[]>(100_000, 16, getRandom());
+        var outputPath = testDirectory.resolve("large_graph");
+        writeGraph(graph, new GraphIndexTestCase.CircularFloatVectorValues(graph.size()), outputPath);
+
+        try (var onDiskGraph = createOnDiskGraph(outputPath); var onDiskView = onDiskGraph.getView())
+        {
+            validateGraph(graph.getView(), onDiskView);
+            validateGraph(graph.getView(), new CachingGraphIndex(onDiskGraph).getView());
+        }
+    }
+}


### PR DESCRIPTION
Bring over roundtrip OnDiskGraphIndex tests and associated helper utilities.

This attempts to replace C*-isms with the appropriate JVector concepts, including paring down the test to not test irrelevant/nonexistent infrastructure.