### PR TITLE
Remove query-time usage of ByteSequence::slice in PQVectors to reduce object allocations

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/PQDecoder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/PQDecoder.java
@@ -53,8 +53,8 @@ abstract class PQDecoder implements ScoreFunction.ApproximateScoreFunction {
             }
         }
 
-        protected float decodedSimilarity(ByteSequence<?> encoded) {
-            return VectorUtil.assembleAndSum(partialSums, cv.pq.getClusterCount(), encoded);
+        protected float decodedSimilarity(ByteSequence<?> encoded, int offset, int length) {
+            return VectorUtil.assembleAndSum(partialSums, cv.pq.getClusterCount(), encoded, offset, length);
         }
     }
 
@@ -65,7 +65,7 @@ abstract class PQDecoder implements ScoreFunction.ApproximateScoreFunction {
 
         @Override
         public float similarityTo(int node2) {
-            return (1 + decodedSimilarity(cv.get(node2))) / 2;
+            return (1 + decodedSimilarity(cv.getChunk(node2), cv.getOffsetInChunk(node2), cv.pq.getSubspaceCount())) / 2;
         }
     }
 
@@ -76,7 +76,7 @@ abstract class PQDecoder implements ScoreFunction.ApproximateScoreFunction {
 
         @Override
         public float similarityTo(int node2) {
-            return 1 / (1 + decodedSimilarity(cv.get(node2)));
+            return 1 / (1 + decodedSimilarity(cv.getChunk(node2), cv.getOffsetInChunk(node2), cv.pq.getSubspaceCount()));
         }
     }
 
@@ -132,9 +132,10 @@ abstract class PQDecoder implements ScoreFunction.ApproximateScoreFunction {
 
         protected float decodedCosine(int node2) {
 
-            ByteSequence<?> encoded = cv.get(node2);
+            ByteSequence<?> encoded = cv.getChunk(node2);
+            int offset = cv.getOffsetInChunk(node2);
 
-            return VectorUtil.pqDecodedCosineSimilarity(encoded, cv.pq.getClusterCount(), partialSums, aMagnitude, bMagnitude);
+            return VectorUtil.pqDecodedCosineSimilarity(encoded, offset, cv.pq.getSubspaceCount(), cv.pq.getClusterCount(), partialSums, aMagnitude, bMagnitude);
         }
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
@@ -296,9 +296,14 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
 
   @Override
   public float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> baseOffsets) {
+    return assembleAndSum(data, dataBase, baseOffsets, 0, baseOffsets.length());
+  }
+
+  @Override
+  public float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength) {
     float sum = 0f;
-    for (int i = 0; i < baseOffsets.length(); i++) {
-      sum += data.get(dataBase * i + Byte.toUnsignedInt(baseOffsets.get(i)));
+    for (int i = 0; i < baseOffsetsLength; i++) {
+      sum += data.get(dataBase * i + Byte.toUnsignedInt(baseOffsets.get(i + baseOffsetsOffset)));
     }
     return sum;
   }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -166,6 +166,10 @@ public final class VectorUtil {
     return impl.assembleAndSum(data, dataBase, dataOffsets);
   }
 
+  public static float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> dataOffsets, int dataOffsetsOffset, int dataOffsetsLength) {
+    return impl.assembleAndSum(data, dataBase, dataOffsets, dataOffsetsOffset, dataOffsetsLength);
+  }
+
   public static void bulkShuffleQuantizedSimilarity(ByteSequence<?> shuffles, int codebookCount, ByteSequence<?> quantizedPartials, float delta, float minDistance, VectorFloat<?> results, VectorSimilarityFunction vsf) {
     impl.bulkShuffleQuantizedSimilarity(shuffles, codebookCount, quantizedPartials, delta, minDistance, vsf, results);
   }
@@ -213,6 +217,10 @@ public final class VectorUtil {
 
   public static float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude) {
     return impl.pqDecodedCosineSimilarity(encoded, clusterCount, partialSums, aMagnitude, bMagnitude);
+  }
+
+  public static float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int encodedOffset, int encodedLength, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude) {
+    return impl.pqDecodedCosineSimilarity(encoded, encodedOffset, encodedLength, clusterCount, partialSums, aMagnitude, bMagnitude);
   }
 
   public static float nvqDotProduct8bit(VectorFloat<?> vector, ByteSequence<?> bytes, float growthRate, float midpoint, float minValue, float maxValue) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
@@ -100,6 +100,19 @@ public interface VectorUtilSupport {
    */
   float assembleAndSum(VectorFloat<?> data, int baseIndex, ByteSequence<?> baseOffsets);
 
+  /**
+   * Calculates the sum of sparse points in a vector.
+   *
+   * @param data the vector of all datapoints
+   * @param baseIndex the start of the data in the offset table
+   *                  (scaled by the index of the lookup table)
+   * @param baseOffsets bytes that represent offsets from the baseIndex
+   * @param baseOffsetsOffset the offset into the baseOffsets ByteSequence
+   * @param baseOffsetsLength the length of the baseOffsets ByteSequence to use
+   * @return the sum of the points
+   */
+  float assembleAndSum(VectorFloat<?> data, int baseIndex, ByteSequence<?> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength);
+
   int hammingDistance(long[] v1, long[] v2);
 
 
@@ -213,11 +226,16 @@ public interface VectorUtilSupport {
 
   default float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude)
   {
+    return pqDecodedCosineSimilarity(encoded, 0, encoded.length(), clusterCount, partialSums, aMagnitude, bMagnitude);
+  }
+
+  default float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int encodedOffset, int encodedLength, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude)
+  {
     float sum = 0.0f;
     float aMag = 0.0f;
 
-    for (int m = 0; m < encoded.length(); ++m) {
-      int centroidIndex = Byte.toUnsignedInt(encoded.get(m));
+    for (int m = 0; m < encodedLength; ++m) {
+      int centroidIndex = Byte.toUnsignedInt(encoded.get(m + encodedOffset));
       var index = m * clusterCount + centroidIndex;
       sum += partialSums.get(index);
       aMag += aMagnitude.get(index);

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
@@ -122,6 +122,14 @@ final class NativeVectorUtilSupport implements VectorUtilSupport
     }
 
     @Override
+    public float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength)
+    {
+        assert baseOffsetsOffset == 0;
+        assert baseOffsetsLength == baseOffsets.length();
+        return assembleAndSum(data, dataBase, baseOffsets);
+    }
+
+    @Override
     public int hammingDistance(long[] v1, long[] v2) {
         return VectorSimdOps.hammingDistance(v1, v2);
     }

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -112,7 +112,13 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     @Override
     public float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> baseOffsets) {
-        return SimdOps.assembleAndSum(((ArrayVectorFloat) data).get(), dataBase, ((ByteSequence<byte[]>) baseOffsets));
+        return SimdOps.assembleAndSum(((ArrayVectorFloat) data).get(), dataBase, ((ByteSequence<byte[]>) baseOffsets),
+                0, baseOffsets.length());
+    }
+
+    @Override
+    public float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength) {
+        return SimdOps.assembleAndSum(((ArrayVectorFloat) data).get(), dataBase, ((ByteSequence<byte[]>) baseOffsets), baseOffsetsOffset, baseOffsetsLength);
     }
 
     @Override
@@ -177,9 +183,14 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
 
     @Override
-    public float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude)
+    public float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude) {
+        return pqDecodedCosineSimilarity(encoded, 0, encoded.length(),  clusterCount, partialSums, aMagnitude, bMagnitude);
+    }
+
+    @Override
+    public float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int encodedOffset, int encodedLength, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude)
     {
-        return SimdOps.pqDecodedCosineSimilarity((ByteSequence<byte[]>) encoded, clusterCount, (ArrayVectorFloat) partialSums, (ArrayVectorFloat) aMagnitude, bMagnitude);
+        return SimdOps.pqDecodedCosineSimilarity((ByteSequence<byte[]>) encoded, encodedOffset, encodedLength, clusterCount, (ArrayVectorFloat) partialSums, (ArrayVectorFloat) aMagnitude, bMagnitude);
     }
 
     @Override

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/SimdOps.java
@@ -632,25 +632,25 @@ final class SimdOps {
         }
     }
 
-    static float assembleAndSum(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets) {
+    static float assembleAndSum(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength) {
         return switch (PREFERRED_BIT_SIZE)
         {
-            case 512 -> assembleAndSum512(data, dataBase, baseOffsets);
-            case 256 -> assembleAndSum256(data, dataBase, baseOffsets);
-            case 128 -> assembleAndSum128(data, dataBase, baseOffsets);
+            case 512 -> assembleAndSum512(data, dataBase, baseOffsets, baseOffsetsOffset, baseOffsetsLength);
+            case 256 -> assembleAndSum256(data, dataBase, baseOffsets, baseOffsetsOffset, baseOffsetsLength);
+            case 128 -> assembleAndSum128(data, dataBase, baseOffsets, baseOffsetsOffset, baseOffsetsLength);
             default -> throw new IllegalStateException("Unsupported vector width: " + PREFERRED_BIT_SIZE);
         };
     }
 
-    static float assembleAndSum512(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets) {
+    static float assembleAndSum512(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength) {
         int[] convOffsets = scratchInt512.get();
         FloatVector sum = FloatVector.zero(FloatVector.SPECIES_512);
         int i = 0;
-        int limit = ByteVector.SPECIES_128.loopBound(baseOffsets.length());
+        int limit = ByteVector.SPECIES_128.loopBound(baseOffsetsLength);
         var scale = IntVector.zero(IntVector.SPECIES_512).addIndex(dataBase);
 
         for (; i < limit; i += ByteVector.SPECIES_128.length()) {
-            ByteVector.fromArray(ByteVector.SPECIES_128, baseOffsets.get(), i + baseOffsets.offset())
+            ByteVector.fromArray(ByteVector.SPECIES_128, baseOffsets.get(), i + baseOffsets.offset() + baseOffsetsOffset)
                     .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
                     .lanewise(VectorOperators.AND, BYTE_TO_INT_MASK_512)
                     .reinterpretAsInts()
@@ -664,22 +664,22 @@ final class SimdOps {
         float res = sum.reduceLanes(VectorOperators.ADD);
 
         //Process tail
-        for (; i < baseOffsets.length(); i++)
-            res += data[dataBase * i + Byte.toUnsignedInt(baseOffsets.get(i))];
+        for (; i < baseOffsetsLength; i++)
+            res += data[dataBase * i + Byte.toUnsignedInt(baseOffsets.get(i + baseOffsetsOffset))];
 
         return res;
     }
 
-    static float assembleAndSum256(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets) {
+    static float assembleAndSum256(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength) {
         int[] convOffsets = scratchInt256.get();
         FloatVector sum = FloatVector.zero(FloatVector.SPECIES_256);
         int i = 0;
-        int limit = ByteVector.SPECIES_64.loopBound(baseOffsets.length());
+        int limit = ByteVector.SPECIES_64.loopBound(baseOffsetsLength);
         var scale = IntVector.zero(IntVector.SPECIES_256).addIndex(dataBase);
 
         for (; i < limit; i += ByteVector.SPECIES_64.length()) {
 
-            ByteVector.fromArray(ByteVector.SPECIES_64, baseOffsets.get(), i + baseOffsets.offset())
+            ByteVector.fromArray(ByteVector.SPECIES_64, baseOffsets.get(), i + baseOffsets.offset() + baseOffsetsOffset)
                     .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
                     .lanewise(VectorOperators.AND, BYTE_TO_INT_MASK_256)
                     .reinterpretAsInts()
@@ -693,17 +693,17 @@ final class SimdOps {
         float res = sum.reduceLanes(VectorOperators.ADD);
 
         // Process tail
-        for (; i < baseOffsets.length(); i++)
-            res += data[dataBase * i + Byte.toUnsignedInt(baseOffsets.get(i))];
+        for (; i < baseOffsetsLength; i++)
+            res += data[dataBase * i + Byte.toUnsignedInt(baseOffsets.get(i + baseOffsetsOffset))];
 
         return res;
     }
 
-    static float assembleAndSum128(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets) {
+    static float assembleAndSum128(float[] data, int dataBase, ByteSequence<byte[]> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength) {
         // benchmarking a 128-bit SIMD implementation showed it performed worse than scalar
         float sum = 0f;
-        for (int i = 0; i < baseOffsets.length(); i++) {
-            sum += data[dataBase * i + Byte.toUnsignedInt(baseOffsets.get(i))];
+        for (int i = 0; i < baseOffsetsLength; i++) {
+            sum += data[dataBase * i + Byte.toUnsignedInt(baseOffsets.get(i + baseOffsetsOffset))];
         }
         return sum;
     }
@@ -791,16 +791,16 @@ final class SimdOps {
         }
     }
 
-    public static float pqDecodedCosineSimilarity(ByteSequence<byte[]> encoded, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
+    public static float pqDecodedCosineSimilarity(ByteSequence<byte[]> encoded, int encodedOffset, int encodedLength, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
         return switch (PREFERRED_BIT_SIZE) {
-            case 512 -> pqDecodedCosineSimilarity512(encoded, clusterCount, partialSums, aMagnitude, bMagnitude);
-            case 256 -> pqDecodedCosineSimilarity256(encoded, clusterCount, partialSums, aMagnitude, bMagnitude);
-            case 128 -> pqDecodedCosineSimilarity128(encoded, clusterCount, partialSums, aMagnitude, bMagnitude);
+            case 512 -> pqDecodedCosineSimilarity512(encoded, encodedOffset, encodedLength, clusterCount, partialSums, aMagnitude, bMagnitude);
+            case 256 -> pqDecodedCosineSimilarity256(encoded, encodedOffset, encodedLength, clusterCount, partialSums, aMagnitude, bMagnitude);
+            case 128 -> pqDecodedCosineSimilarity128(encoded, encodedOffset, encodedLength, clusterCount, partialSums, aMagnitude, bMagnitude);
             default -> throw new IllegalStateException("Unsupported vector width: " + PREFERRED_BIT_SIZE);
         };
     }
 
-    public static float pqDecodedCosineSimilarity512(ByteSequence<byte[]> baseOffsets, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
+    public static float pqDecodedCosineSimilarity512(ByteSequence<byte[]> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
         var sum = FloatVector.zero(FloatVector.SPECIES_512);
         var vaMagnitude = FloatVector.zero(FloatVector.SPECIES_512);
         var partialSumsArray = partialSums.get();
@@ -808,13 +808,13 @@ final class SimdOps {
 
         int[] convOffsets = scratchInt512.get();
         int i = 0;
-        int limit = i + ByteVector.SPECIES_128.loopBound(baseOffsets.length());
+        int limit = i + ByteVector.SPECIES_128.loopBound(baseOffsetsLength);
 
         var scale = IntVector.zero(IntVector.SPECIES_512).addIndex(clusterCount);
 
         for (; i < limit; i += ByteVector.SPECIES_128.length()) {
 
-            ByteVector.fromArray(ByteVector.SPECIES_128, baseOffsets.get(), i + baseOffsets.offset())
+            ByteVector.fromArray(ByteVector.SPECIES_128, baseOffsets.get(), i + baseOffsets.offset() + baseOffsetsOffset)
                     .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
                     .lanewise(VectorOperators.AND, BYTE_TO_INT_MASK_512)
                     .reinterpretAsInts()
@@ -829,8 +829,8 @@ final class SimdOps {
         float sumResult = sum.reduceLanes(VectorOperators.ADD);
         float aMagnitudeResult = vaMagnitude.reduceLanes(VectorOperators.ADD);
 
-        for (; i < baseOffsets.length(); i++) {
-            int offset = clusterCount * i + Byte.toUnsignedInt(baseOffsets.get(i));
+        for (; i < baseOffsetsLength; i++) {
+            int offset = clusterCount * i + Byte.toUnsignedInt(baseOffsets.get(i + baseOffsetsOffset));
             sumResult += partialSumsArray[offset];
             aMagnitudeResult += aMagnitudeArray[offset];
         }
@@ -838,7 +838,7 @@ final class SimdOps {
         return (float) (sumResult / Math.sqrt(aMagnitudeResult * bMagnitude));
     }
 
-    public static float pqDecodedCosineSimilarity256(ByteSequence<byte[]> baseOffsets, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
+    public static float pqDecodedCosineSimilarity256(ByteSequence<byte[]> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
         var sum = FloatVector.zero(FloatVector.SPECIES_256);
         var vaMagnitude = FloatVector.zero(FloatVector.SPECIES_256);
         var partialSumsArray = partialSums.get();
@@ -846,13 +846,13 @@ final class SimdOps {
 
         int[] convOffsets = scratchInt256.get();
         int i = 0;
-        int limit = ByteVector.SPECIES_64.loopBound(baseOffsets.length());
+        int limit = ByteVector.SPECIES_64.loopBound(baseOffsetsLength);
 
         var scale = IntVector.zero(IntVector.SPECIES_256).addIndex(clusterCount);
 
         for (; i < limit; i += ByteVector.SPECIES_64.length()) {
 
-            ByteVector.fromArray(ByteVector.SPECIES_64, baseOffsets.get(), i + baseOffsets.offset())
+            ByteVector.fromArray(ByteVector.SPECIES_64, baseOffsets.get(), i + baseOffsets.offset() + baseOffsetsOffset)
                     .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
                     .lanewise(VectorOperators.AND, BYTE_TO_INT_MASK_256)
                     .reinterpretAsInts()
@@ -867,8 +867,8 @@ final class SimdOps {
         float sumResult = sum.reduceLanes(VectorOperators.ADD);
         float aMagnitudeResult = vaMagnitude.reduceLanes(VectorOperators.ADD);
 
-        for (; i < baseOffsets.length(); i++) {
-            int offset = clusterCount * i + Byte.toUnsignedInt(baseOffsets.get(i));
+        for (; i < baseOffsetsLength; i++) {
+            int offset = clusterCount * i + Byte.toUnsignedInt(baseOffsets.get(i + baseOffsetsOffset));
             sumResult += partialSumsArray[offset];
             aMagnitudeResult += aMagnitudeArray[offset];
         }
@@ -876,13 +876,13 @@ final class SimdOps {
         return (float) (sumResult / Math.sqrt(aMagnitudeResult * bMagnitude));
     }
 
-    public static float pqDecodedCosineSimilarity128(ByteSequence<byte[]> baseOffsets, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
+    public static float pqDecodedCosineSimilarity128(ByteSequence<byte[]> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength, int clusterCount, ArrayVectorFloat partialSums, ArrayVectorFloat aMagnitude, float bMagnitude) {
         // benchmarking showed that a 128-bit SIMD implementation performed worse than scalar
         float sum = 0.0f;
         float aMag = 0.0f;
 
-        for (int m = 0; m < baseOffsets.length(); ++m) {
-            int centroidIndex = Byte.toUnsignedInt(baseOffsets.get(m));
+        for (int m = 0; m < baseOffsetsLength; ++m) {
+            int centroidIndex = Byte.toUnsignedInt(baseOffsets.get(m + baseOffsetsOffset));
             var index = m * clusterCount + centroidIndex;
             sum += partialSums.get(index);
             aMag += aMagnitude.get(index);


### PR DESCRIPTION
With https://github.com/datastax/jvector/pull/370, I introduced the `ByteSequence::slice` method and started using it on the query path. The PR replaces long lived pq vector ByteSequences with short lived slices of larger ByteSequences created at query time. However, profiling reveals that these objects get created very often for certain workloads, especially brute force workloads in Cassandra. After analyzing the code, it looks trivial to migrate to a solution where we do not create a slice object per access to a pq vector. The main downside is the addition of an `offset` and a `length` argument to many methods and the fact that these changes feel brittle, if we want to maintain the `slice()` construct, which I think we do for the simplicity of non-query path code. However, given the performance implications and the fact that the interface changes are all internal to jvector, I think this change is worth considering.