### PR TITLE
Fix flaky ProductQuantization test

### DIFF
--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestProductQuantization.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestProductQuantization.java
@@ -122,7 +122,7 @@ public class TestProductQuantization extends RandomizedTest {
         var loss = 0.0;
         for (int i = 0; i < vectors.length; i++) {
             pq.decode(encoded[i], decodedScratch);
-            loss += 1 - VectorSimilarityFunction.COSINE.compare(vectors[i], decodedScratch);
+            loss += 1 - VectorSimilarityFunction.EUCLIDEAN.compare(vectors[i], decodedScratch);
         }
         return loss;
     }


### PR DESCRIPTION
Tests using the `loss` function are flaky. This is easiest to reproduce by increasing the number of runs in the iterative improvement test. I believe this to be due to the fact that a round of k-means is not guaranteed to decrease loss for COSINE, only squared Euclidean distances.