### PR TITLE
Reduce tendency of reconnectOrphanedNodes to leave orphaned nodes

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -236,9 +236,11 @@ public class GraphIndexBuilder implements Closeable {
     private void reconnectOrphanedNodes() {
         var searchPathNeighbors = new ConcurrentHashMap<Integer, NodeArray>();
         // It's possible that reconnecting one node will result in disconnecting another, since we are maintaining
-        // the maxConnections invariant. So, we do a best effort of 5 loops.
+        // the maxConnections invariant. So, we do a best effort of 3 loops. We claim the entry node as an
+        // already used connectionTarget so that we don't clutter its edge list.
         var connectionTargets = ConcurrentHashMap.<Integer>newKeySet();
-        for (int i = 0; i < 5; i++) {
+        connectionTargets.add(graph.entry());
+        for (int i = 0; i < 3; i++) {
             // find all nodes reachable from the entry node
             var connectedNodes = new AtomicFixedBitSet(graph.getIdUpperBound());
             connectedNodes.set(graph.entry());


### PR DESCRIPTION
This PR proposes three changes, each addressing a different source of disconnected graphs.

1. Update the entry node before reconnecting orphaned nodes. If the entry node is updated after, orphaned nodes that were reconnected to the new entry node tend to be disconnected by improvements to the new entry node.
2. Preserve connection targets map across loop iterations. When reset on each iteration of the loop, it's not exceedingly rare to see disconnection cycles where on run 0, node A is reconnected (disconnecting B) and node C is reconnected to node D in its neighbor list. Then, if D is the best neighbor of B, C/B will alternate being reconnected across future iterations.
3. Exclude connectionTargets when searching for new connection points. If all of a node's existing neighbors have been considered and a search is performed, it is not unusual to see that the existing neighbors are many of the search results. This is particularly important if approach 2 is used, as connection targets will grow across loop iterations.

Testing on real data sets looks positive. This approach has also been successful at reconnecting graphs build from random vectors.