### PR TITLE
Fix BQVectors#ramBytesUsed and BQVectors#getCompressedSize on empty BQVectors

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/BQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/BQVectors.java
@@ -119,7 +119,7 @@ public abstract class BQVectors implements CompressedVectors {
 
     @Override
     public int getCompressedSize() {
-        return compressedVectors[0].length * Long.BYTES;
+        return bq.compressedVectorSize();
     }
 
     @Override
@@ -129,7 +129,11 @@ public abstract class BQVectors implements CompressedVectors {
 
     @Override
     public long ramBytesUsed() {
-        return count() * RamUsageEstimator.sizeOf(compressedVectors[0]);
+        long[] compressedVector = compressedVectors[0];
+        if (compressedVector == null) {
+            return 0;
+        }
+        return count() * RamUsageEstimator.sizeOf(compressedVector);
     }
 
     @Override


### PR DESCRIPTION
These can throw NPEs if they are called on a MutableBQVectors instance that hasn't yet had vectors added.