### PR TITLE
Search pruning & fix the reported number of visited nodes

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
@@ -77,7 +77,7 @@ public class GraphSearcher implements Closeable {
         this.approximateResults = new NodeQueue(new BoundedLongHeap(100), NodeQueue.Order.MIN_HEAP);
         this.rerankedResults = new NodeQueue(new BoundedLongHeap(100), NodeQueue.Order.MIN_HEAP);
         this.visited = new IntHashSet();
-        this.pruneSearch = false;
+        this.pruneSearch = true;
     }
 
     private void initializeScoreProvider(SearchScoreProvider scoreProvider) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
@@ -117,6 +117,19 @@ public class GraphSearcher implements Closeable {
     }
 
     /**
+     * Convenience function for simple one-off searches.  It is caller's responsibility to make sure that it
+     * is the unique owner of the vectors instance passed in here.
+     */
+    public static SearchResult search(VectorFloat<?> queryVector, int topK, int rerankK, RandomAccessVectorValues vectors, VectorSimilarityFunction similarityFunction, GraphIndex graph, Bits acceptOrds) {
+        try (var searcher = new GraphSearcher(graph)) {
+            var ssp = SearchScoreProvider.exact(queryVector, similarityFunction, vectors);
+            return searcher.search(ssp, topK, rerankK, 0.f, 0.f, acceptOrds);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
      * Sets the view of the graph to be used by the searcher.
      * <p>
      * This method should be used when the searcher operates over a view whose contents might not reflect all changes

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
@@ -47,7 +47,7 @@ public class Bench {
         var overqueryGrid = List.of(1.0, 2.0, 5.0); // rerankK = oq * topK
         var neighborOverflowGrid = List.of(1.2f); // List.of(1.2f, 2.0f);
         var addHierarchyGrid = List.of(true); // List.of(false, true);
-        var usePruningGrid = List.of(false); // List.of(false, true);
+        var usePruningGrid = List.of(true); // List.of(false, true);
         List<Function<DataSet, CompressorParameters>> buildCompression = Arrays.asList(
                 ds -> new PQParameters(ds.getDimension() / 8, 256, ds.similarityFunction == VectorSimilarityFunction.EUCLIDEAN, UNWEIGHTED),
                 __ -> CompressorParameters.NONE

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -366,13 +366,14 @@ public class Grid {
         int queryRuns = 2;
         System.out.format("Using %s:%n", cs.index);
         for (var overquery : efSearchOptions) {
-            var start = System.nanoTime();
             int rerankK = (int) (topK * overquery);
             for (var usePruning : usePruningGrid) {
+                var startTime = System.nanoTime();
                 var pqr = performQueries(cs, topK, rerankK, usePruning, queryRuns);
+                var stopTime = System.nanoTime();
                 var recall = ((double) pqr.topKFound) / (queryRuns * cs.ds.queryVectors.size() * topK);
                 System.out.format(" Query top %d/%d recall %.4f in %.2fms after %.2f nodes visited (AVG) with pruning=%b%n",
-                        topK, rerankK, recall, (System.nanoTime() - start) / 1_000_000.0,
+                        topK, rerankK, recall, (stopTime - startTime) / (queryRuns * 1_000_000.0),
                         (double) pqr.nodesVisited / (queryRuns * cs.ds.queryVectors.size()), usePruning);
             }
         }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -363,15 +363,17 @@ public class Grid {
 
     private static void testConfiguration(ConfiguredSystem cs, List<Double> efSearchOptions, List<Boolean> usePruningGrid) {
         var topK = cs.ds.groundTruth.get(0).size();
+        int queryRuns = 2;
         System.out.format("Using %s:%n", cs.index);
         for (var overquery : efSearchOptions) {
             var start = System.nanoTime();
             int rerankK = (int) (topK * overquery);
             for (var usePruning : usePruningGrid) {
-                var pqr = performQueries(cs, topK, rerankK, usePruning, 2);
-                var recall = ((double) pqr.topKFound) / (2 * cs.ds.queryVectors.size() * topK);
-                System.out.format(" Query top %d/%d recall %.4f in %.2fms after %,d nodes visited with pruning=%b%n",
-                        topK, rerankK, recall, (System.nanoTime() - start) / 1_000_000.0, pqr.nodesVisited, usePruning);
+                var pqr = performQueries(cs, topK, rerankK, usePruning, queryRuns);
+                var recall = ((double) pqr.topKFound) / (queryRuns * cs.ds.queryVectors.size() * topK);
+                System.out.format(" Query top %d/%d recall %.4f in %.2fms after %.2f nodes visited (AVG) with pruning=%b%n",
+                        topK, rerankK, recall, (System.nanoTime() - start) / 1_000_000.0,
+                        (double) pqr.nodesVisited / (queryRuns * cs.ds.queryVectors.size()), usePruning);
             }
         }
     }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
@@ -111,6 +111,7 @@ public class TestVectorGraph extends LuceneTestCase {
                 GraphSearcher.search(
                         getTargetVector(),
                         10,
+                        20,
                         vectors.copy(),
                         similarityFunction,
                         graph,


### PR DESCRIPTION
There were two bugs in the measurements in Bench:
1. The start time for measuring runtime was wrongly placed, so we were getting the wrong measurement for the second value in usePruningGrid. This bug caused to identify the use of search pruning (early termination) as a pessimization with the new hierarchical index, but the contrary is true. **We should enable search pruning by default**
2. The time was also the aggregate of both runs.
3. The reported node count was the aggregate of both runs through the queries. We are now correcting that.

This PR also changes returning the aggregate count of all queries to the average, which is more informative.