### PR TITLE
Use on-heap MemorySegments for native vectors/sequences

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,7 +18,7 @@ jobs:
         cancel-in-progress: true
     strategy:
       matrix:
-        jdk: [ 11, 20, 21 ]
+        jdk: [ 11, 20 ] # 22 is not yet released, but it needs to be added
         os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -29,9 +29,9 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: temurin
           cache: maven
-      - name: Compile, run tests, and package (JDK 21)
+      - name: Compile, run tests, and package (JDK 22)
         run: mvn -B verify
-        if: matrix.jdk == '21'
+        if: matrix.jdk == '22'
       - name: Compile, run tests, and package (JDK 20)
         run: mvn -B -Pjdk20 -am -pl jvector-tests test
         if: matrix.jdk == '20'

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,7 +2,7 @@
 
 ## New features
 - Experimental support for native code acceleration has been added. This currently only supports Linux x86-64 
-  with certain AVX-512 extensions. This is opt-in and requires the use of off-heap `VectorFloat`/`ByteSequence`
+  with certain AVX-512 extensions. This is opt-in and requires the use of MemorySegment `VectorFloat`/`ByteSequence`
   representations.
 - Experimental support for fused graph indexes has been added. These work in best concert with native code acceleration.
   This explores a design space allowing for packed representations of vectors fused into the graph in shapes optimal

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessReader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessReader.java
@@ -32,11 +32,15 @@ public interface RandomAccessReader extends AutoCloseable {
 
     void readFully(ByteBuffer buffer) throws IOException;
 
-    void readFully(float[] floats) throws IOException;
+    default void readFully(float[] floats) throws IOException {
+        read(floats, 0, floats.length);
+    }
 
     void readFully(long[] vector) throws IOException;
 
     void read(int[] ints, int offset, int count) throws IOException;
+
+    void read(float[] floats, int offset, int count) throws IOException;
 
     void close() throws IOException;
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleMappedReader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleMappedReader.java
@@ -114,6 +114,13 @@ public class SimpleMappedReader implements RandomAccessReader {
     }
 
     @Override
+    public void read(float[] floats, int offset, int count) {
+        for (int i = 0; i < count; i++) {
+            floats[offset + i] = mbb.getFloat();
+        }
+    }
+
+    @Override
     public void close() {
         if (unsafe != null) {
             try {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayVectorProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayVectorProvider.java
@@ -54,9 +54,7 @@ final class ArrayVectorProvider implements VectorTypeSupport
 
     @Override
     public void readFloatVector(RandomAccessReader r, int size, VectorFloat<?> vector, int offset) throws IOException {
-        float[] v = new float[size];
-        r.readFully(v);
-        System.arraycopy(v, 0, ((ArrayVectorFloat)vector).get(), offset, size);
+        r.read(((ArrayVectorFloat) vector).get(), offset, size);
     }
 
     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorizationProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorizationProvider.java
@@ -77,7 +77,7 @@ public abstract class VectorizationProvider {
   // visible for tests
   static VectorizationProvider lookup(boolean testMode) {
     final int runtimeVersion = Runtime.version().feature();
-    if (runtimeVersion >= 20 && runtimeVersion <= 21) {
+    if (runtimeVersion >= 20 && runtimeVersion <= 22) {
       // is locale sane (only buggy in Java 20)
       if (isAffectedByJDK8301190()) {
         LOG.warning(
@@ -136,8 +136,8 @@ public abstract class VectorizationProvider {
       } catch (Throwable th) {
         throw new AssertionError(th);
       }
-    } else if (runtimeVersion >= 22) {
-      LOG.warning("You are running with Java 22 or later. To make full use of the Vector API, please update jvector.");
+    } else if (runtimeVersion >= 23) {
+      LOG.warning("You are running with Java 23 or later. To make full use of the Vector API, please update jvector.");
     } else {
       LOG.warning("You are running with Java 19 or earlier, which do not support the required incubating Vector API. Falling back to slower defaults.");
     }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/MMapReader.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/MMapReader.java
@@ -87,6 +87,17 @@ public class MMapReader implements RandomAccessReader {
     }
 
     @Override
+    public void read(float[] floats, int offset, int count) {
+        int bytesToRead = count * Float.BYTES;
+        if (scratch.length < bytesToRead) {
+            scratch = new byte[bytesToRead];
+        }
+        read(scratch, 0, bytesToRead);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(scratch).order(ByteOrder.BIG_ENDIAN);
+        byteBuffer.asFloatBuffer().get(floats, offset, count);
+    }
+
+    @Override
     public void readFully(long[] vector) {
         int bytesToRead = vector.length * Long.BYTES;
         if (scratch.length < bytesToRead) {

--- a/jvector-multirelease/src/assembly/mrjar.xml
+++ b/jvector-multirelease/src/assembly/mrjar.xml
@@ -39,7 +39,7 @@
                 <include>io.github.jbellis:jvector-native</include>
             </includes>
             <binaries>
-                <outputDirectory>META-INF/versions/21</outputDirectory>
+                <outputDirectory>META-INF/versions/22</outputDirectory>
                 <unpack>true</unpack>
                 <includeDependencies>false</includeDependencies>
                 <unpackOptions>

--- a/jvector-native/pom.xml
+++ b/jvector-native/pom.xml
@@ -18,7 +18,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>21</release>
+                    <release>22</release>
                     <compilerArgs>
                         <arg>--add-modules</arg>
                         <arg>jdk.incubator.vector</arg>

--- a/jvector-native/src/main/c/jextract_vector_simd.sh
+++ b/jvector-native/src/main/c/jextract_vector_simd.sh
@@ -42,3 +42,6 @@ jextract \
   -I . \
   --header-class-name NativeSimdOps \
   jvector_simd.h
+
+# Set critical linker option with heap-based segments for all generated methods
+sed -i 's/DESC)/DESC, Linker.Option.critical(true))/g' ../java/io/github/jbellis/jvector/vector/cnative/NativeSimdOps.java

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentByteSequence.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentByteSequence.java
@@ -18,32 +18,31 @@ package io.github.jbellis.jvector.vector;
 
 import io.github.jbellis.jvector.vector.types.ByteSequence;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.Buffer;
 
 /**
- * ByteSequence implementation backed by an off-heap MemorySegment.
+ * ByteSequence implementation backed by an on-heap MemorySegment.
  */
-public class OffHeapByteSequence implements ByteSequence<MemorySegment> {
+public class MemorySegmentByteSequence implements ByteSequence<MemorySegment> {
     private final MemorySegment segment;
     private final int length;
 
-    OffHeapByteSequence(int length) {
-        this.segment = Arena.ofAuto().allocate(length, 1);
+    MemorySegmentByteSequence(int length) {
         this.length = length;
+        segment = MemorySegment.ofArray(new byte[length]);
     }
 
-    OffHeapByteSequence(Buffer data) {
+    MemorySegmentByteSequence(Buffer data) {
         this(data.remaining());
         segment.copyFrom(MemorySegment.ofBuffer(data));
     }
 
-    OffHeapByteSequence(byte[] data) {
-        this(data.length);
-        segment.copyFrom(MemorySegment.ofArray(data));
+    MemorySegmentByteSequence(byte[] data) {
+        this.segment = MemorySegment.ofArray(data);
+        this.length = data.length;
     }
 
     @Override
@@ -53,7 +52,7 @@ public class OffHeapByteSequence implements ByteSequence<MemorySegment> {
 
     @Override
     public void copyFrom(ByteSequence<?> src, int srcOffset, int destOffset, int length) {
-        OffHeapByteSequence csrc = (OffHeapByteSequence) src;
+        MemorySegmentByteSequence csrc = (MemorySegmentByteSequence) src;
         segment.asSlice(destOffset, length).copyFrom(csrc.segment.asSlice(srcOffset));
     }
 
@@ -84,7 +83,7 @@ public class OffHeapByteSequence implements ByteSequence<MemorySegment> {
 
     @Override
     public ByteSequence<MemorySegment> copy() {
-        OffHeapByteSequence copy = new OffHeapByteSequence(length());
+        MemorySegmentByteSequence copy = new MemorySegmentByteSequence(length());
         copy.copyFrom(this, 0, 0, length());
         return copy;
     }
@@ -110,7 +109,7 @@ public class OffHeapByteSequence implements ByteSequence<MemorySegment> {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        OffHeapByteSequence that = (OffHeapByteSequence) o;
+        MemorySegmentByteSequence that = (MemorySegmentByteSequence) o;
         return segment.mismatch(that.segment) == -1;
     }
 

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
@@ -34,12 +34,12 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
 
     @Override
     public float cosine(VectorFloat<?> v1, VectorFloat<?> v2) {
-        return VectorSimdOps.cosineSimilarity((OffHeapVectorFloat)v1, (OffHeapVectorFloat)v2);
+        return VectorSimdOps.cosineSimilarity((MemorySegmentVectorFloat)v1, (MemorySegmentVectorFloat)v2);
     }
 
     @Override
     public float cosine(VectorFloat<?> a, int aoffset, VectorFloat<?> b, int boffset, int length) {
-        return VectorSimdOps.cosineSimilarity((OffHeapVectorFloat)a, aoffset, (OffHeapVectorFloat)b, boffset, length);
+        return VectorSimdOps.cosineSimilarity((MemorySegmentVectorFloat)a, aoffset, (MemorySegmentVectorFloat)b, boffset, length);
     }
 
     @Override
@@ -49,12 +49,12 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
 
     @Override
     public float squareDistance(VectorFloat<?> a, int aoffset, VectorFloat<?> b, int boffset, int length) {
-        return VectorSimdOps.squareDistance((OffHeapVectorFloat) a, aoffset, (OffHeapVectorFloat) b, boffset, length);
+        return VectorSimdOps.squareDistance((MemorySegmentVectorFloat) a, aoffset, (MemorySegmentVectorFloat) b, boffset, length);
     }
 
     @Override
     public float dotProduct(VectorFloat<?> a, int aoffset, VectorFloat<?> b, int boffset, int length) {
-        return VectorSimdOps.dotProduct((OffHeapVectorFloat)a, aoffset, (OffHeapVectorFloat)b, boffset, length);
+        return VectorSimdOps.dotProduct((MemorySegmentVectorFloat) a, aoffset, (MemorySegmentVectorFloat) b, boffset, length);
     }
 
     @Override
@@ -64,22 +64,22 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
 
     @Override
     public float sum(VectorFloat<?> vector) {
-        return VectorSimdOps.sum((OffHeapVectorFloat) vector);
+        return VectorSimdOps.sum((MemorySegmentVectorFloat) vector);
     }
 
     @Override
     public void scale(VectorFloat<?> vector, float multiplier) {
-        VectorSimdOps.scale((OffHeapVectorFloat) vector, multiplier);
+        VectorSimdOps.scale((MemorySegmentVectorFloat) vector, multiplier);
     }
 
     @Override
     public void addInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
-        VectorSimdOps.addInPlace((OffHeapVectorFloat)v1, (OffHeapVectorFloat)v2);
+        VectorSimdOps.addInPlace((MemorySegmentVectorFloat)v1, (MemorySegmentVectorFloat)v2);
     }
 
     @Override
     public void subInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
-        VectorSimdOps.subInPlace((OffHeapVectorFloat)v1, (OffHeapVectorFloat)v2);
+        VectorSimdOps.subInPlace((MemorySegmentVectorFloat)v1, (MemorySegmentVectorFloat)v2);
     }
 
     @Override
@@ -92,12 +92,12 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
 
     @Override
     public VectorFloat<?> sub(VectorFloat<?> a, int aOffset, VectorFloat<?> b, int bOffset, int length) {
-        return VectorSimdOps.sub((OffHeapVectorFloat) a, aOffset, (OffHeapVectorFloat) b, bOffset, length);
+        return VectorSimdOps.sub((MemorySegmentVectorFloat) a, aOffset, (MemorySegmentVectorFloat) b, bOffset, length);
     }
 
     @Override
     public float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> baseOffsets) {
-        return NativeSimdOps.assemble_and_sum_f32_512(((OffHeapVectorFloat)data).get(), dataBase, ((OffHeapByteSequence)baseOffsets).get(), baseOffsets.length());
+        return NativeSimdOps.assemble_and_sum_f32_512(((MemorySegmentVectorFloat)data).get(), dataBase, ((MemorySegmentByteSequence)baseOffsets).get(), baseOffsets.length());
     }
 
     @Override
@@ -108,8 +108,8 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
     @Override
     public void bulkShuffleSimilarity(ByteSequence<?> shuffles, int codebookCount, VectorFloat<?> partials, VectorSimilarityFunction vsf, VectorFloat<?> results) {
         switch (vsf) {
-            case DOT_PRODUCT -> NativeSimdOps.bulk_shuffle_dot_f32_512(((OffHeapByteSequence) shuffles).get(), codebookCount, ((OffHeapVectorFloat) partials).get(), ((OffHeapVectorFloat) results).get());
-            case EUCLIDEAN -> NativeSimdOps.bulk_shuffle_euclidean_f32_512(((OffHeapByteSequence) shuffles).get(), codebookCount, ((OffHeapVectorFloat) partials).get(), ((OffHeapVectorFloat) results).get());
+            case DOT_PRODUCT -> NativeSimdOps.bulk_shuffle_dot_f32_512(((MemorySegmentByteSequence) shuffles).get(), codebookCount, ((MemorySegmentVectorFloat) partials).get(), ((MemorySegmentVectorFloat) results).get());
+            case EUCLIDEAN -> NativeSimdOps.bulk_shuffle_euclidean_f32_512(((MemorySegmentByteSequence) shuffles).get(), codebookCount, ((MemorySegmentVectorFloat) partials).get(), ((MemorySegmentVectorFloat) results).get());
             case COSINE -> throw new UnsupportedOperationException("Cosine similarity not supported for bulkShuffleSimilarity");
         }
     }
@@ -117,19 +117,19 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
     @Override
     public void calculatePartialSums(VectorFloat<?> codebook, int codebookBase, int size, int clusterCount, VectorFloat<?> query, int queryOffset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums) {
         switch (vsf) {
-            case DOT_PRODUCT -> NativeSimdOps.calculate_partial_sums_dot_f32_512(((OffHeapVectorFloat)codebook).get(), codebookBase, size, clusterCount, ((OffHeapVectorFloat)query).get(), queryOffset, ((OffHeapVectorFloat)partialSums).get());
-            case EUCLIDEAN -> NativeSimdOps.calculate_partial_sums_euclidean_f32_512(((OffHeapVectorFloat)codebook).get(), codebookBase, size, clusterCount, ((OffHeapVectorFloat)query).get(), queryOffset, ((OffHeapVectorFloat)partialSums).get());
+            case DOT_PRODUCT -> NativeSimdOps.calculate_partial_sums_dot_f32_512(((MemorySegmentVectorFloat)codebook).get(), codebookBase, size, clusterCount, ((MemorySegmentVectorFloat)query).get(), queryOffset, ((MemorySegmentVectorFloat)partialSums).get());
+            case EUCLIDEAN -> NativeSimdOps.calculate_partial_sums_euclidean_f32_512(((MemorySegmentVectorFloat)codebook).get(), codebookBase, size, clusterCount, ((MemorySegmentVectorFloat)query).get(), queryOffset, ((MemorySegmentVectorFloat)partialSums).get());
             case COSINE -> throw new UnsupportedOperationException("Cosine similarity not supported for calculatePartialSums");
         }
     }
 
     @Override
     public void dotProductMultiScore(VectorFloat<?> v1, VectorFloat<?> v2, VectorFloat<?> results) {
-        NativeSimdOps.dot_product_multi_f32_512(((OffHeapVectorFloat)v1).get(), ((OffHeapVectorFloat)v2).get(), v1.length(), results.length(), ((OffHeapVectorFloat)results).get());
+        NativeSimdOps.dot_product_multi_f32_512(((MemorySegmentVectorFloat)v1).get(), ((MemorySegmentVectorFloat)v2).get(), v1.length(), results.length(), ((MemorySegmentVectorFloat)results).get());
     }
 
     @Override
     public void squareL2DistanceMultiScore(VectorFloat<?> v1, VectorFloat<?> v2, VectorFloat<?> results) {
-        NativeSimdOps.square_distance_multi_f32_512(((OffHeapVectorFloat)v1).get(), ((OffHeapVectorFloat)v2).get(), v1.length(), results.length(), ((OffHeapVectorFloat)results).get());
+        NativeSimdOps.square_distance_multi_f32_512(((MemorySegmentVectorFloat)v1).get(), ((MemorySegmentVectorFloat)v2).get(), v1.length(), results.length(), ((MemorySegmentVectorFloat)results).get());
     }
 }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorizationProvider.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorizationProvider.java
@@ -23,7 +23,7 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 
 /**
  * Experimental!
- * VectorizationProvider implementation that assumes OffHeap vectors and prefers native/Panama SIMD.
+ * VectorizationProvider implementation that uses MemorySegment vectors and prefers native/Panama SIMD.
  */
 @Experimental
 public class NativeVectorizationProvider extends VectorizationProvider {
@@ -39,7 +39,7 @@ public class NativeVectorizationProvider extends VectorizationProvider {
             throw new UnsupportedOperationException("Native SIMD operations are not supported on this platform due to missing CPU support.");
         }
         this.vectorUtilSupport = new NativeVectorUtilSupport();
-        this.vectorTypeSupport = new OffHeapVectorProvider();
+        this.vectorTypeSupport = new MemorySegmentVectorProvider();
     }
 
     @Override

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Support class for vector operations using a mix of native and Panama SIMD.
  */
 final class VectorSimdOps {
-    static float sum(OffHeapVectorFloat vector) {
+    static float sum(MemorySegmentVectorFloat vector) {
         var sum = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
         int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(vector.length());
 
@@ -54,17 +54,17 @@ final class VectorSimdOps {
         }
 
         int dimension = vectors.get(0).length();
-        OffHeapVectorFloat sum = new OffHeapVectorFloat(dimension);
+        MemorySegmentVectorFloat sum = new MemorySegmentVectorFloat(dimension);
 
         // Process each vector from the list
         for (VectorFloat<?> vector : vectors) {
-            addInPlace(sum, (OffHeapVectorFloat) vector);
+            addInPlace(sum, (MemorySegmentVectorFloat) vector);
         }
 
         return sum;
     }
 
-    static void scale(OffHeapVectorFloat vector, float multiplier) {
+    static void scale(MemorySegmentVectorFloat vector, float multiplier) {
         int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(vector.length());
 
         // Process the vectorized part
@@ -80,35 +80,35 @@ final class VectorSimdOps {
         }
     }
 
-    static float dot64(OffHeapVectorFloat v1, int offset1, OffHeapVectorFloat v2, int offset2) {
+    static float dot64(MemorySegmentVectorFloat v1, int offset1, MemorySegmentVectorFloat v2, int offset2) {
         var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_64, v1.get(), v1.offset(offset1), ByteOrder.LITTLE_ENDIAN);
         var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_64, v2.get(), v1.offset(offset2), ByteOrder.LITTLE_ENDIAN);
         return a.mul(b).reduceLanes(VectorOperators.ADD);
     }
 
-    static float dot128(OffHeapVectorFloat v1, int offset1, OffHeapVectorFloat v2, int offset2) {
+    static float dot128(MemorySegmentVectorFloat v1, int offset1, MemorySegmentVectorFloat v2, int offset2) {
         var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_128, v1.get(), v1.offset(offset1), ByteOrder.LITTLE_ENDIAN);
         var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_128, v2.get(), v2.offset(offset2), ByteOrder.LITTLE_ENDIAN);
         return a.mul(b).reduceLanes(VectorOperators.ADD);
     }
 
-    static float dot256(OffHeapVectorFloat v1, int offset1, OffHeapVectorFloat v2, int offset2) {
+    static float dot256(MemorySegmentVectorFloat v1, int offset1, MemorySegmentVectorFloat v2, int offset2) {
         var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_256, v1.get(), v1.offset(offset1), ByteOrder.LITTLE_ENDIAN);
         var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_256, v2.get(), v2.offset(offset2), ByteOrder.LITTLE_ENDIAN);
         return a.mul(b).reduceLanes(VectorOperators.ADD);
     }
 
-    static float dotPreferred(OffHeapVectorFloat v1, int offset1, OffHeapVectorFloat v2, int offset2) {
+    static float dotPreferred(MemorySegmentVectorFloat v1, int offset1, MemorySegmentVectorFloat v2, int offset2) {
         var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, v1.get(), v1.offset(offset1), ByteOrder.LITTLE_ENDIAN);
         var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, v2.get(), v2.offset(offset2), ByteOrder.LITTLE_ENDIAN);
         return a.mul(b).reduceLanes(VectorOperators.ADD);
     }
 
-    static float dotProduct(OffHeapVectorFloat v1, OffHeapVectorFloat v2) {
+    static float dotProduct(MemorySegmentVectorFloat v1, MemorySegmentVectorFloat v2) {
         return dotProduct(v1, 0, v2, 0, v1.length());
     }
 
-    static float dotProduct(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, final int length)
+    static float dotProduct(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, final int length)
     {
         //Common case first
         if (length >= FloatVector.SPECIES_PREFERRED.length())
@@ -123,7 +123,7 @@ final class VectorSimdOps {
 
     }
 
-    static float dotProduct64(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, int length) {
+    static float dotProduct64(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, int length) {
 
         if (length == FloatVector.SPECIES_64.length())
             return dot64(v1, v1offset, v2, v2offset);
@@ -148,7 +148,7 @@ final class VectorSimdOps {
         return res;
     }
 
-    static float dotProduct128(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, int length) {
+    static float dotProduct128(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, int length) {
 
         if (length == FloatVector.SPECIES_128.length())
             return dot128(v1, v1offset, v2, v2offset);
@@ -174,7 +174,7 @@ final class VectorSimdOps {
     }
 
 
-    static float dotProduct256(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, int length) {
+    static float dotProduct256(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, int length) {
 
         if (length == FloatVector.SPECIES_256.length())
             return dot256(v1, v1offset, v2, v2offset);
@@ -199,7 +199,7 @@ final class VectorSimdOps {
         return res;
     }
 
-    static float dotProductPreferred(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, int length) {
+    static float dotProductPreferred(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, int length) {
 
         if (length == FloatVector.SPECIES_PREFERRED.length())
             return dotPreferred(v1, v1offset, v2, v2offset);
@@ -224,7 +224,7 @@ final class VectorSimdOps {
         return res;
     }
 
-    static float cosineSimilarity(OffHeapVectorFloat v1, OffHeapVectorFloat v2) {
+    static float cosineSimilarity(MemorySegmentVectorFloat v1, MemorySegmentVectorFloat v2) {
         if (v1.length() != v2.length()) {
             throw new IllegalArgumentException("Vectors must have the same length");
         }
@@ -257,7 +257,7 @@ final class VectorSimdOps {
         return (float) (sum / Math.sqrt(aMagnitude * bMagnitude));
     }
 
-    static float cosineSimilarity(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, int length) {
+    static float cosineSimilarity(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, int length) {
         var vsum = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
         var vaMagnitude = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
         var vbMagnitude = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
@@ -283,39 +283,39 @@ final class VectorSimdOps {
         return (float) (sum / Math.sqrt(aMagnitude * bMagnitude));
     }
 
-    static float squareDistance64(OffHeapVectorFloat v1, int offset1, OffHeapVectorFloat v2, int offset2) {
+    static float squareDistance64(MemorySegmentVectorFloat v1, int offset1, MemorySegmentVectorFloat v2, int offset2) {
         var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_64, v1.get(), v1.offset(offset1), ByteOrder.LITTLE_ENDIAN);
         var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_64, v2.get(), v2.offset(offset2), ByteOrder.LITTLE_ENDIAN);
         var diff = a.sub(b);
         return diff.mul(diff).reduceLanes(VectorOperators.ADD);
     }
 
-    static float squareDistance128(OffHeapVectorFloat v1, int offset1, OffHeapVectorFloat v2, int offset2) {
+    static float squareDistance128(MemorySegmentVectorFloat v1, int offset1, MemorySegmentVectorFloat v2, int offset2) {
         var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_128, v1.get(), v1.offset(offset1), ByteOrder.LITTLE_ENDIAN);
         var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_128, v2.get(), v2.offset(offset2), ByteOrder.LITTLE_ENDIAN);
         var diff = a.sub(b);
         return diff.mul(diff).reduceLanes(VectorOperators.ADD);
     }
 
-    static float squareDistance256(OffHeapVectorFloat v1, int offset1, OffHeapVectorFloat v2, int offset2) {
+    static float squareDistance256(MemorySegmentVectorFloat v1, int offset1, MemorySegmentVectorFloat v2, int offset2) {
         var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_256, v1.get(), v1.offset(offset1), ByteOrder.LITTLE_ENDIAN);
         var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_256, v2.get(), v2.offset(offset2), ByteOrder.LITTLE_ENDIAN);
         var diff = a.sub(b);
         return diff.mul(diff).reduceLanes(VectorOperators.ADD);
     }
 
-    static float squareDistancePreferred(OffHeapVectorFloat v1, int offset1, OffHeapVectorFloat v2, int offset2) {
+    static float squareDistancePreferred(MemorySegmentVectorFloat v1, int offset1, MemorySegmentVectorFloat v2, int offset2) {
         var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, v1.get(), v1.offset(offset1), ByteOrder.LITTLE_ENDIAN);
         var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, v2.get(), v2.offset(offset2), ByteOrder.LITTLE_ENDIAN);
         var diff = a.sub(b);
         return diff.mul(diff).reduceLanes(VectorOperators.ADD);
     }
 
-    static float squareDistance(OffHeapVectorFloat v1, OffHeapVectorFloat v2) {
+    static float squareDistance(MemorySegmentVectorFloat v1, MemorySegmentVectorFloat v2) {
         return squareDistance(v1, 0, v2, 0, v1.length());
     }
 
-    static float squareDistance(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, final int length)
+    static float squareDistance(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, final int length)
     {
         //Common case first
         if (length >= FloatVector.SPECIES_PREFERRED.length())
@@ -329,7 +329,7 @@ final class VectorSimdOps {
             return squareDistance256(v1, v1offset, v2, v2offset, length);
     }
 
-    static float squareDistance64(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, int length) {
+    static float squareDistance64(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, int length) {
         if (length == FloatVector.SPECIES_64.length())
             return squareDistance64(v1, v1offset, v2, v2offset);
 
@@ -356,7 +356,7 @@ final class VectorSimdOps {
         return res;
     }
 
-    static float squareDistance128(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, int length) {
+    static float squareDistance128(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, int length) {
         if (length == FloatVector.SPECIES_128.length())
             return squareDistance128(v1, v1offset, v2, v2offset);
 
@@ -384,7 +384,7 @@ final class VectorSimdOps {
     }
 
 
-    static float squareDistance256(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, int length) {
+    static float squareDistance256(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, int length) {
         if (length == FloatVector.SPECIES_256.length())
             return squareDistance256(v1, v1offset, v2, v2offset);
 
@@ -411,7 +411,7 @@ final class VectorSimdOps {
         return res;
     }
 
-    static float squareDistancePreferred(OffHeapVectorFloat v1, int v1offset, OffHeapVectorFloat v2, int v2offset, int length) {
+    static float squareDistancePreferred(MemorySegmentVectorFloat v1, int v1offset, MemorySegmentVectorFloat v2, int v2offset, int length) {
 
         if (length == FloatVector.SPECIES_PREFERRED.length())
             return squareDistancePreferred(v1, v1offset, v2, v2offset);
@@ -439,13 +439,13 @@ final class VectorSimdOps {
         return res;
     }
 
-    static void addInPlace64(OffHeapVectorFloat v1, OffHeapVectorFloat v2) {
+    static void addInPlace64(MemorySegmentVectorFloat v1, MemorySegmentVectorFloat v2) {
         var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_64, v1.get(), 0, ByteOrder.LITTLE_ENDIAN);
         var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_64, v2.get(), 0, ByteOrder.LITTLE_ENDIAN);
         a.add(b).intoMemorySegment(v1.get(), v1.offset(0), ByteOrder.LITTLE_ENDIAN);
     }
 
-    static void addInPlace(OffHeapVectorFloat v1, OffHeapVectorFloat v2) {
+    static void addInPlace(MemorySegmentVectorFloat v1, MemorySegmentVectorFloat v2) {
         if (v1.length() != v2.length()) {
             throw new IllegalArgumentException("Vectors must have the same length");
         }
@@ -470,8 +470,8 @@ final class VectorSimdOps {
         }
     }
 
-    static VectorFloat<?> sub(OffHeapVectorFloat a, int aOffset, OffHeapVectorFloat b, int bOffset, int length) {
-        OffHeapVectorFloat result = new OffHeapVectorFloat(length);
+    static VectorFloat<?> sub(MemorySegmentVectorFloat a, int aOffset, MemorySegmentVectorFloat b, int bOffset, int length) {
+        MemorySegmentVectorFloat result = new MemorySegmentVectorFloat(length);
         int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(length);
 
         // Process the vectorized part
@@ -490,7 +490,7 @@ final class VectorSimdOps {
         return result;
     }
 
-    static void subInPlace(OffHeapVectorFloat v1, OffHeapVectorFloat v2) {
+    static void subInPlace(MemorySegmentVectorFloat v1, MemorySegmentVectorFloat v2) {
         if (v1.length() != v2.length()) {
             throw new IllegalArgumentException("Vectors must have the same length");
         }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/NativeSimdOps.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/NativeSimdOps.java
@@ -102,7 +102,7 @@ public class NativeSimdOps {
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
                     NativeSimdOps.findOrThrow("check_compatibility"),
-                    DESC);
+                    DESC, Linker.Option.critical(true));
     }
 
     /**
@@ -154,7 +154,7 @@ public class NativeSimdOps {
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
                     NativeSimdOps.findOrThrow("dot_product_f32"),
-                    DESC);
+                    DESC, Linker.Option.critical(true));
     }
 
     /**
@@ -206,7 +206,7 @@ public class NativeSimdOps {
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
                     NativeSimdOps.findOrThrow("euclidean_f32"),
-                    DESC);
+                    DESC, Linker.Option.critical(true));
     }
 
     /**
@@ -255,7 +255,7 @@ public class NativeSimdOps {
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
                     NativeSimdOps.findOrThrow("bulk_shuffle_dot_f32_512"),
-                    DESC);
+                    DESC, Linker.Option.critical(true));
     }
 
     /**
@@ -304,7 +304,7 @@ public class NativeSimdOps {
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
                     NativeSimdOps.findOrThrow("bulk_shuffle_euclidean_f32_512"),
-                    DESC);
+                    DESC, Linker.Option.critical(true));
     }
 
     /**
@@ -354,7 +354,7 @@ public class NativeSimdOps {
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
                     NativeSimdOps.findOrThrow("assemble_and_sum_f32_512"),
-                    DESC);
+                    DESC, Linker.Option.critical(true));
     }
 
     /**
@@ -406,7 +406,7 @@ public class NativeSimdOps {
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
                     NativeSimdOps.findOrThrow("calculate_partial_sums_dot_f32_512"),
-                    DESC);
+                    DESC, Linker.Option.critical(true));
     }
 
     /**
@@ -458,7 +458,7 @@ public class NativeSimdOps {
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
                     NativeSimdOps.findOrThrow("calculate_partial_sums_euclidean_f32_512"),
-                    DESC);
+                    DESC, Linker.Option.critical(true));
     }
 
     /**
@@ -508,7 +508,7 @@ public class NativeSimdOps {
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
                     NativeSimdOps.findOrThrow("dot_product_multi_f32_512"),
-                    DESC);
+                    DESC, Linker.Option.critical(true));
     }
 
     /**
@@ -558,7 +558,7 @@ public class NativeSimdOps {
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
                     NativeSimdOps.findOrThrow("square_distance_multi_f32_512"),
-                    DESC);
+                    DESC, Linker.Option.critical(true));
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
                                 <additionalJOption>--add-modules=jdk.incubator.vector</additionalJOption>
                                 <additionalJOption>--enable-preview</additionalJOption>
                             </additionalJOptions>
-                            <release>21</release>
+                            <release>22</release>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
As discussed, the current Arena.ofAuto usage for off-heap memory segments is not sufficient for production workloads. While it may be worthwhile to continue to invest in off-heap options, this switch to on-heap memory segments increases stability at very little cost. It continues to allow the use of native code, as long as that code doesn't upcall back into the JVM.