### PR TITLE
Switch to ThreadLocal cached searcher in GraphIndexBuilder

### DIFF
--- a/src/main/java/com/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/src/main/java/com/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -166,7 +166,7 @@ public class GraphIndexBuilder<T> {
     try {
       // find ANN of the new node by searching the graph
       int ep = graph.entry();
-      var gs = new GraphSearcher.Builder(graph.getView()).withConcurrentUpdates().build(); // TODO cache these (but not with the same View)
+      var gs = graphSearcher.get();
       NeighborSimilarity.ExactScoreFunction scoreFunction = i -> scoreBetween(vectorsCopy.get().vectorValue(i), value);
 
       var bits = new ExcludingBits(node);


### PR DESCRIPTION
This TODO looked essentially resolved, as the ThreadLocal graphSearcher field already existed. Swapping to using a cached searcher with distinct view per thread measurably improved graph building times on my machine. Am I missing something?