### PR TITLE
Don't use segment hashCode in MemorySegmentVectorFloat

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayVectorFloat.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayVectorFloat.java
@@ -114,7 +114,7 @@ final public class ArrayVectorFloat implements VectorFloat<float[]>
     @Override
     public int hashCode()
     {
-        return Arrays.hashCode(data);
+        return this.getHashCode();
     }
 }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/VectorFloat.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/VectorFloat.java
@@ -40,4 +40,14 @@ public interface VectorFloat<T> extends Accountable
     void set(int i, float value);
 
     void zero();
+
+    default int getHashCode() {
+        int result = 1;
+        for (int i = 0; i < length(); i++) {
+            if (get(i) != 0) {
+                result = 31 * result + Float.hashCode(get(i));
+            }
+        }
+        return result;
+    }
 }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentVectorFloat.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentVectorFloat.java
@@ -130,6 +130,6 @@ final public class MemorySegmentVectorFloat implements VectorFloat<MemorySegment
 
     @Override
     public int hashCode() {
-        return segment.hashCode();
+        return this.getHashCode();
     }
 }


### PR DESCRIPTION
This hashcode depends on segment base/offset in the heap rather than contents. This breaks testing around PQVectors hashcodes added in #370. Rather than this being a regression uncovered in #370, this is due to increased test assertions added in #370 that only fail when using the native provider. We adopt the same approach used by ByteSequence in #370.