### PR TITLE
Switch Fused ADC from 32-cluster to 256-cluster PQ, maxDegree 32 graphs

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
@@ -289,7 +289,8 @@ public class GraphSearcher implements AutoCloseable {
 
             // score the neighbors of the top candidate and add them to the queue
             var scoreFunction = scoreProvider.scoreFunction();
-            if (scoreFunction.supportsEdgeLoadingSimilarity()) {
+            var useEdgeLoading = scoreFunction.supportsEdgeLoadingSimilarity();
+            if (useEdgeLoading) {
                 similarities = scoreFunction.edgeLoadingSimilarityTo(topCandidateNode);
             }
 
@@ -301,7 +302,7 @@ public class GraphSearcher implements AutoCloseable {
                 }
                 numVisited++;
 
-                float friendSimilarity = scoreFunction.supportsEdgeLoadingSimilarity()
+                float friendSimilarity = useEdgeLoading
                         ? similarities.get(i)
                         : scoreFunction.similarityTo(friendOrd);
                 scoreTracker.track(friendSimilarity);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/FusedADCNeighbors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/FusedADCNeighbors.java
@@ -25,4 +25,10 @@ public interface FusedADCNeighbors {
      * @return the quantized, transposed, and packed vectors of the given node's neighbors.
      */
     ByteSequence<?> getPackedNeighbors(int node);
+
+    /**
+     * Get the maximum degree of the graph for which this FusedADCNeighbors instance is used.
+     * @return the maximum degree of the graph.
+     */
+    int maxDegree();
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexWriter.java
@@ -296,10 +296,6 @@ public class OnDiskGraphIndexWriter implements Closeable {
         }
 
         public OnDiskGraphIndexWriter build() throws IOException {
-            if (features.containsKey(FeatureId.FUSED_ADC) && !(features.containsKey(FeatureId.LVQ) || features.containsKey(FeatureId.INLINE_VECTORS))) {
-                throw new IllegalArgumentException("Fused ADC requires an exact score source.");
-            }
-
             int dimension;
             if (features.containsKey(FeatureId.INLINE_VECTORS)) {
                 dimension = ((InlineVectors) features.get(FeatureId.INLINE_VECTORS)).dimension();

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQDecoder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/PQDecoder.java
@@ -48,9 +48,8 @@ abstract class PQDecoder implements ScoreFunction.ApproximateScoreFunction {
             for (var i = 0; i < pq.getSubspaceCount(); i++) {
                 int offset = pq.subvectorSizesAndOffsets[i][1];
                 int size = pq.subvectorSizesAndOffsets[i][0];
-                int baseOffset = i * pq.getClusterCount();
                 var codebook = pq.codebooks[i];
-                VectorUtil.calculatePartialSums(codebook, baseOffset, size, pq.getClusterCount(), centeredQuery, offset, vsf, partialSums);
+                VectorUtil.calculatePartialSums(codebook, i, size, pq.getClusterCount(), centeredQuery, offset, vsf, partialSums);
             }
         }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayByteSequence.java
@@ -52,6 +52,12 @@ final public class ArrayByteSequence implements ByteSequence<byte[]>
     }
 
     @Override
+    public void setLittleEndianShort(int byteIndex, short value) {
+        data[byteIndex] = (byte) (value & 0xFF);
+        data[byteIndex + 1] = (byte) ((value >> 8) & 0xFF);
+    }
+
+    @Override
     public void zero() {
         Arrays.fill(data, (byte) 0);
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -151,16 +151,24 @@ public final class VectorUtil {
     return impl.assembleAndSum(data, dataBase, dataOffsets);
   }
 
-  public static void bulkShuffleSimilarity(ByteSequence<?> shuffles, int codebookCount, VectorFloat<?> partials, VectorFloat<?> results, VectorSimilarityFunction vsf) {
-    impl.bulkShuffleSimilarity(shuffles, codebookCount, partials, vsf, results);
+  public static void bulkShuffleQuantizedSimilarity(ByteSequence<?> shuffles, int codebookCount, ByteSequence<?> quantizedPartials, float delta, float minDistance, VectorFloat<?> results, VectorSimilarityFunction vsf) {
+    impl.bulkShuffleQuantizedSimilarity(shuffles, codebookCount, quantizedPartials, delta, minDistance, vsf, results);
   }
 
   public static int hammingDistance(long[] v1, long[] v2) {
     return impl.hammingDistance(v1, v2);
   }
 
-  public static void calculatePartialSums(VectorFloat<?> codebook, int baseOffset, int size, int clusterCount, VectorFloat<?> query, int offset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums) {
-    impl.calculatePartialSums(codebook, baseOffset, size, clusterCount, query, offset, vsf, partialSums);
+  public static void calculatePartialSums(VectorFloat<?> codebook, int codebookIndex, int size, int clusterCount, VectorFloat<?> query, int offset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums, VectorFloat<?> partialBestDistances) {
+    impl.calculatePartialSums(codebook, codebookIndex, size, clusterCount, query, offset, vsf, partialSums, partialBestDistances);
+  }
+
+  public static void calculatePartialSums(VectorFloat<?> codebook, int codebookIndex, int size, int clusterCount, VectorFloat<?> query, int offset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums) {
+    impl.calculatePartialSums(codebook, codebookIndex, size, clusterCount, query, offset, vsf, partialSums);
+  }
+
+  public static void quantizePartialSums(float delta, VectorFloat<?> partialSums, VectorFloat<?> partialBest, ByteSequence<?> partialQuantizedSums) {
+    impl.quantizePartialSums(delta, partialSums, partialBest, partialQuantizedSums);
   }
 
   /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/ByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/ByteSequence.java
@@ -31,6 +31,12 @@ public interface ByteSequence<T> extends Accountable
 
     void set(int i, byte value);
 
+    /**
+     * @param byteIndex byte index inside the sequence to start setting short value
+     * @param value short value to set
+     */
+    void setLittleEndianShort(int byteIndex, short value);
+
     void zero();
 
     void copyFrom(ByteSequence<?> src, int srcOffset, int destOffset, int length);

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
@@ -46,7 +46,7 @@ public class Bench {
         var efConstructionGrid = List.of(100); // List.of(60, 80, 100, 120, 160, 200, 400, 600, 800);
         var efSearchGrid = List.of(1, 2);
         List<Function<DataSet, CompressorParameters>> buildCompression = Arrays.asList(
-                // ds -> new PQParameters(ds.getDimension() / 8, 256, ds.similarityFunction == VectorSimilarityFunction.EUCLIDEAN, UNWEIGHTED),
+                ds -> new PQParameters(ds.getDimension() / 8, 256, ds.similarityFunction == VectorSimilarityFunction.EUCLIDEAN, UNWEIGHTED),
                 __ -> CompressorParameters.NONE
         );
         List<Function<DataSet, CompressorParameters>> searchCompression = Arrays.asList(
@@ -56,8 +56,8 @@ public class Bench {
         );
         List<EnumSet<FeatureId>> featureSets = Arrays.asList(
                 EnumSet.of(FeatureId.INLINE_VECTORS), // baseline
-                EnumSet.of(FeatureId.LVQ)
-                // EnumSet.of(FeatureId.LVQ, FeatureId.FUSED_ADC)
+                EnumSet.of(FeatureId.LVQ),
+                EnumSet.of(FeatureId.LVQ, FeatureId.FUSED_ADC)
         );
 
         // args is list of regexes, possibly needing to be split by whitespace.

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -26,9 +26,9 @@ import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.CachingGraphIndex;
-import io.github.jbellis.jvector.graph.disk.InlineVectorValues;
 import io.github.jbellis.jvector.graph.disk.Feature;
 import io.github.jbellis.jvector.graph.disk.FeatureId;
+import io.github.jbellis.jvector.graph.disk.FusedADC;
 import io.github.jbellis.jvector.graph.disk.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.LVQ;
 import io.github.jbellis.jvector.graph.disk.LvqVectorValues;
@@ -168,7 +168,7 @@ public class Grid {
         int n = 0;
         for (var features : featureSets) {
             var graphPath = testDirectory.resolve("graph" + n++);
-            var bws = builderWithSuppliers(features, builder.getGraph(), graphPath, floatVectors);
+            var bws = builderWithSuppliers(features, builder.getGraph(), graphPath, floatVectors, pq.getProductQuantization());
             var writer = bws.builder.build();
             writers.put(features, writer);
             suppliers.put(features, bws.suppliers);
@@ -205,9 +205,20 @@ public class Grid {
         }).join();
         builder.cleanup();
         // write the edge lists and close the writers
-        writers.values().stream().parallel().forEach(writer -> {
+        // if our feature set contains Fused ADC, we need a Fused ADC write-time supplier (as we don't have neighbor information during writeInline)
+        writers.entrySet().stream().parallel().forEach(entry -> {
+            var writer = entry.getValue();
+            var features = entry.getKey();
+            Map<FeatureId, IntFunction<Feature.State>> writeSuppliers;
+            if (features.contains(FeatureId.FUSED_ADC)) {
+                writeSuppliers = new EnumMap<>(FeatureId.class);
+                var view = builder.getGraph().getView();
+                writeSuppliers.put(FeatureId.FUSED_ADC, ordinal -> new FusedADC.State(view, pq, ordinal));
+            } else {
+                writeSuppliers = Map.of();
+            }
             try {
-                writer.write(Map.of());
+                writer.write(writeSuppliers);
                 writer.close();
                 ivv.close();
             } catch (IOException e) {
@@ -227,7 +238,7 @@ public class Grid {
         return indexes;
     }
 
-    private static BuilderWithSuppliers builderWithSuppliers(Set<FeatureId> features, OnHeapGraphIndex onHeapGraph, Path outPath, RandomAccessVectorValues floatVectors) {
+    private static BuilderWithSuppliers builderWithSuppliers(Set<FeatureId> features, OnHeapGraphIndex onHeapGraph, Path outPath, RandomAccessVectorValues floatVectors, ProductQuantization pq) {
         var builder = new OnDiskGraphIndexWriter.Builder(onHeapGraph, outPath).withMapper(new OnDiskGraphIndexWriter.IdentityMapper());
         Map<FeatureId, IntFunction<Feature.State>> suppliers = new EnumMap<>(FeatureId.class);
         for (var featureId : features) {
@@ -242,11 +253,13 @@ public class Grid {
                     suppliers.put(FeatureId.LVQ, ordinal -> new LVQ.State(lvq.encode(floatVectors.getVector(ordinal))));
                     break;
                 case FUSED_ADC:
-                    // ???
-                    // var pq = (PQVectors) buildCompressor;
-                    // builder.with(new FusedADC(onHeapGraph.maxDegree(), pq.getProductQuantization()));
-                    // suppliers.put(FeatureId.FUSED_ADC, ordinal -> new FusedADC.State(onHeapGraph.getView(), pq, ordinal));
-                    throw new UnsupportedOperationException("Unsupported feature " + featureId);
+                    if (pq == null) {
+                        System.out.println("Skipping Fused ADC feature due to null ProductQuantization");
+                        continue;
+                    }
+                    // no supplier as these will be used for writeInline, when we don't have enough information to fuse neighbors
+                    builder.with(new FusedADC(onHeapGraph.maxDegree(), pq));
+                    break;
             }
         }
         return new BuilderWithSuppliers(builder, suppliers);
@@ -286,8 +299,12 @@ public class Grid {
                           onHeapGraph.getAverageShortEdges());
         int n = 0;
         for (var features : featureSets) {
+            if (features.contains(FeatureId.FUSED_ADC)) {
+                System.out.println("Skipping Fused ADC feature when building in memory");
+                continue;
+            }
             var graphPath = testDirectory.resolve("graph" + n++);
-            var bws = builderWithSuppliers(features, onHeapGraph, graphPath, floatVectors);
+            var bws = builderWithSuppliers(features, onHeapGraph, graphPath, floatVectors, null);
             try (var writer = bws.builder.build()) {
                 start = System.nanoTime();
                 writer.write(bws.suppliers);

--- a/jvector-native/src/main/c/jextract_vector_simd.sh
+++ b/jvector-native/src/main/c/jextract_vector_simd.sh
@@ -21,7 +21,7 @@ mkdir -p ../resources
 # compile jvector_simd_check.c as x86-64
 # compile jvector_simd.c as skylake-avx512
 # produce one shared library
-gcc -fPIC -O3 -march=skylake-avx512 -c jvector_simd.c -o jvector_simd.o
+gcc -fPIC -O3 -march=icelake-server -c jvector_simd.c -o jvector_simd.o
 gcc -fPIC -O3 -march=x86-64 -c jvector_simd_check.c -o jvector_simd_check.o
 gcc -shared -o ../resources/libjvector.so jvector_simd_check.o jvector_simd.o
 

--- a/jvector-native/src/main/c/jvector_simd.h
+++ b/jvector-native/src/main/c/jvector_simd.h
@@ -25,11 +25,13 @@ bool check_compatibility(void);
 //F32
 float dot_product_f32(int preferred_size, const float* a, int aoffset, const float* b, int boffset, int length);
 float euclidean_f32(int preferred_size, const float* a, int aoffset, const float* b, int boffset, int length);
-void bulk_shuffle_dot_f32_512(const unsigned char* shuffles, int codebookCount, const float* partials, float* results);
-void bulk_shuffle_euclidean_f32_512(const unsigned char* shuffles, int codebookCount, const float* partials, float* results);
+void bulk_quantized_shuffle_dot_f32_512(const unsigned char* shuffles, int codebookCount, const char* quantizedPartials, float delta, float minDistance, float* results);
+void bulk_quantized_shuffle_euclidean_f32_512(const unsigned char* shuffles, int codebookCount, const char* quantizedPartials, float delta, float minDistance, float* results);
 float assemble_and_sum_f32_512(const float* data, int dataBase, const unsigned char* baseOffsets, int baseOffsetsLength);
 void calculate_partial_sums_dot_f32_512(const float* codebook, int codebookBase, int size, int clusterCount, const float* query, int queryOffset, float* partialSums);
 void calculate_partial_sums_euclidean_f32_512(const float* codebook, int codebookBase, int size, int clusterCount, const float* query, int queryOffset, float* partialSums);
+void calculate_partial_sums_best_dot_f32_512(const float* codebook, int codebookBase, int size, int clusterCount, const float* query, int queryOffset, float* partialSums, float* partialBestDistances);
+void calculate_partial_sums_best_euclidean_f32_512(const float* codebook, int codebookBase, int size, int clusterCount, const float* query, int queryOffset, float* partialSums, float* partialBestDistances);
 void dot_product_multi_f32_512(const float* v1, const float* packedv2, int v1Length, int resultsLength, float* results);
 void square_distance_multi_f32_512(const float* v1, const float* packedv2, int v1Length, int resultsLength, float* results);
 #endif

--- a/jvector-native/src/main/c/jvector_simd_check.c
+++ b/jvector-native/src/main/c/jvector_simd_check.c
@@ -19,28 +19,20 @@
 
 bool check_compatibility(void) {
     unsigned int eax, ebx, ecx, edx;
-    bool avx512f_supported = 0, avx512cd_supported = 0, avx512bw_supported = 0, avx512dq_supported = 0, avx512vl_supported = 0;
+    bool avx512f_supported = false, avx512cd_supported = false,
+         avx512bw_supported = false, avx512dq_supported = false,
+         avx512vl_supported = false, avx512vbmi_supported = false;
 
-    // Check for AVX-512 Foundation (AVX-512F) support:
-    // It is indicated by bit 16 of EBX from leaf 7, sub-leaf 0.
+    // Check for AVX-512 Foundation (AVX-512F) and other AVX-512 features:
+    // These are indicated by various bits of EBX from leaf 7, sub-leaf 0.
     if (__get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx)) {
-        avx512f_supported = ebx & (1 << 16);
+        avx512f_supported = ebx & (1 << 16);     // AVX-512F
+        avx512cd_supported = ebx & (1 << 28);    // AVX-512CD
+        avx512bw_supported = ebx & (1 << 30);    // AVX-512BW
+        avx512dq_supported = ebx & (1 << 17);    // AVX-512DQ
+        avx512vl_supported = ebx & (1 << 31);    // AVX-512VL
+        avx512vbmi_supported = ecx & (1 << 1);         // VBMI
     }
 
-    // Check for AVX-512 Conflict Detection (AVX-512CD) support:
-    // It is indicated by bit 28 of EBX from leaf 7, sub-leaf 0.
-    avx512cd_supported = ebx & (1 << 28);
-
-    // Check for AVX-512 Byte and Word Instructions (AVX-512BW) and
-    // AVX-512 Doubleword and Quadword Instructions (AVX-512DQ) support:
-    // Both are indicated by bits in EBX from leaf 7, sub-leaf 0:
-    // AVX-512BW by bit 30 and AVX-512DQ by bit 17.
-    avx512bw_supported = ebx & (1 << 30);
-    avx512dq_supported = ebx & (1 << 17);
-
-    // Check for AVX-512 Vector Length Extensions (AVX-512VL) support:
-    // It is indicated by bit 31 of EBX from leaf 7, sub-leaf 0.
-    avx512vl_supported = ebx & (1 << 31);
-
-    return avx512f_supported && avx512cd_supported && avx512bw_supported && avx512dq_supported && avx512vl_supported;
+    return avx512f_supported && avx512cd_supported && avx512bw_supported && avx512dq_supported && avx512vl_supported && avx512vbmi_supported;
 }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentByteSequence.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentByteSequence.java
@@ -22,6 +22,7 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.Buffer;
+import java.nio.ByteOrder;
 
 /**
  * ByteSequence implementation backed by an on-heap MemorySegment.
@@ -29,6 +30,8 @@ import java.nio.Buffer;
 public class MemorySegmentByteSequence implements ByteSequence<MemorySegment> {
     private final MemorySegment segment;
     private final int length;
+
+    private static final ValueLayout.OfShort LITTLEENDIAN_SHORT_LAYOUT_UNALIGNED = ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
 
     MemorySegmentByteSequence(int length) {
         this.length = length;
@@ -69,6 +72,11 @@ public class MemorySegmentByteSequence implements ByteSequence<MemorySegment> {
     @Override
     public void set(int n, byte value) {
         segment.set(ValueLayout.JAVA_BYTE, n, value);
+    }
+
+    @Override
+    public void setLittleEndianShort(int byteIndex, short value) {
+        segment.set(LITTLEENDIAN_SHORT_LAYOUT_UNALIGNED, byteIndex, value);
     }
 
     @Override

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentVectorFloat.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentVectorFloat.java
@@ -19,7 +19,6 @@ package io.github.jbellis.jvector.vector;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
 import java.nio.Buffer;
 
 /**
@@ -57,13 +56,15 @@ final public class MemorySegmentVectorFloat implements VectorFloat<MemorySegment
     @Override
     public float get(int n)
     {
-        return segment.getAtIndex(ValueLayout.JAVA_FLOAT, n);
+        // this is (unfortunately) meaningfully better performing than getting at an offset in the memory segment
+        return ((float[])segment.heapBase().get())[n];
     }
 
     @Override
     public void set(int n, float value)
     {
-        segment.setAtIndex(ValueLayout.JAVA_FLOAT, n, value);
+        // this is (unfortunately) meaningfully better performing than setting at an offset in the memory segment
+        ((float[])segment.heapBase().get())[n] = value;
     }
 
     @Override

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
@@ -22,6 +22,7 @@ import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.IntVector;
 import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.ShortVector;
 import jdk.incubator.vector.VectorOperators;
 
 import java.nio.ByteOrder;
@@ -844,6 +845,30 @@ final class VectorSimdOps {
             return lvqCosine512(vector, packedVector, centroid);
         } else {
             return lvqCosine256(vector, packedVector, centroid);
+        }
+    }
+
+    public static void quantizePartialSums(float delta, MemorySegmentVectorFloat partialSums, MemorySegmentVectorFloat partialBestDistances, MemorySegmentByteSequence partialQuantizedSums) {
+        var codebookSize = partialSums.length() / partialBestDistances.length();
+        var codebookCount = partialBestDistances.length();
+
+        for (int i = 0; i < codebookCount; i++) {
+            var vectorizedLength = FloatVector.SPECIES_512.loopBound(codebookSize);
+            var codebookBest = partialBestDistances.get(i);
+            var codebookBestVector = FloatVector.broadcast(FloatVector.SPECIES_512, codebookBest);
+            int j = 0;
+            for (; j < vectorizedLength; j += FloatVector.SPECIES_512.length()) {
+                var partialSumVector = FloatVector.fromMemorySegment(FloatVector.SPECIES_512, partialSums.get(), partialSums.offset(i * codebookSize + j), ByteOrder.LITTLE_ENDIAN);
+                var quantized = (partialSumVector.sub(codebookBestVector)).div(delta);
+                quantized = quantized.max(FloatVector.zero(FloatVector.SPECIES_512)).min(FloatVector.broadcast(FloatVector.SPECIES_512, 65535));
+                var quantizedBytes = (ShortVector) quantized.convertShape(VectorOperators.F2S, ShortVector.SPECIES_256, 0);
+                quantizedBytes.intoMemorySegment(partialQuantizedSums.get(), 2 * (i * codebookSize + j), ByteOrder.LITTLE_ENDIAN);
+            }
+            for (; j < codebookSize; j++) {
+                var val = partialSums.get(i * codebookSize + j);
+                var quantized = (short) Math.min((val - codebookBest) / delta, 65535);
+                partialQuantizedSums.setLittleEndianShort(2 * (i * codebookSize + j), quantized);
+            }
         }
     }
 }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/NativeSimdOps.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/NativeSimdOps.java
@@ -245,99 +245,103 @@ public class NativeSimdOps {
         }
     }
 
-    private static class bulk_shuffle_dot_f32_512 {
+    private static class bulk_quantized_shuffle_dot_f32_512 {
         public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
             NativeSimdOps.C_POINTER,
             NativeSimdOps.C_INT,
             NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_FLOAT,
+            NativeSimdOps.C_FLOAT,
             NativeSimdOps.C_POINTER
         );
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    NativeSimdOps.findOrThrow("bulk_shuffle_dot_f32_512"),
+                    NativeSimdOps.findOrThrow("bulk_quantized_shuffle_dot_f32_512"),
                     DESC, Linker.Option.critical(true));
     }
 
     /**
      * Function descriptor for:
      * {@snippet lang=c :
-     * void bulk_shuffle_dot_f32_512(const unsigned char *shuffles, int codebookCount, const float *partials, float *results)
+     * void bulk_quantized_shuffle_dot_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
      */
-    public static FunctionDescriptor bulk_shuffle_dot_f32_512$descriptor() {
-        return bulk_shuffle_dot_f32_512.DESC;
+    public static FunctionDescriptor bulk_quantized_shuffle_dot_f32_512$descriptor() {
+        return bulk_quantized_shuffle_dot_f32_512.DESC;
     }
 
     /**
      * Downcall method handle for:
      * {@snippet lang=c :
-     * void bulk_shuffle_dot_f32_512(const unsigned char *shuffles, int codebookCount, const float *partials, float *results)
+     * void bulk_quantized_shuffle_dot_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
      */
-    public static MethodHandle bulk_shuffle_dot_f32_512$handle() {
-        return bulk_shuffle_dot_f32_512.HANDLE;
+    public static MethodHandle bulk_quantized_shuffle_dot_f32_512$handle() {
+        return bulk_quantized_shuffle_dot_f32_512.HANDLE;
     }
     /**
      * {@snippet lang=c :
-     * void bulk_shuffle_dot_f32_512(const unsigned char *shuffles, int codebookCount, const float *partials, float *results)
+     * void bulk_quantized_shuffle_dot_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
      */
-    public static void bulk_shuffle_dot_f32_512(MemorySegment shuffles, int codebookCount, MemorySegment partials, MemorySegment results) {
-        var mh$ = bulk_shuffle_dot_f32_512.HANDLE;
+    public static void bulk_quantized_shuffle_dot_f32_512(MemorySegment shuffles, int codebookCount, MemorySegment quantizedPartials, float delta, float minDistance, MemorySegment results) {
+        var mh$ = bulk_quantized_shuffle_dot_f32_512.HANDLE;
         try {
             if (TRACE_DOWNCALLS) {
-                traceDowncall("bulk_shuffle_dot_f32_512", shuffles, codebookCount, partials, results);
+                traceDowncall("bulk_quantized_shuffle_dot_f32_512", shuffles, codebookCount, quantizedPartials, delta, minDistance, results);
             }
-            mh$.invokeExact(shuffles, codebookCount, partials, results);
+            mh$.invokeExact(shuffles, codebookCount, quantizedPartials, delta, minDistance, results);
         } catch (Throwable ex$) {
            throw new AssertionError("should not reach here", ex$);
         }
     }
 
-    private static class bulk_shuffle_euclidean_f32_512 {
+    private static class bulk_quantized_shuffle_euclidean_f32_512 {
         public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
             NativeSimdOps.C_POINTER,
             NativeSimdOps.C_INT,
             NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_FLOAT,
+            NativeSimdOps.C_FLOAT,
             NativeSimdOps.C_POINTER
         );
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    NativeSimdOps.findOrThrow("bulk_shuffle_euclidean_f32_512"),
+                    NativeSimdOps.findOrThrow("bulk_quantized_shuffle_euclidean_f32_512"),
                     DESC, Linker.Option.critical(true));
     }
 
     /**
      * Function descriptor for:
      * {@snippet lang=c :
-     * void bulk_shuffle_euclidean_f32_512(const unsigned char *shuffles, int codebookCount, const float *partials, float *results)
+     * void bulk_quantized_shuffle_euclidean_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
      */
-    public static FunctionDescriptor bulk_shuffle_euclidean_f32_512$descriptor() {
-        return bulk_shuffle_euclidean_f32_512.DESC;
+    public static FunctionDescriptor bulk_quantized_shuffle_euclidean_f32_512$descriptor() {
+        return bulk_quantized_shuffle_euclidean_f32_512.DESC;
     }
 
     /**
      * Downcall method handle for:
      * {@snippet lang=c :
-     * void bulk_shuffle_euclidean_f32_512(const unsigned char *shuffles, int codebookCount, const float *partials, float *results)
+     * void bulk_quantized_shuffle_euclidean_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
      */
-    public static MethodHandle bulk_shuffle_euclidean_f32_512$handle() {
-        return bulk_shuffle_euclidean_f32_512.HANDLE;
+    public static MethodHandle bulk_quantized_shuffle_euclidean_f32_512$handle() {
+        return bulk_quantized_shuffle_euclidean_f32_512.HANDLE;
     }
     /**
      * {@snippet lang=c :
-     * void bulk_shuffle_euclidean_f32_512(const unsigned char *shuffles, int codebookCount, const float *partials, float *results)
+     * void bulk_quantized_shuffle_euclidean_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
      */
-    public static void bulk_shuffle_euclidean_f32_512(MemorySegment shuffles, int codebookCount, MemorySegment partials, MemorySegment results) {
-        var mh$ = bulk_shuffle_euclidean_f32_512.HANDLE;
+    public static void bulk_quantized_shuffle_euclidean_f32_512(MemorySegment shuffles, int codebookCount, MemorySegment quantizedPartials, float delta, float minDistance, MemorySegment results) {
+        var mh$ = bulk_quantized_shuffle_euclidean_f32_512.HANDLE;
         try {
             if (TRACE_DOWNCALLS) {
-                traceDowncall("bulk_shuffle_euclidean_f32_512", shuffles, codebookCount, partials, results);
+                traceDowncall("bulk_quantized_shuffle_euclidean_f32_512", shuffles, codebookCount, quantizedPartials, delta, minDistance, results);
             }
-            mh$.invokeExact(shuffles, codebookCount, partials, results);
+            mh$.invokeExact(shuffles, codebookCount, quantizedPartials, delta, minDistance, results);
         } catch (Throwable ex$) {
            throw new AssertionError("should not reach here", ex$);
         }
@@ -492,6 +496,112 @@ public class NativeSimdOps {
                 traceDowncall("calculate_partial_sums_euclidean_f32_512", codebook, codebookBase, size, clusterCount, query, queryOffset, partialSums);
             }
             mh$.invokeExact(codebook, codebookBase, size, clusterCount, query, queryOffset, partialSums);
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class calculate_partial_sums_best_dot_f32_512 {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_INT,
+            NativeSimdOps.C_INT,
+            NativeSimdOps.C_INT,
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_INT,
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_POINTER
+        );
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
+                    NativeSimdOps.findOrThrow("calculate_partial_sums_best_dot_f32_512"),
+                    DESC, Linker.Option.critical(true));
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * void calculate_partial_sums_best_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
+     * }
+     */
+    public static FunctionDescriptor calculate_partial_sums_best_dot_f32_512$descriptor() {
+        return calculate_partial_sums_best_dot_f32_512.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * void calculate_partial_sums_best_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
+     * }
+     */
+    public static MethodHandle calculate_partial_sums_best_dot_f32_512$handle() {
+        return calculate_partial_sums_best_dot_f32_512.HANDLE;
+    }
+    /**
+     * {@snippet lang=c :
+     * void calculate_partial_sums_best_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
+     * }
+     */
+    public static void calculate_partial_sums_best_dot_f32_512(MemorySegment codebook, int codebookBase, int size, int clusterCount, MemorySegment query, int queryOffset, MemorySegment partialSums, MemorySegment partialBestDistances) {
+        var mh$ = calculate_partial_sums_best_dot_f32_512.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("calculate_partial_sums_best_dot_f32_512", codebook, codebookBase, size, clusterCount, query, queryOffset, partialSums, partialBestDistances);
+            }
+            mh$.invokeExact(codebook, codebookBase, size, clusterCount, query, queryOffset, partialSums, partialBestDistances);
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class calculate_partial_sums_best_euclidean_f32_512 {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_INT,
+            NativeSimdOps.C_INT,
+            NativeSimdOps.C_INT,
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_INT,
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_POINTER
+        );
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
+                    NativeSimdOps.findOrThrow("calculate_partial_sums_best_euclidean_f32_512"),
+                    DESC, Linker.Option.critical(true));
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * void calculate_partial_sums_best_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
+     * }
+     */
+    public static FunctionDescriptor calculate_partial_sums_best_euclidean_f32_512$descriptor() {
+        return calculate_partial_sums_best_euclidean_f32_512.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * void calculate_partial_sums_best_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
+     * }
+     */
+    public static MethodHandle calculate_partial_sums_best_euclidean_f32_512$handle() {
+        return calculate_partial_sums_best_euclidean_f32_512.HANDLE;
+    }
+    /**
+     * {@snippet lang=c :
+     * void calculate_partial_sums_best_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
+     * }
+     */
+    public static void calculate_partial_sums_best_euclidean_f32_512(MemorySegment codebook, int codebookBase, int size, int clusterCount, MemorySegment query, int queryOffset, MemorySegment partialSums, MemorySegment partialBestDistances) {
+        var mh$ = calculate_partial_sums_best_euclidean_f32_512.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("calculate_partial_sums_best_euclidean_f32_512", codebook, codebookBase, size, clusterCount, query, queryOffset, partialSums, partialBestDistances);
+            }
+            mh$.invokeExact(codebook, codebookBase, size, clusterCount, query, queryOffset, partialSums, partialBestDistances);
         } catch (Throwable ex$) {
            throw new AssertionError("should not reach here", ex$);
         }


### PR DESCRIPTION
This PR implements support for 256 cluster fused ADC in the style of Quicker ADC. As before, transposed quantized neighbors are fused into the graph structure. To reduce the number of shuffles/blends when doing bulk shuffle edge similarity, partial sum tables are quantized to 16-bit ints and summed with saturating arithmetic.

Several interesting bits of the PR:

- Quantization of the partial sums to 8-bit ints was attempted. This had too significant an adverse effect of recall.
- Quantization bounds are decided based on worst distances encountered during the search. As such, there is a tradeoff between finding the worst distance required and the number of slower evaluations before the quantization of partial sums can be performed. This PR currently evaluates maxDegree slow similarities before quantizing with no noticeable impact on recall.
- Earlier versions of this PR used LVQ for the slower evaluations prior to quantization. This was accelerated by implementing a specialized assemble/sum of the transposed neighbors which has not yet been SIMD-ified. This is still a performance improvement. During review, I will attempt to SIMD-ify this and PR a follow up if this has a noticeable performance improvement.
- LVQ/Fused ADC shows no noticeable recall drop over LVQ in Bench.
- Supporting varying max degrees/varying cluster counts is possible, but it will require additional complexity in the native implementations. I've deferred this in support of evaluating quality in the overall case. If this is valuable, we can do it as a follow up.
- Unsigned shorts are being read/written to the ByteSequence. This incurs some additional mental overhead at call sites. It might be worth adding a ShortSequence interface.