### PR TITLE
Swap Maven jdk11 build to use -release 11, which also checks for too-new APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,8 +172,7 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <version>3.11.0</version>
             <configuration>
-              <source>11</source>
-              <target>11</target>
+              <release>11</release>
               <excludes>
                 <exclude>**/jdk20/*.java</exclude>
               </excludes>


### PR DESCRIPTION
-release is slightly stronger than `-source`/`-target` combination and will catch more issues at compile-time.