### PR TITLE
Fork test VM per core

### DIFF
--- a/jvector-tests/pom.xml
+++ b/jvector-tests/pom.xml
@@ -21,7 +21,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
                 <configuration>
-                    <forkCount>1</forkCount>
+                    <forkCount>1C</forkCount>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
This forks a test VM per core. Output while tests are running may be interleaved, but you still get a neat summary of failures at the end, e.g.:

```
12:35:27,583 [INFO]
12:35:27,583 [ERROR] Failures: 
12:35:27,583 [ERROR]   TestNeighborArray.testScoresDescOrder:81->assertNodesEqual:92 expected: <0> but was: <1>
12:35:27,583 [ERROR]   TestLongHeap.testPQ:48->testPQ:69 expected:<6331863779841936392> but was:<6331863779841936393>
12:35:27,583 [INFO]
12:35:27,583 [ERROR] Tests run: 86, Failures: 2, Errors: 0, Skipped: 0
```