### PR TITLE
Fix usage of Float.MIN_VALUE

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/pq/QuickADCPQDecoder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/pq/QuickADCPQDecoder.java
@@ -143,7 +143,7 @@ public abstract class QuickADCPQDecoder implements ScoreFunction.ApproximateScor
     static class DotProductDecoder extends CachingDecoder {
         public DotProductDecoder(FusedADC.PackedNeighbors neighbors, ProductQuantization pq, VectorFloat<?> query, VectorFloat<?> results, ExactScoreFunction esf) {
             super(neighbors, results, pq, query, neighbors.maxDegree(), VectorSimilarityFunction.DOT_PRODUCT, esf);
-            worstDistance = Float.MAX_VALUE;
+            worstDistance = Float.MAX_VALUE; // initialize at best value, update as we search
         }
 
         @Override
@@ -160,7 +160,7 @@ public abstract class QuickADCPQDecoder implements ScoreFunction.ApproximateScor
     static class EuclideanDecoder extends CachingDecoder {
         public EuclideanDecoder(FusedADC.PackedNeighbors neighbors, ProductQuantization pq, VectorFloat<?> query, VectorFloat<?> results, ExactScoreFunction esf) {
             super(neighbors, results, pq, query, neighbors.maxDegree(), VectorSimilarityFunction.EUCLIDEAN, esf);
-            worstDistance = Float.MIN_VALUE;
+            worstDistance = 0; // initialize at best value, update as we search
         }
 
         @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
@@ -302,7 +302,7 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
 
   @Override
   public void calculatePartialSums(VectorFloat<?> codebook, int codebookIndex, int size, int clusterCount, VectorFloat<?> query, int queryOffset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums, VectorFloat<?> partialBest) {
-    float best = vsf == VectorSimilarityFunction.EUCLIDEAN ? Float.MAX_VALUE : Float.MIN_VALUE;
+    float best = vsf == VectorSimilarityFunction.EUCLIDEAN ? Float.MAX_VALUE : -Float.MAX_VALUE;
     float val;
     int codebookBase = codebookIndex * clusterCount;
     for (int i = 0; i < clusterCount; i++) {
@@ -339,7 +339,7 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
 
   @Override
   public float max(VectorFloat<?> v) {
-      float max = Float.MIN_VALUE;
+      float max = -Float.MAX_VALUE;
       for (int i = 0; i < v.length(); i++) {
         max = Math.max(max, v.get(i));
       }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -204,10 +204,20 @@ public final class VectorUtil {
     impl.cosineMultiScore(v1, v2, results);
   }
 
+  /**
+   * Calculates the maximum value in the vector.
+   * @param v vector
+   * @return the maximum value, or -Float.MAX_VALUE if the vector is empty
+   */
   public static float max(VectorFloat<?> v) {
     return impl.max(v);
   }
 
+  /**
+   * Calculates the minimum value in the vector.
+   * @param v vector
+   * @return the minimum value, or Float.MAX_VALUE if the vector is empty
+   */
   public static float min(VectorFloat<?> v) {
     return impl.min(v);
   }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
@@ -540,12 +540,13 @@ final class VectorSimdOps {
     }
 
     public static float max(MemorySegmentVectorFloat vector) {
+        var accum = FloatVector.broadcast(FloatVector.SPECIES_PREFERRED, -Float.MAX_VALUE);
         int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(vector.length());
-        float max = Float.MIN_VALUE;
         for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
             FloatVector a = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, vector.get(), vector.offset(i), ByteOrder.LITTLE_ENDIAN);
-            max = Math.max(max, a.reduceLanes(VectorOperators.MAX));
+            accum = accum.max(a);
         }
+        float max = accum.reduceLanes(VectorOperators.MAX);
         for (int i = vectorizedLength; i < vector.length(); i++) {
             max = Math.max(max, vector.get(i));
         }
@@ -553,12 +554,13 @@ final class VectorSimdOps {
     }
 
     public static float min(MemorySegmentVectorFloat vector) {
+        var accum = FloatVector.broadcast(FloatVector.SPECIES_PREFERRED, Float.MAX_VALUE);
         int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(vector.length());
-        float min = Float.MAX_VALUE;
         for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
             FloatVector a = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, vector.get(), vector.offset(i), ByteOrder.LITTLE_ENDIAN);
-            min = Math.min(min, a.reduceLanes(VectorOperators.MIN));
+            accum = accum.min(a);
         }
+        float min = accum.reduceLanes(VectorOperators.MIN);
         for (int i = vectorizedLength; i < vector.length(); i++) {
             min = Math.min(min, vector.get(i));
         }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestProductQuantization.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/pq/TestProductQuantization.java
@@ -93,10 +93,10 @@ public class TestProductQuantization extends RandomizedTest {
                                             1_000 + R.nextInt(10_000));
 
         var clusterer = new KMeansPlusPlusClusterer(vectors, DEFAULT_CLUSTERS);
-        var initialLoss = loss(clusterer, vectors, Float.MIN_VALUE);
+        var initialLoss = loss(clusterer, vectors, -Float.MAX_VALUE);
 
         assert clusterer.clusterOnceUnweighted() > 0;
-        var improvedLoss = loss(clusterer, vectors, Float.MIN_VALUE);
+        var improvedLoss = loss(clusterer, vectors, -Float.MAX_VALUE);
 
         assertTrue("improvedLoss=" + improvedLoss + " initialLoss=" + initialLoss, improvedLoss < initialLoss);
     }

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -149,7 +149,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     @Override
     public void calculatePartialSums(VectorFloat<?> codebook, int codebookIndex, int size, int clusterCount, VectorFloat<?> query, int queryOffset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums, VectorFloat<?> partialBest) {
-        float best = vsf == VectorSimilarityFunction.EUCLIDEAN ? Float.MAX_VALUE : Float.MIN_VALUE;
+        float best = vsf == VectorSimilarityFunction.EUCLIDEAN ? Float.MAX_VALUE : -Float.MAX_VALUE;
         float val;
         int codebookBase = codebookIndex * clusterCount;
         for (int i = 0; i < clusterCount; i++) {

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -609,7 +609,7 @@ final class SimdOps {
     }
 
     public static float max(ArrayVectorFloat v) {
-        var accum = FloatVector.broadcast(FloatVector.SPECIES_PREFERRED, Float.MIN_VALUE);
+        var accum = FloatVector.broadcast(FloatVector.SPECIES_PREFERRED, -Float.MAX_VALUE);
         int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(v.length());
         for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
             var a = FloatVector.fromArray(FloatVector.SPECIES_PREFERRED, v.get(), i);


### PR DESCRIPTION
Float.MIN_VALUE is not what I thought.

Incidentally, I noticed that the VectorSimdOps min/max implementation is less efficient than SimdOps. Fixing those while I'm here.