### PR TITLE
Set IdentityMapper maxOrdinal correctly in Grid/SiftSmall.

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -241,7 +241,7 @@ public class Grid {
                                                              ProductQuantization pq)
             throws FileNotFoundException
     {
-        var identityMapper = new OrdinalMapper.IdentityMapper(onHeapGraph.getIdUpperBound() - 1);
+        var identityMapper = new OrdinalMapper.IdentityMapper(floatVectors.size() - 1);
         var builder = new OnDiskGraphIndexWriter.Builder(onHeapGraph, outPath).withMapper(identityMapper);
         Map<FeatureId, IntFunction<Feature.State>> suppliers = new EnumMap<>(FeatureId.class);
         for (var featureId : features) {

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -226,7 +226,7 @@ public class SiftSmall {
              // explicit Writer for the first time, this is what's behind OnDiskGraphIndex.write
              OnDiskGraphIndexWriter writer = new OnDiskGraphIndexWriter.Builder(builder.getGraph(), indexPath)
                      .with(new InlineVectors(ravv.dimension()))
-                     .withMapper(new OrdinalMapper.IdentityMapper(builder.getGraph().getIdUpperBound() - 1))
+                     .withMapper(new OrdinalMapper.IdentityMapper(baseVectors.size() - 1))
                      .build();
              // output for the compressed vectors
              DataOutputStream pqOut = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(pqPath))))


### PR DESCRIPTION
At the time of initialization, no nodes are present in the graph, so getting the ID upper bound does not set the IdentityMapper max ordinal correctly. This has no material impact on SiftSmall but broke Bench entirely.