### PR TITLE
Fix code coverage in IntelliJ

### DIFF
--- a/jvector-tests/pom.xml
+++ b/jvector-tests/pom.xml
@@ -83,7 +83,7 @@
             <groupId>io.github.jbellis</groupId>
             <artifactId>jvector-base</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
     <profiles>
@@ -97,7 +97,7 @@
                     <groupId>io.github.jbellis</groupId>
                     <artifactId>jvector-twenty</artifactId>
                     <version>${jvector.version}</version>
-                    <scope>test</scope>
+                    <scope>compile</scope>
                 </dependency>
             </dependencies>
             <properties>


### PR DESCRIPTION
jvector-base/jvector-twenty must be compile time deps for the classes files to be included in the scope for code coverage generation.