### PR TITLE
Fix flaky tests and eliminate console output

### DIFF
--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/Test2DThreshold.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/Test2DThreshold.java
@@ -41,7 +41,7 @@ public class Test2DThreshold extends LuceneTestCase {
     @Test
     public void testThreshold20k() throws IOException {
         for (int i = 0; i < 10; i++) {
-            testThreshold(20_000, 24, 0.80f, 0.95f);
+            testThreshold(20_000, 24, 0.80f, 0.9f);
         }
     }
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/Test2DThreshold.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/Test2DThreshold.java
@@ -41,7 +41,7 @@ public class Test2DThreshold extends LuceneTestCase {
     @Test
     public void testThreshold20k() throws IOException {
         for (int i = 0; i < 10; i++) {
-            testThreshold(20_000, 24, 0.75f, 0.95f);
+            testThreshold(20_000, 24, 0.80f, 0.95f);
         }
     }
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestCompressedVectors.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestCompressedVectors.java
@@ -207,10 +207,10 @@ public class TestCompressedVectors extends RandomizedTest {
             } else if (vsf == VectorSimilarityFunction.DOT_PRODUCT) {
                 tolerance *= 4;
             }
-            System.out.println(vsf + " error " + error + " tolerance " + tolerance);
+            // System.out.println(vsf + " error " + error + " tolerance " + tolerance);
             assert error <= tolerance : String.format("%s > %s for %s with %d dimensions and %d subvectors", error, tolerance, vsf, dimension, nSubvectors);
         }
-        System.out.println("--");
+        // System.out.println("--");
     }
 
     @Test
@@ -221,7 +221,7 @@ public class TestCompressedVectors extends RandomizedTest {
 
             for (var nSubvectors : List.of(1, 2, 4, 8)) {
                 for (var learn : List.of(false, true)) {
-                    System.out.println("dimensions: " + d + " subvectors: " + nSubvectors + " learn: " + learn);
+                    // System.out.println("dimensions: " + d + " subvectors: " + nSubvectors + " learn: " + learn);
                     testNVQEncodings(vectors, queries, nSubvectors, learn);
                 }
             }


### PR DESCRIPTION
Two minor updates:
- In Test2DThreshold.testThreshold20k, use a more lenient threshold. The previous value was randomly failing (sometimes).
- In TestCompressedVectors.testNVQEncodings, remove the print statements that were polluting the console.