### PR TITLE
Fix indexing into MemorySegment when loading/storing from FloatVector in scale

### DIFF
--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
@@ -69,9 +69,9 @@ final class VectorSimdOps {
 
         // Process the vectorized part
         for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
-            var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, vector.get(), i, ByteOrder.LITTLE_ENDIAN);
+            var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, vector.get(), vector.offset(i), ByteOrder.LITTLE_ENDIAN);
             var divResult = a.mul(multiplier);
-            divResult.intoMemorySegment(vector.get(), i, ByteOrder.LITTLE_ENDIAN);
+            divResult.intoMemorySegment(vector.get(), vector.offset(i), ByteOrder.LITTLE_ENDIAN);
         }
 
         // Process the tail


### PR DESCRIPTION
When rebasing, I picked up loading into the index vector as if using array style indexes. For MemorySegments, we need to scale by float size, which is handled by by the `offset` call.

This PR will be followed by another change that includes better test coverage for consistent vector operations across providers.