### PR TITLE
Fix regression in assembleAndSum PQ decoder performance

### DIFF
--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/VectorSimdOps.java
@@ -30,8 +30,6 @@ import java.util.List;
  * Support class for vector operations using a mix of native and Panama SIMD.
  */
 final class VectorSimdOps {
-    static final boolean HAS_AVX512 = IntVector.SPECIES_PREFERRED == IntVector.SPECIES_512;
-
     static float sum(MemorySegmentVectorFloat vector) {
         var sum = FloatVector.zero(FloatVector.SPECIES_PREFERRED);
         int vectorizedLength = FloatVector.SPECIES_PREFERRED.loopBound(vector.length());


### PR DESCRIPTION
Following #368, performance of the assembling PQ fragments suffers on 128-bit SIMD platforms from simulating vector operations. I first attempted implementing an 128-bit version, which improved performance relative to post-#368, but it did not restore performance to pre-#368 levels. As a result, I switched back to the scalar implementation on 128-bit platforms.