### PR TITLE
Use fma in SIMD Euclidean/cosine

### DIFF
--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -269,8 +269,8 @@ final class SimdOps {
             var a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v1, i);
             var b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v2, i);
             vsum = a.fma(b, vsum);
-            vaMagnitude = vaMagnitude.add(a.mul(a));
-            vbMagnitude = vbMagnitude.add(b.mul(b));
+            vaMagnitude = a.fma(a, vaMagnitude);
+            vbMagnitude = b.fma(b, vbMagnitude);
         }
 
         float sum = vsum.reduceLanes(VectorOperators.ADD);
@@ -379,7 +379,7 @@ final class SimdOps {
             FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_64, v1, v1offset + i);
             FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_64, v2, v2offset + i);
             var diff = a.sub(b);
-            sum = sum.add(diff.mul(diff));
+            sum = diff.fma(diff, sum);
         }
 
         float res = sum.reduceLanes(VectorOperators.ADD);
@@ -406,7 +406,7 @@ final class SimdOps {
             FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_128, v1, v1offset + i);
             FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_128, v2, v2offset + i);
             var diff = a.sub(b);
-            sum = sum.add(diff.mul(diff));
+            sum = diff.fma(diff, sum);
         }
 
         float res = sum.reduceLanes(VectorOperators.ADD);
@@ -434,7 +434,7 @@ final class SimdOps {
             FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_256, v1, v1offset + i);
             FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_256, v2, v2offset + i);
             var diff = a.sub(b);
-            sum = sum.add(diff.mul(diff));
+            sum = diff.fma(diff, sum);
         }
 
         float res = sum.reduceLanes(VectorOperators.ADD);
@@ -462,7 +462,7 @@ final class SimdOps {
             FloatVector a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v1, v1offset + i);
             FloatVector b = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v2, v2offset + i);
             var diff = a.sub(b);
-            sum = sum.add(diff.mul(diff));
+            sum = diff.fma(diff, sum);
         }
 
         float res = sum.reduceLanes(VectorOperators.ADD);


### PR DESCRIPTION
We already use SIMD fma in our dot product implementations, so we shouldn't be particularly concerned about compatibility concerns here (and all recent platforms support this). This produces a noticeable improvement on JMH microbenchmarks, no noticeable regressions in any workloads I've tested, and a slight improvement on memtable searches for larger vectors.