### PR TITLE
Generify abstracted caching/storage

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -29,7 +29,6 @@ import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.util.DenseIntMap;
 import io.github.jbellis.jvector.util.RamUsageEstimator;
 import io.github.jbellis.jvector.util.ThreadSafeGrowableBitSet;
-import io.github.jbellis.jvector.vector.types.VectorFloat;
 
 import java.io.DataOutput;
 import java.util.Set;
@@ -263,7 +262,7 @@ public class OnHeapGraphIndex implements GraphIndex, Accountable {
         }
     }
 
-    class ConcurrentGraphIndexView implements GraphIndex.View {
+    public class ConcurrentGraphIndexView implements GraphIndex.View {
         final long stamp;
 
         public ConcurrentGraphIndexView() {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/GraphCache.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/GraphCache.java
@@ -20,7 +20,7 @@ import io.github.jbellis.jvector.util.Accountable;
 import io.github.jbellis.jvector.util.RamUsageEstimator;
 import org.agrona.collections.Int2ObjectHashMap;
 
-public abstract class GraphCache implements Accountable
+public abstract class GraphCache<T extends GraphCache.CachedNode> implements Accountable
 {
     public static class CachedNode implements Accountable {
         public final int[] neighbors;
@@ -35,21 +35,21 @@ public abstract class GraphCache implements Accountable
     }
 
     /** return the cached node if present, or null if not */
-    public abstract CachedNode getNode(int ordinal);
+    public abstract T getNode(int ordinal);
 
-    public static GraphCache load(OnDiskGraphIndex graph, int distance)
+    public static <U extends OnDiskView<V>, V extends CachedNode> GraphCache<V> load(OnDiskGraphIndex<U, V> graph, int distance)
     {
         if (distance < 0)
-            return new EmptyGraphCache();
-        return new HMGraphCache(graph, distance);
+            return new EmptyGraphCache<>();
+        return new HMGraphCache<>(graph, distance);
     }
 
     public abstract long ramBytesUsed();
 
-    private static final class EmptyGraphCache extends GraphCache
+    private static final class EmptyGraphCache<U extends CachedNode> extends GraphCache<U>
     {
         @Override
-        public CachedNode getNode(int ordinal) {
+        public U getNode(int ordinal) {
             return null;
         }
 
@@ -60,15 +60,15 @@ public abstract class GraphCache implements Accountable
         }
     }
 
-    private static final class HMGraphCache extends GraphCache
+    private static final class HMGraphCache<T extends OnDiskView<U>, U extends CachedNode> extends GraphCache<U>
     {
         // Map is created on construction and never modified
-        private final Int2ObjectHashMap<CachedNode> cache;
+        private final Int2ObjectHashMap<U> cache;
         private long ramBytesUsed = 0;
 
-        public HMGraphCache(OnDiskGraphIndex graph, int distance) {
+        public HMGraphCache(OnDiskGraphIndex<T, U> graph, int distance) {
             try (var view = graph.getView()) {
-                var tmpCache = new Int2ObjectHashMap<CachedNode>();
+                var tmpCache = new Int2ObjectHashMap<U>();
                 cacheNeighborsOf(tmpCache, view, view.entryNode(), distance);
                 // Assigning to a final value ensure it is safely published
                 cache = tmpCache;
@@ -77,7 +77,7 @@ public abstract class GraphCache implements Accountable
             }
         }
 
-        private void cacheNeighborsOf(Int2ObjectHashMap<CachedNode> tmpCache, OnDiskView view, int ordinal, int distance) {
+        private void cacheNeighborsOf(Int2ObjectHashMap<U> tmpCache, OnDiskView<U> view, int ordinal, int distance) {
             // cache this node
             var it = view.getNeighborsIterator(ordinal);
             int[] neighbors = new int[it.size()];
@@ -102,7 +102,7 @@ public abstract class GraphCache implements Accountable
 
 
         @Override
-        public CachedNode getNode(int ordinal) {
+        public U getNode(int ordinal) {
             return cache.get(ordinal);
         }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -45,7 +45,7 @@ import java.util.stream.IntStream;
  * implies a subclass of CachedNode and a cached View.  By convention, these are implemented
  * in the same file as the subclass of OnDiskGraphIndex.  See DiskAnnGraphIndex for an example.
  */
-public abstract class OnDiskGraphIndex implements GraphIndex, AutoCloseable, Accountable
+public abstract class OnDiskGraphIndex<T extends OnDiskView<U>, U extends GraphCache.CachedNode> implements GraphIndex, AutoCloseable, Accountable
 {
     protected static final VectorTypeSupport vectorTypeSupport = VectorizationProvider.getInstance().getVectorTypeSupport();
     protected final ReaderSupplier readerSupplier;
@@ -221,5 +221,5 @@ public abstract class OnDiskGraphIndex implements GraphIndex, AutoCloseable, Acc
 
     // re-declared to specify type
     @Override
-    public abstract OnDiskView getView();
+    public abstract T getView();
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskView.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskView.java
@@ -11,7 +11,7 @@ import io.github.jbellis.jvector.vector.types.VectorFloat;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-public abstract class OnDiskView implements GraphIndex.RerankingView {
+public abstract class OnDiskView<T extends GraphCache.CachedNode> implements GraphIndex.RerankingView {
     private final OnDiskGraphIndex index;
     protected final RandomAccessReader reader;
     private final int[] neighbors;
@@ -56,9 +56,9 @@ public abstract class OnDiskView implements GraphIndex.RerankingView {
         reader.close();
     }
 
-    public abstract GraphCache.CachedNode loadCachedNode(int node, int[] neighbors);
+    abstract T loadCachedNode(int node, int[] neighbors);
 
     public abstract ScoreFunction.ExactScoreFunction rerankerFor(VectorFloat<?> queryVector, VectorSimilarityFunction similarity);
 
-    public abstract GraphIndex.RerankingView cachedWith(GraphCache cache);
+    abstract GraphIndex.RerankingView cachedWith(GraphCache<T> cache);
 }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -16,11 +16,6 @@
 
 package io.github.jbellis.jvector.example;
 
-import io.github.jbellis.jvector.graph.disk.ADCView;
-import io.github.jbellis.jvector.graph.disk.CachingGraphIndex;
-import io.github.jbellis.jvector.graph.disk.DiskAnnGraphIndex;
-import io.github.jbellis.jvector.graph.disk.ADCGraphIndex;
-import io.github.jbellis.jvector.graph.disk.LVQGraphIndex;
 import io.github.jbellis.jvector.example.util.CompressorParameters;
 import io.github.jbellis.jvector.example.util.DataSet;
 import io.github.jbellis.jvector.example.util.ReaderSupplierFactory;
@@ -29,6 +24,11 @@ import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.SearchResult;
+import io.github.jbellis.jvector.graph.disk.ADCGraphIndex;
+import io.github.jbellis.jvector.graph.disk.ADCView;
+import io.github.jbellis.jvector.graph.disk.CachingGraphIndex;
+import io.github.jbellis.jvector.graph.disk.DiskAnnGraphIndex;
+import io.github.jbellis.jvector.graph.disk.LVQGraphIndex;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
@@ -155,9 +155,9 @@ public class Grid {
                     }
                 }
 
-                try (var onDiskGraph = new CachingGraphIndex(DiskAnnGraphIndex.load(ReaderSupplierFactory.open(graphPath), 0));
-                     var onDiskLVQGraph = compressor == null ? null : new CachingGraphIndex(LVQGraphIndex.load(ReaderSupplierFactory.open(lvqGraphPath), 0));
-                     var onDiskFusedGraph = fusedCompatible ? new CachingGraphIndex(ADCGraphIndex.load(ReaderSupplierFactory.open(fusedGraphPath), 0)) : null) {
+                try (var onDiskGraph = CachingGraphIndex.from((DiskAnnGraphIndex.load(ReaderSupplierFactory.open(graphPath), 0)));
+                     var onDiskLVQGraph = compressor == null ? null : CachingGraphIndex.from(LVQGraphIndex.load(ReaderSupplierFactory.open(lvqGraphPath), 0));
+                     var onDiskFusedGraph = fusedCompatible ? CachingGraphIndex.from(ADCGraphIndex.load(ReaderSupplierFactory.open(fusedGraphPath), 0)) : null) {
                     List<GraphIndex> graphs = new ArrayList<>();
                     graphs.add(onDiskGraph);
                     if (onDiskFusedGraph != null) {

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/IPCService.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/IPCService.java
@@ -16,9 +16,6 @@
 
 package io.github.jbellis.jvector.example;
 
-import io.github.jbellis.jvector.graph.disk.CachingGraphIndex;
-import io.github.jbellis.jvector.graph.disk.DiskAnnGraphIndex;
-import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.example.util.MMapRandomAccessVectorValues;
 import io.github.jbellis.jvector.example.util.ReaderSupplierFactory;
 import io.github.jbellis.jvector.example.util.UpdatableRandomAccessVectorValues;
@@ -28,6 +25,8 @@ import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.SearchResult;
+import io.github.jbellis.jvector.graph.disk.CachingGraphIndex;
+import io.github.jbellis.jvector.graph.disk.DiskAnnGraphIndex;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.pq.CompressedVectors;
@@ -208,7 +207,7 @@ public class IPCService
             try (var outputStream = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(graphPath)))) {
                 DiskAnnGraphIndex.write(onHeapIndex, ravv, outputStream);
             }
-            return new CachingGraphIndex(DiskAnnGraphIndex.load(ReaderSupplierFactory.open(graphPath), 0));
+            return CachingGraphIndex.from(DiskAnnGraphIndex.load(ReaderSupplierFactory.open(graphPath), 0));
         } catch (IOException e) {
             throw new IOError(e);
         }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -16,8 +16,6 @@
 
 package io.github.jbellis.jvector.example;
 
-import io.github.jbellis.jvector.graph.disk.CachingGraphIndex;
-import io.github.jbellis.jvector.graph.disk.DiskAnnGraphIndex;
 import io.github.jbellis.jvector.example.util.ReaderSupplierFactory;
 import io.github.jbellis.jvector.example.util.SiftLoader;
 import io.github.jbellis.jvector.graph.GraphIndex;
@@ -25,7 +23,8 @@ import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
-import io.github.jbellis.jvector.graph.disk.OnDiskView;
+import io.github.jbellis.jvector.graph.disk.CachingGraphIndex;
+import io.github.jbellis.jvector.graph.disk.DiskAnnGraphIndex;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.pq.CompressedVectors;
@@ -75,7 +74,7 @@ public class SiftSmall {
         try (DataOutputStream outputFile = new DataOutputStream(new FileOutputStream(graphPath.toFile()))){
 
             DiskAnnGraphIndex.write(onHeapGraph, ravv, outputFile);
-            onDiskGraph = new CachingGraphIndex(DiskAnnGraphIndex.load(ReaderSupplierFactory.open(graphPath), 0));
+            onDiskGraph = CachingGraphIndex.from(DiskAnnGraphIndex.load(ReaderSupplierFactory.open(graphPath), 0));
 
             testRecallInternal(onHeapGraph, ravv, queryVectors, groundTruth, null);
             testRecallInternal(onDiskGraph, null, queryVectors, groundTruth, compressedVectors);

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestGraphCache.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestGraphCache.java
@@ -21,9 +21,6 @@ import io.github.jbellis.jvector.TestUtil;
 import io.github.jbellis.jvector.disk.SimpleMappedReader;
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
-import io.github.jbellis.jvector.graph.disk.DiskAnnGraphIndex;
-import io.github.jbellis.jvector.graph.disk.GraphCache;
-import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,7 +69,7 @@ public class TestGraphCache extends RandomizedTest {
             // move from caching entry node to entry node + all its neighbors (5)
             assertEquals(one.ramBytesUsed(), zero.ramBytesUsed() * (onDiskGraph.size()));
             for (int i = 0; i < 6; i++) {
-                assertEquals(((DiskAnnGraphIndex.CachedNode) one.getNode(i)).vector, vectors.getVector(i));
+                assertEquals((one.getNode(i)).vector, vectors.getVector(i));
                 // fully connected,
                 assertEquals(one.getNode(i).neighbors.length, onDiskGraph.maxDegree());
             }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
@@ -174,7 +174,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
 
         try (var marr = new SimpleMappedReader(outputPath.toAbsolutePath().toString());
              var onDiskGraph = DiskAnnGraphIndex.load(marr::duplicate, 0);
-             var cachedOnDiskGraph = new CachingGraphIndex(onDiskGraph))
+             var cachedOnDiskGraph = CachingGraphIndex.from(onDiskGraph))
         {
             TestUtil.assertGraphEquals(graph, onDiskGraph);
             TestUtil.assertGraphEquals(graph, cachedOnDiskGraph);

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestADCGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestADCGraphIndex.java
@@ -21,9 +21,9 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import io.github.jbellis.jvector.TestUtil;
 import io.github.jbellis.jvector.disk.SimpleMappedReader;
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.disk.ADCGraphIndex;
 import io.github.jbellis.jvector.graph.disk.ADCView;
 import io.github.jbellis.jvector.graph.disk.CachingGraphIndex;
-import io.github.jbellis.jvector.graph.disk.ADCGraphIndex;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import org.junit.After;
 import org.junit.Before;
@@ -70,7 +70,7 @@ public class TestADCGraphIndex extends RandomizedTest {
 
         try (var marr = new SimpleMappedReader(outputPath.toAbsolutePath().toString());
              var onDiskGraph = ADCGraphIndex.load(marr::duplicate, 0);
-             var cachedOnDiskGraph = new CachingGraphIndex(onDiskGraph))
+             var cachedOnDiskGraph = CachingGraphIndex.from(onDiskGraph))
         {
             TestUtil.assertGraphEquals(graph, onDiskGraph);
             TestUtil.assertGraphEquals(graph, cachedOnDiskGraph);


### PR DESCRIPTION
Generify new abstracted ODGI, such that the caching hierarchy doesn't require casting back to view/cachednode types. Fix any leakage of return types outside of visibility scope.