### PR TITLE
Remove PQVectors from ADCGraphIndex

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/ADCView.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/ADCView.java
@@ -17,13 +17,14 @@
 package io.github.jbellis.jvector.graph.disk;
 
 import io.github.jbellis.jvector.graph.GraphIndex;
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
-import io.github.jbellis.jvector.pq.PQVectors;
+import io.github.jbellis.jvector.pq.ProductQuantization;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
-public interface ADCView extends GraphIndex.RerankingView {
+public interface ADCView extends GraphIndex.RerankingView, RandomAccessVectorValues {
     /**
      * @return the quantized, transposed, and packed vectors of the given node's neighbors.
      * Only one ByteSequence is allocated by the View, so if you need to keep multiple
@@ -36,7 +37,7 @@ public interface ADCView extends GraphIndex.RerankingView {
      */
     VectorFloat<?> reusableResults();
 
-    PQVectors getPQVectors();
+    ProductQuantization getProductQuantization();
 
     ScoreFunction.ApproximateScoreFunction approximateScoreFunctionFor(VectorFloat<?> query, VectorSimilarityFunction similarityFunction);
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQVectors.java
@@ -36,15 +36,11 @@ public class PQVectors implements CompressedVectors {
     private static final VectorTypeSupport vectorTypeSupport = VectorizationProvider.getInstance().getVectorTypeSupport();
     final ProductQuantization pq;
     private final ByteSequence<?>[] compressedVectors;
-    private final ThreadLocal<VectorFloat<?>> partialSums; // for dot product, euclidean, and cosine
-    private final AtomicReference<VectorFloat<?>> partialMagnitudes; // for cosine
 
     public PQVectors(ProductQuantization pq, ByteSequence<?>[] compressedVectors)
     {
         this.pq = pq;
         this.compressedVectors = compressedVectors;
-        this.partialSums = ThreadLocal.withInitial(() -> vectorTypeSupport.createFloatVector(pq.getSubspaceCount() * pq.getClusterCount()));
-        this.partialMagnitudes = new AtomicReference<>(null);
     }
 
     @Override
@@ -190,11 +186,11 @@ public class PQVectors implements CompressedVectors {
     }
 
     VectorFloat<?> reusablePartialSums() {
-        return partialSums.get();
+        return pq.reusablePartialSums();
     }
 
     AtomicReference<VectorFloat<?>> partialMagnitudes() {
-        return partialMagnitudes;
+        return pq.partialMagnitudes();
     }
 
     @Override
@@ -204,7 +200,7 @@ public class PQVectors implements CompressedVectors {
 
     @Override
     public int getCompressedSize() {
-        return pq.codebooks.length;
+        return pq.getCompressedSize();
     }
 
     @Override

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestADCGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestADCGraphIndex.java
@@ -42,9 +42,6 @@ public class TestADCGraphIndex extends RandomizedTest {
 
     private Path testDirectory;
 
-    private TestUtil.FullyConnectedGraphIndex fullyConnectedGraph;
-    private TestUtil.RandomlyConnectedGraphIndex randomlyConnectedGraph;
-
     @Before
     public void setup() throws IOException {
         testDirectory = Files.createTempDirectory(this.getClass().getSimpleName());


### PR DESCRIPTION
Use ProductQuantization, falling back to exact similarity for vector->vector comparisons (entry nodes).