### PR TITLE
Remove overzealous dependency exclusion affecting util-mmap

### DIFF
--- a/jvector-examples/pom.xml
+++ b/jvector-examples/pom.xml
@@ -46,10 +46,6 @@
                     <artifactId>slf4j-api</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/ReaderSupplierFactory.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/ReaderSupplierFactory.java
@@ -21,12 +21,16 @@ import io.github.jbellis.jvector.disk.SimpleMappedReaderSupplier;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.logging.Logger;
 
 public class ReaderSupplierFactory {
+    private static final Logger LOG = Logger.getLogger(ReaderSupplierFactory.class.getName());
+
     public static ReaderSupplier open(Path path) throws IOException {
         try {
             return new MMapReaderSupplier(path);
         } catch (UnsatisfiedLinkError|NoClassDefFoundError e) {
+            LOG.log(java.util.logging.Level.WARNING, "MMapReaderSupplier not available, falling back to SimpleMappedReaderSupplier", e);
             if (Files.size(path) > Integer.MAX_VALUE) {
                 throw new RuntimeException("File sizes greater than 2GB are not supported on Windows--contributions welcome");
             }


### PR DESCRIPTION
This dependency exclusion was intended to prevent a conflict at some point. Whatever conflicting transitive dependency brought in Guava must have been removed, so util-mmap was failing at runtime due to missing dependencies.

Additional log message will help diagnose fallback causes in the future.