### PR TITLE
Clean up all build warnings related to multimodule versioning.

### DIFF
--- a/jvector-base/pom.xml
+++ b/jvector-base/pom.xml
@@ -7,9 +7,8 @@
     <parent>
         <groupId>io.github.jbellis</groupId>
         <artifactId>jvector-parent</artifactId>
-        <version>dev</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>jvector-base</artifactId>
-    <version>${jvector.version}</version>
     <name>Base</name>
 </project>

--- a/jvector-examples/pom.xml
+++ b/jvector-examples/pom.xml
@@ -7,10 +7,9 @@
     <parent>
         <groupId>io.github.jbellis</groupId>
         <artifactId>jvector-parent</artifactId>
-        <version>dev</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>jvector-examples</artifactId>
-    <version>${jvector.version}</version>
     <name>JVector Examples</name>
     <build>
         <plugins>
@@ -28,7 +27,7 @@
         <dependency>
             <groupId>io.github.jbellis</groupId>
             <artifactId>jvector-base</artifactId>
-            <version>${jvector.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.jhdf</groupId>
@@ -90,7 +89,7 @@
                 <dependency>
                     <groupId>io.github.jbellis</groupId>
                     <artifactId>jvector-twenty</artifactId>
-                    <version>${jvector.version}</version>
+                    <version>${project.version}</version>
                     <scope>compile</scope>
                 </dependency>
             </dependencies>

--- a/jvector-multirelease/pom.xml
+++ b/jvector-multirelease/pom.xml
@@ -7,10 +7,9 @@
     <parent>
         <groupId>io.github.jbellis</groupId>
         <artifactId>jvector-parent</artifactId>
-        <version>dev</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>jvector</artifactId>
-    <version>${jvector.version}</version>
     <name>JVector</name>
     <properties>
         <maven.install.skip>false</maven.install.skip>
@@ -95,7 +94,7 @@
                                     <type>jar</type>
                                     <classifier>javadoc</classifier>
                                     <outputDirectory>target</outputDirectory>
-                                    <destFileName>jvector-${jvector.version}-javadoc.jar</destFileName>
+                                    <destFileName>jvector-${project.version}-javadoc.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/jvector-tests/pom.xml
+++ b/jvector-tests/pom.xml
@@ -7,10 +7,9 @@
     <parent>
         <groupId>io.github.jbellis</groupId>
         <artifactId>jvector-parent</artifactId>
-        <version>dev</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>jvector-tests</artifactId>
-    <version>${jvector.version}</version>
     <name>Tests</name>
     <properties>
         <skipJdk11Tests>true</skipJdk11Tests>
@@ -96,7 +95,7 @@
                 <dependency>
                     <groupId>io.github.jbellis</groupId>
                     <artifactId>jvector-twenty</artifactId>
-                    <version>${jvector.version}</version>
+                    <version>${project.version}</version>
                     <scope>compile</scope>
                 </dependency>
             </dependencies>

--- a/jvector-twenty/pom.xml
+++ b/jvector-twenty/pom.xml
@@ -7,10 +7,9 @@
     <parent>
         <groupId>io.github.jbellis</groupId>
         <artifactId>jvector-parent</artifactId>
-        <version>dev</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>jvector-twenty</artifactId>
-    <version>${jvector.version}</version>
     <name>Twenty</name>
     <build>
         <plugins>
@@ -42,7 +41,7 @@
         <dependency>
             <groupId>io.github.jbellis</groupId>
             <artifactId>jvector-base</artifactId>
-            <version>${jvector.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.jbellis</groupId>
     <artifactId>jvector-parent</artifactId>
-    <version>dev</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
     <!-- Project Metadata setup -->
     <name>JVector parent</name>
@@ -41,7 +41,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.install.skip>true</maven.install.skip>
-        <jvector.version>0.9.3-SNAPSHOT</jvector.version>
+        <revision>0.9.3-SNAPSHOT</revision>
     </properties>
     <modules>
         <module>jvector-base</module>
@@ -61,6 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
The old approach worked and was previously considered the best way to approach this type of structure, but it did reasonably generate warnings as it violated some Maven assumptions. This transitions to using the magical ${revision} property, which does essentially the same thing, but it has special handling inside Maven. There's some clean up to how dependency versions are declared as well.