### PR TITLE
Fix MutableBQVectors parameterization/encoding

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/BQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/BQVectors.java
@@ -155,7 +155,7 @@ public abstract class BQVectors implements CompressedVectors {
     public String toString() {
         return "BQVectors{" +
                "bq=" + bq +
-               ", count=" + compressedVectors.length +
+               ", count=" + count() +
                '}';
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/MutableBQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/MutableBQVectors.java
@@ -16,8 +16,10 @@
 
 package io.github.jbellis.jvector.quantization;
 
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+
 @SuppressWarnings("unused")
-public class MutableBQVectors extends BQVectors implements MutableCompressedVectors<long[]> {
+public class MutableBQVectors extends BQVectors implements MutableCompressedVectors<VectorFloat<?>> {
     private static final int INITIAL_CAPACITY = 1024;
     private static final float GROWTH_FACTOR = 1.5f;
     
@@ -44,9 +46,9 @@ public class MutableBQVectors extends BQVectors implements MutableCompressedVect
     }
 
     @Override
-    public void encodeAndSet(int ordinal, long[] vector) {
+    public void encodeAndSet(int ordinal, VectorFloat<?> vector) {
         ensureCapacity(ordinal);
-        compressedVectors[ordinal] = vector;
+        compressedVectors[ordinal] = bq.encode(vector);
         vectorCount = Math.max(vectorCount, ordinal + 1);
     }
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestBinaryQuantization.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestBinaryQuantization.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.quantization;
+
+import org.junit.Test;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import io.github.jbellis.jvector.TestUtil;
+import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+
+import static io.github.jbellis.jvector.TestUtil.createRandomVectors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class TestBinaryQuantization extends RandomizedTest
+{
+    @Test
+    public void testMutableImmutableBQEquality()
+    {
+        var vectors = createRandomVectors(512, 64);
+        var ravv = new ListRandomAccessVectorValues(vectors, 64);
+        var bq = new BinaryQuantization(ravv.dimension());
+        var immutableCompressedVectors = bq.encodeAll(ravv);
+        var mutableCompressedVectors = new MutableBQVectors(bq);
+        for (int i = 0; i < ravv.size(); i++)
+        {
+            mutableCompressedVectors.encodeAndSet(i, ravv.getVector(i));
+        }
+        assertEquals(mutableCompressedVectors.count(), immutableCompressedVectors.count());
+        var randomVector = TestUtil.randomVector(getRandom(), 64);
+        for (VectorSimilarityFunction vsf : VectorSimilarityFunction.values())
+        {
+            var immutableScoreFunction = immutableCompressedVectors.scoreFunctionFor(randomVector, vsf);
+            var mutableScoreFunction = mutableCompressedVectors.scoreFunctionFor(randomVector, vsf);
+            for (int i = 0; i < ravv.size(); i++)
+            {
+                assertEquals(immutableScoreFunction.similarityTo(i), mutableScoreFunction.similarityTo(i));
+            }
+        }
+    }
+}


### PR DESCRIPTION
MutableBQVectors implements encodeAndSet as if it's taking an already encoded vector. This PR fixes the type parameter to take an unencoded vector and encode it. A basic test is added to compare mutable/immutable BQ vectors construction.