### PR TITLE
Reduce repetition in Bench. Factor out more concise methods.

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/CachingADCGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/CachingADCGraphIndex.java
@@ -81,6 +81,11 @@ public class CachingADCGraphIndex implements GraphIndex, AutoCloseable, Accounta
         graph.close();
     }
 
+    @Override
+    public String toString() {
+        return String.format("CachingADCGraphIndex(graph=%s)", graph);
+    }
+
     public class CachedView implements ADCView, ApproximateScoreProvider {
         private final ADCView view;
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/CachingGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/CachingGraphIndex.java
@@ -72,6 +72,11 @@ public class CachingGraphIndex implements GraphIndex, AutoCloseable, Accountable
         graph.close();
     }
 
+    @Override
+    public String toString() {
+        return String.format("CachingGraphIndex(graph=%s)", graph);
+    }
+
     private class CachedView implements View {
         private final View view;
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/OnDiskADCGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/OnDiskADCGraphIndex.java
@@ -240,6 +240,11 @@ public class OnDiskADCGraphIndex implements GraphIndex, AutoCloseable, Accountab
         readerSupplier.close();
     }
 
+    @Override
+    public String toString() {
+        return String.format("OnDiskADCGraphIndex(size=%d, entryPoint=%d)", size, entryNode);
+    }
+
     /**
      * @param graph the graph to write
      * @param vectors the vectors associated with each node

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/OnDiskGraphIndex.java
@@ -185,6 +185,11 @@ public class OnDiskGraphIndex implements GraphIndex, AutoCloseable, Accountable
         readerSupplier.close();
     }
 
+    @Override
+    public String toString() {
+        return String.format("OnDiskGraphIndex(size=%d, entryPoint=%d)", size, entryNode);
+    }
+
     /**
      * @param graph the graph to write
      * @param vectors the vectors associated with each node

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/BQVectors.java
@@ -133,4 +133,12 @@ public class BQVectors implements CompressedVectors {
         result = 31 * result + Arrays.deepHashCode(compressedVectors);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "BQVectors{" +
+               "bq=" + bq +
+               ", count=" + compressedVectors.length +
+               '}';
+    }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
@@ -154,4 +154,12 @@ public class PQVectors implements CompressedVectors {
         long compressedVectorSize = RamUsageEstimator.sizeOf(compressedVectors[0]);
         return codebooksSize + (compressedVectorSize * compressedVectors.length);
     }
+
+    @Override
+    public String toString() {
+        return "PQVectors{" +
+                "pq=" + pq +
+                ", count=" + compressedVectors.length +
+                '}';
+    }
 }


### PR DESCRIPTION
Output now looks like:
```
nytimes-256-angular.hdf5: 289761 base and 9991 query vectors created, dimensions 256
Build M=32 ef=100 in 44.19s with avg degree 31.99 and 0.77 short edges
Uncompressed vectors
Using CachingGraphIndex(graph=OnDiskGraphIndex(size=289761, entryPoint=187905)):
 Query top 100/1 recall 0.7235 in 2.66s after 41,922,470 nodes visited
 Query top 100/2 recall 0.7747 in 4.27s after 74,016,694 nodes visited
Using OnHeapGraphIndex(size=289761, entryPoint=187905):
 Query top 100/1 recall 0.7235 in 2.51s after 41,922,470 nodes visited
 Query top 100/2 recall 0.7747 in 3.94s after 74,016,694 nodes visited
ProductQuantization(64,256) build in 7.41s,
ProductQuantization(64,256) encoded 289761 vectors [26.78 MB] in 1.60s
Using CachingGraphIndex(graph=OnDiskGraphIndex(size=289761, entryPoint=187905)):
 Query top 100/1 recall 0.6453 in 2.20s after 42,890,384 nodes visited
 Query top 100/2 recall 0.7609 in 2.88s after 75,333,026 nodes visited
```