### PR TITLE
Adjust PQ clustering parameters based on experimentation

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/ProductQuantization.java
@@ -39,8 +39,8 @@ import static java.lang.Math.min;
  */
 public class ProductQuantization {
     static final int CLUSTERS = 256; // number of clusters per subspace = one byte's worth
-    private static final int K_MEANS_ITERATIONS = 12;
-    private static final int MAX_PQ_TRAINING_SET_SIZE = 256000;
+    private static final int K_MEANS_ITERATIONS = 6;
+    private static final int MAX_PQ_TRAINING_SET_SIZE = 128000;
 
     final float[][][] codebooks;
     final int M;


### PR DESCRIPTION
Experimentation shows these parameters get us very similar recall while reducing PQ build time by 50%.