### PR TITLE
Fix recall regression for centered PQ with non-dot product metrics

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/CompressedVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/CompressedVectors.java
@@ -86,7 +86,7 @@ public class CompressedVectors
             default:
                 // TODO implement other similarity functions efficiently
                 var decoded = new float[pq.getOriginalDimension()];
-                pq.decode(compressedVectors.get(ordinal), decoded);
+                pq.decodeCentered(compressedVectors.get(ordinal), decoded);
                 return similarityFunction.compare(decoded, v);
         }
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
@@ -147,15 +147,22 @@ public class ProductQuantization {
      * Decodes the quantized representation (byte array) to its approximate original vector.
      */
     public void decode(byte[] encoded, float[] target) {
-        for (int m = 0; m < M; m++) {
-            int centroidIndex = Byte.toUnsignedInt(encoded[m]);
-            float[] centroidSubvector = codebooks[m][centroidIndex];
-            System.arraycopy(centroidSubvector, 0, target, subvectorSizesAndOffsets[m][1], subvectorSizesAndOffsets[m][0]);
-        }
+        decodeCentered(encoded, target);
 
         if (globalCentroid != null) {
             // Add back the global centroid to get the approximate original vector.
             VectorUtil.addInPlace(target, globalCentroid);
+        }
+    }
+
+    /**
+     * Decodes the quantized representation (byte array) to its approximate original vector, relative to the global centroid.
+     */
+    public void decodeCentered(byte[] encoded, float[] target) {
+        for (int m = 0; m < M; m++) {
+            int centroidIndex = Byte.toUnsignedInt(encoded[m]);
+            float[] centroidSubvector = codebooks[m][centroidIndex];
+            System.arraycopy(centroidSubvector, 0, target, subvectorSizesAndOffsets[m][1], subvectorSizesAndOffsets[m][0]);
         }
     }
 


### PR DESCRIPTION
Now that decodedSimilarity caller is responsible for centering comparison vector, decodedSimilarity shouldn't uncenter decoded vector.