### PR TITLE
Revert changes to hdf5 path in Bench, set up mvn exec to use parent basedir

### DIFF
--- a/jvector-base/src/main/java/com/github/jbellis/jvector/example/Bench.java
+++ b/jvector-base/src/main/java/com/github/jbellis/jvector/example/Bench.java
@@ -241,10 +241,10 @@ public class Bench {
     public static void main(String[] args) throws IOException {
         System.out.println("Heap space available is " + Runtime.getRuntime().maxMemory());
         var files = List.of(
-                "../hdf5/nytimes-256-angular.hdf5",
-                "../hdf5/glove-100-angular.hdf5",
-                "../hdf5/glove-200-angular.hdf5",
-                "../hdf5/sift-128-euclidean.hdf5");
+                "hdf5/nytimes-256-angular.hdf5",
+                "hdf5/glove-100-angular.hdf5",
+                "hdf5/glove-200-angular.hdf5",
+                "hdf5/sift-128-euclidean.hdf5");
         var mGrid = List.of(8, 12, 16, 24, 32, 48, 64);
         var efConstructionGrid = List.of(60, 80, 100, 120, 160, 200, 400, 600, 800);
         var efSearchFactor = List.of(1, 2);
@@ -257,7 +257,7 @@ public class Bench {
         }
 
         // tiny dataset, don't waste time building a huge index
-        files = List.of("../hdf5/fashion-mnist-784-euclidean.hdf5");
+        files = List.of("hdf5/fashion-mnist-784-euclidean.hdf5");
         mGrid = List.of(8, 12, 16, 24);
         efConstructionGrid = List.of(40, 60, 80, 100, 120, 160);
         for (var f : files) {

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
                         </goals>
                         <configuration>
                             <executable>${java.home}/bin/java</executable>
+                            <workingDirectory>${project.parent.basedir}</workingDirectory>
                         </configuration>
                     </execution>
                     <execution>
@@ -64,6 +65,7 @@
                         </goals>
                         <configuration>
                             <executable>${java.home}/bin/java</executable>
+                            <workingDirectory>${project.parent.basedir}</workingDirectory>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Previous multimodule reorganization changed the path for Bench to look at hdf5 files to be relative to child modules. This conflicted with IDE run integration. This restores the previous paths and configures `mvn exec` to look at the parent basedir.