### PR TITLE
Fix Bench timings on paths performing multiple types of queries

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
@@ -25,7 +25,6 @@ import io.github.jbellis.jvector.example.util.DataSetCreator;
 import io.github.jbellis.jvector.example.util.DownloadHelper;
 import io.github.jbellis.jvector.example.util.Hdf5Loader;
 import io.github.jbellis.jvector.example.util.ReaderSupplierFactory;
-import io.github.jbellis.jvector.example.util.SiftLoader;
 import io.github.jbellis.jvector.graph.GraphIndex;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
@@ -111,9 +110,9 @@ public class Bench {
                      var onDiskFusedGraph = fusedCompatible ? new CachingADCGraphIndex(new OnDiskADCGraphIndex(ReaderSupplierFactory.open(fusedGraphPath), 0)) : null) {
                     int queryRuns = 2;
                     for (int overquery : efSearchOptions) {
-                        start = System.nanoTime();
                         if (compressor == null) {
                             // include both in-memory and on-disk search of uncompressed vectors
+                            start = System.nanoTime();
                             var pqr = performQueries(ds, floatVectors, cv, onHeapGraph, topK, topK * overquery, queryRuns);
                             var recall = ((double) pqr.topKFound) / (queryRuns * ds.queryVectors.size() * topK);
                             System.out.format("  Query %s top %d/%d recall %.4f in %.2fs after %,d nodes visited%n",
@@ -121,11 +120,13 @@ public class Bench {
                         }
                         if (fusedCompatible) {
                             // include both fused and regular graphs for PQ if clusters == 32
+                            start = System.nanoTime();
                             var pqr = performQueries(ds, floatVectors, cv, onDiskFusedGraph, topK, topK * overquery, queryRuns);
                             var recall = ((double) pqr.topKFound) / (queryRuns * ds.queryVectors.size() * topK);
                             System.out.format("  Query %s top %d/%d recall %.4f in %.2fs after %,d nodes visited%n",
                                               "(fused)", topK, overquery, recall, (System.nanoTime() - start) / 1_000_000_000.0, pqr.nodesVisited);
                         }
+                        start = System.nanoTime();
                         var pqr = performQueries(ds, floatVectors, cv, onDiskGraph, topK, topK * overquery, queryRuns);
                         var recall = ((double) pqr.topKFound) / (queryRuns * ds.queryVectors.size() * topK);
                         System.out.format("  Query %stop %d/%d recall %.4f in %.2fs after %,d nodes visited%n",


### PR DESCRIPTION
AFAICT, these timings have been wrong since we first started doing on-heap/on-disk exact searches in the same overquery loop.

Fortunately, the benchmarking of fused graphs was comparing 32-cluster fused against 256-cluster traditional, which were in different compressor settings, so the timings were still accurate. I'm not sure that we made any impactful decisions based on on-disk/on-memory comparison for exact searches.