### PR TITLE
Fix TestVectorSimilarityFunction test. Add missing license.

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/MultiFileDatasource.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/MultiFileDatasource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.jbellis.jvector.example.util;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorSimilarityFunction.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorSimilarityFunction.java
@@ -49,6 +49,7 @@ public class TestVectorSimilarityFunction extends RandomizedTest {
         }
 
         for (VectorSimilarityFunction vsf : VectorSimilarityFunction.values()) {
+            results.zero();
             vsf.compareMulti(q, packedVectors, results);
             for (int i = 0; i < length; i++) {
                 Assert.assertEquals(vsf.compare(q, vectors.get(ids[i])), results.get(i), 0.01f);


### PR DESCRIPTION
This test was previously passing with the native provider because the scale bug meant the normalized random vectors were extremely small in some dimensions, usually concealing that the results vector wasn't properly zeroed before passing to native code. Other providers don't care about the results vector not being zeroed because they explicitly calculate and set each index.

Add missing license to allow all tests to run.