### PR TITLE
Fix bytesToRead math in MMapReader.read(int[], int, int)

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/MMapReader.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/MMapReader.java
@@ -77,7 +77,7 @@ public class MMapReader implements RandomAccessReader {
 
     @Override
     public void read(int[] ints, int offset, int count) {
-        int bytesToRead = (count - offset) * Integer.BYTES;
+        int bytesToRead = count * Integer.BYTES;
         if (scratch.length < bytesToRead) {
             scratch = new byte[bytesToRead];
         }


### PR DESCRIPTION
No callers were failing because all current callers pass offset=0, but we want to read count bytes from offset, not count-offset bytes.