### PR TITLE
Fix offset math in testing MappedRandomAccessReader readFloatsAt

### DIFF
--- a/src/main/java/com/github/jbellis/jvector/example/util/MappedRandomAccessReader.java
+++ b/src/main/java/com/github/jbellis/jvector/example/util/MappedRandomAccessReader.java
@@ -53,7 +53,7 @@ public class MappedRandomAccessReader implements RandomAccessReader {
     @Override
     public void readFloatsAt(long offset, float[] buffer) {
         for (int i = 0; i < buffer.length; i++) {
-            buffer[i] = mbb.getFloat((int) offset + i);
+            buffer[i] = mbb.getFloat((int) offset + i * Float.BYTES);
         }
     }
 


### PR DESCRIPTION
Offset bug that didn't get exercised until OnDiskGraphIndex started using readFloatsAt.