### PR TITLE
Remove max JDK version check

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorizationProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorizationProvider.java
@@ -77,7 +77,7 @@ public abstract class VectorizationProvider {
   // visible for tests
   static VectorizationProvider lookup(boolean testMode) {
     final int runtimeVersion = Runtime.version().feature();
-    if (runtimeVersion >= 20 && runtimeVersion <= 22) {
+    if (runtimeVersion >= 20) {
       // is locale sane (only buggy in Java 20)
       if (isAffectedByJDK8301190()) {
         LOG.warning(
@@ -136,8 +136,6 @@ public abstract class VectorizationProvider {
       } catch (Throwable th) {
         throw new AssertionError(th);
       }
-    } else if (runtimeVersion >= 23) {
-      LOG.warning("You are running with Java 24 or later. To make full use of the Vector API, please update jvector.");
     } else {
       LOG.warning("You are running with Java 19 or earlier, which do not support the required incubating Vector API. Falling back to slower defaults.");
     }

--- a/jvector-examples/pom.xml
+++ b/jvector-examples/pom.xml
@@ -164,7 +164,6 @@
                                     <arguments>
                                         <argument>-classpath</argument>
                                         <classpath/>
-                                        <argument>--enable-preview</argument>
                                         <argument>--enable-native-access=ALL-UNNAMED</argument>
                                         <argument>--add-modules=jdk.incubator.vector</argument>
                                         <argument>-XX:+HeapDumpOnOutOfMemoryError</argument>
@@ -181,7 +180,6 @@
                                     <arguments>
                                         <argument>-classpath</argument>
                                         <classpath/>
-                                        <argument>--enable-preview</argument>
                                         <argument>--enable-native-access=ALL-UNNAMED</argument>
                                         <argument>--add-modules=jdk.incubator.vector</argument>
                                         <argument>-XX:+HeapDumpOnOutOfMemoryError</argument>
@@ -196,7 +194,6 @@
                                     <arguments>
                                         <argument>-classpath</argument>
                                         <classpath/>
-                                        <argument>--enable-preview</argument>
                                         <argument>--enable-native-access=ALL-UNNAMED</argument>
                                         <argument>--add-modules=jdk.incubator.vector</argument>
                                         <argument>-XX:+HeapDumpOnOutOfMemoryError</argument>
@@ -247,7 +244,6 @@
                                     <arguments>
                                         <argument>-classpath</argument>
                                         <classpath/>
-                                        <argument>--enable-preview</argument>
                                         <argument>--enable-native-access=ALL-UNNAMED</argument>
                                         <argument>--add-modules=jdk.incubator.vector</argument>
                                         <argument>-ea</argument>
@@ -262,7 +258,6 @@
                                     <arguments>
                                         <argument>-classpath</argument>
                                         <classpath/>
-                                        <argument>--enable-preview</argument>
                                         <argument>--enable-native-access=ALL-UNNAMED</argument>
                                         <argument>--add-modules=jdk.incubator.vector</argument>
                                         <argument>-XX:+HeapDumpOnOutOfMemoryError</argument>
@@ -280,7 +275,6 @@
                                     <arguments>
                                         <argument>-classpath</argument>
                                         <classpath/>
-                                        <argument>--enable-preview</argument>
                                         <argument>--enable-native-access=ALL-UNNAMED</argument>
                                         <argument>--add-modules=jdk.incubator.vector</argument>
                                         <argument>-ea</argument>
@@ -295,7 +289,6 @@
                                     <arguments>
                                         <argument>-classpath</argument>
                                         <classpath/>
-                                        <argument>--enable-preview</argument>
                                         <argument>--enable-native-access=ALL-UNNAMED</argument>
                                         <argument>--add-modules=jdk.incubator.vector</argument>
                                         <argument>-Djava.util.concurrent.ForkJoinPool.common.parallelism=1</argument>

--- a/jvector-native/pom.xml
+++ b/jvector-native/pom.xml
@@ -22,7 +22,6 @@
                     <compilerArgs>
                         <arg>--add-modules</arg>
                         <arg>jdk.incubator.vector</arg>
-                        <arg>--enable-preview</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/LibraryLoader.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/LibraryLoader.java
@@ -37,7 +37,7 @@ public class LibraryLoader {
             // as a resource and then copy it to a tmp directory and load it from there
             String libName = System.mapLibraryName("jvector");
             File tmpLibFile = File.createTempFile(libName.substring(0, libName.lastIndexOf('.')), libName.substring(libName.lastIndexOf('.')));
-            try (var in = LibraryLoader.class.getResourceAsStream(STR."/\{libName}");
+            try (var in = LibraryLoader.class.getResourceAsStream("/" + libName);
                  var out = Files.newOutputStream(tmpLibFile.toPath())) {
                 if (in != null) {
                     in.transferTo(out);

--- a/jvector-tests/pom.xml
+++ b/jvector-tests/pom.xml
@@ -85,7 +85,6 @@
                                 --add-modules jdk.incubator.vector
                                 --enable-native-access=ALL-UNNAMED
                                 -Djvector.experimental.enable_native_vectorization=true
-                                --enable-preview
                             </argLine>
                             <skip>${skipSIMD}</skip>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
                             <skippedModules>jvector-examples,jvector-tests</skippedModules>
                             <additionalJOptions>
                                 <additionalJOption>--add-modules=jdk.incubator.vector</additionalJOption>
-                                <additionalJOption>--enable-preview</additionalJOption>
                             </additionalJOptions>
                             <release>22</release>
                         </configuration>


### PR DESCRIPTION
Previously, the Panama/Native vectorization providers have a hardcoded max supported runtime version. This was a reasonable precaution when we were using features under heavy modification in Java 20/21/22. Now, these are becoming somewhat more stable, and this may be causing more pain than it's worth.

As of Java 22+, the sole preview feature we were using was the String template in library loader (and string templates have been removed in Java 23). We previously needed this for FFM, but that became stable in Java 22. The vector support is incubating, not preview, so we don't need the enable-preview flag.

We continue to build jvector-native using release version 22, which ensures that JVector built on new versions will still run on Java 22. We don't know when the vector API will leave incubating, but it will likely depend on the release of Valhalla, so we can't set the max version based on that change.