### PR TITLE
Use fma in VectorSimdOps.cosineSimilarity

### DIFF
--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
@@ -242,7 +242,7 @@ final class VectorSimdOps {
         for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
             var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, v1.get(), v1.offset(i), ByteOrder.LITTLE_ENDIAN);
             var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, v2.get(), v2.offset(i), ByteOrder.LITTLE_ENDIAN);
-            vsum = vsum.add(a.mul(b));
+            vsum = a.fma(b, vsum);
             vaMagnitude = a.fma(a, vaMagnitude);
             vbMagnitude = b.fma(b, vbMagnitude);
         }
@@ -269,7 +269,7 @@ final class VectorSimdOps {
         for (int i = 0; i < vectorizedLength; i += FloatVector.SPECIES_PREFERRED.length()) {
             var a = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, v1.get(), v1.offset(v1offset + i), ByteOrder.LITTLE_ENDIAN);
             var b = FloatVector.fromMemorySegment(FloatVector.SPECIES_PREFERRED, v2.get(), v2.offset(v2offset + i), ByteOrder.LITTLE_ENDIAN);
-            vsum = vsum.add(a.mul(b));
+            vsum = a.fma(b, vsum);
             vaMagnitude = a.fma(a, vaMagnitude);
             vbMagnitude = b.fma(b, vbMagnitude);
         }


### PR DESCRIPTION
Same rationale as https://github.com/jbellis/jvector/pull/363, but this is for the NativeVectorizationProvider rather than the PanamaVectorizationProvider.