### PR TITLE
Rework the computation of accuracy

### DIFF
--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithStaticSetBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithStaticSetBenchmark.java
@@ -28,8 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Set;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -42,9 +41,9 @@ import java.util.concurrent.TimeUnit;
 public class IndexConstructionWithStaticSetBenchmark {
     private static final Logger log = LoggerFactory.getLogger(IndexConstructionWithStaticSetBenchmark.class);
     private RandomAccessVectorValues ravv;
-    private ArrayList<VectorFloat<?>> baseVectors;
-    private ArrayList<VectorFloat<?>> queryVectors;
-    private ArrayList<Set<Integer>> groundTruth;
+    private List<VectorFloat<?>> baseVectors;
+    private List<VectorFloat<?>> queryVectors;
+    private List<List<Integer>> groundTruth;
     private BuildScoreProvider bsp;
     @Param({"16", "32", "64"})
     private int M; // graph degree

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/PQBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/PQBenchmark.java
@@ -29,8 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Set;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -43,9 +42,9 @@ import java.util.concurrent.TimeUnit;
 public class PQBenchmark {
     private static final Logger log = LoggerFactory.getLogger(PQBenchmark.class);
     private RandomAccessVectorValues ravv;
-    private ArrayList<VectorFloat<?>> baseVectors;
-    private ArrayList<VectorFloat<?>> queryVectors;
-    private ArrayList<Set<Integer>> groundTruth;
+    private List<VectorFloat<?>> baseVectors;
+    private List<VectorFloat<?>> queryVectors;
+    private List<List<Integer>> groundTruth;
     @Param({"16", "32", "64"})
     private int M; // Number of subspaces
     int originalDimension;

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/StaticSetVectorsBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/StaticSetVectorsBenchmark.java
@@ -28,8 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Set;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -42,9 +41,9 @@ import java.util.concurrent.TimeUnit;
 public class StaticSetVectorsBenchmark {
     private static final Logger log = LoggerFactory.getLogger(StaticSetVectorsBenchmark.class);
     private RandomAccessVectorValues ravv;
-    private ArrayList<VectorFloat<?>> baseVectors;
-    private ArrayList<VectorFloat<?>> queryVectors;
-    private ArrayList<Set<Integer>> groundTruth;
+    private List<VectorFloat<?>> baseVectors;
+    private List<VectorFloat<?>> queryVectors;
+    private List<List<Integer>> groundTruth;
     private GraphIndexBuilder graphIndexBuilder;
     private GraphIndex graphIndex;
     int originalDimension;

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Bench.java
@@ -44,6 +44,7 @@ public class Bench {
 
         var mGrid = List.of(32); // List.of(16, 24, 32, 48, 64, 96, 128);
         var efConstructionGrid = List.of(100); // List.of(60, 80, 100, 120, 160, 200, 400, 600, 800);
+        var topKGrid = List.of(10, 100);
         var overqueryGrid = List.of(1.0, 2.0, 5.0); // rerankK = oq * topK
         var neighborOverflowGrid = List.of(1.2f); // List.of(1.2f, 2.0f);
         var addHierarchyGrid = List.of(true); // List.of(false, true);
@@ -77,7 +78,7 @@ public class Bench {
                 "nv-qa-v4-100k",
                 "colbert-1M",
                 "gecko-100k");
-        executeNw(coreFiles, pattern, buildCompression, featureSets, searchCompression, mGrid, efConstructionGrid, neighborOverflowGrid, addHierarchyGrid, overqueryGrid, usePruningGrid);
+        executeNw(coreFiles, pattern, buildCompression, featureSets, searchCompression, mGrid, efConstructionGrid, neighborOverflowGrid, addHierarchyGrid, topKGrid, overqueryGrid, usePruningGrid);
 
         var extraFiles = List.of(
                 "openai-v3-large-3072-100k",
@@ -85,7 +86,7 @@ public class Bench {
                 "e5-small-v2-100k",
                 "e5-base-v2-100k",
                 "e5-large-v2-100k");
-        executeNw(extraFiles, pattern, buildCompression, featureSets, searchCompression, mGrid, efConstructionGrid, neighborOverflowGrid, addHierarchyGrid, overqueryGrid, usePruningGrid);
+        executeNw(extraFiles, pattern, buildCompression, featureSets, searchCompression, mGrid, efConstructionGrid, neighborOverflowGrid, addHierarchyGrid, topKGrid, overqueryGrid, usePruningGrid);
 
         // smaller vectors from ann-benchmarks
         var hdf5Files = List.of(
@@ -102,7 +103,7 @@ public class Bench {
         for (var f : hdf5Files) {
             if (pattern.matcher(f).find()) {
                 DownloadHelper.maybeDownloadHdf5(f);
-                Grid.runAll(Hdf5Loader.load(f), mGrid, efConstructionGrid, neighborOverflowGrid, addHierarchyGrid, featureSets, buildCompression, searchCompression, overqueryGrid, usePruningGrid);
+                Grid.runAll(Hdf5Loader.load(f), mGrid, efConstructionGrid, neighborOverflowGrid, addHierarchyGrid, featureSets, buildCompression, searchCompression, topKGrid, overqueryGrid, usePruningGrid);
             }
         }
 
@@ -112,15 +113,15 @@ public class Bench {
                                               ds -> new PQParameters(ds.getDimension(), 256, true, UNWEIGHTED));
             buildCompression = Arrays.asList(__ -> CompressorParameters.NONE);
             var grid2d = DataSetCreator.create2DGrid(4_000_000, 10_000, 100);
-            Grid.runAll(grid2d, mGrid, efConstructionGrid, neighborOverflowGrid, addHierarchyGrid, featureSets, buildCompression, searchCompression, overqueryGrid, usePruningGrid);
+            Grid.runAll(grid2d, mGrid, efConstructionGrid, neighborOverflowGrid, addHierarchyGrid, featureSets, buildCompression, searchCompression, topKGrid, overqueryGrid, usePruningGrid);
         }
     }
 
-    private static void executeNw(List<String> coreFiles, Pattern pattern, List<Function<DataSet, CompressorParameters>> buildCompression, List<EnumSet<FeatureId>> featureSets, List<Function<DataSet, CompressorParameters>> compressionGrid, List<Integer> mGrid, List<Integer> efConstructionGrid, List<Float> neighborOverflowGrid, List<Boolean> addHierarchyGrid, List<Double> efSearchGrid, List<Boolean> usePruningGrid) throws IOException {
+    private static void executeNw(List<String> coreFiles, Pattern pattern, List<Function<DataSet, CompressorParameters>> buildCompression, List<EnumSet<FeatureId>> featureSets, List<Function<DataSet, CompressorParameters>> compressionGrid, List<Integer> mGrid, List<Integer> efConstructionGrid, List<Float> neighborOverflowGrid, List<Boolean> addHierarchyGrid, List<Integer> topKGrid, List<Double> efSearchGrid, List<Boolean> usePruningGrid) throws IOException {
         for (var nwDatasetName : coreFiles) {
             if (pattern.matcher(nwDatasetName).find()) {
                 var mfd = DownloadHelper.maybeDownloadFvecs(nwDatasetName);
-                Grid.runAll(mfd.load(), mGrid, efConstructionGrid, neighborOverflowGrid, addHierarchyGrid, featureSets, buildCompression, compressionGrid, efSearchGrid, usePruningGrid);
+                Grid.runAll(mfd.load(), mGrid, efConstructionGrid, neighborOverflowGrid, addHierarchyGrid, featureSets, buildCompression, compressionGrid, topKGrid, efSearchGrid, usePruningGrid);
             }
         }
     }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/AccuracyMetrics.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/AccuracyMetrics.java
@@ -18,14 +18,14 @@ public class AccuracyMetrics {
      * @param kRetrieved the number of retrieved elements
      * @return the recall
      */
-    public static double recallFromSearchResults(List<List<Integer>> gt, List<SearchResult> retrieved, int kGT, int kRetrieved) {
+    public static double recallFromSearchResults(List<? extends List<Integer>> gt, List<SearchResult> retrieved, int kGT, int kRetrieved) {
         if (gt.size() != retrieved.size()) {
             throw new IllegalArgumentException("We should have ground truth for each result");
         }
         Long correctCount = IntStream.range(0, gt.size())
                 .mapToObj(i -> topKCorrect(gt.get(i), retrieved.get(i), kGT, kRetrieved))
                 .reduce(0L, Long::sum);
-        return (double) correctCount / gt.size();
+        return (double) correctCount / (kGT * gt.size());
     }
 
     private static long topKCorrect(List<Integer> gt, List<Integer> retrieved, int kGT, int kRetrieved) {
@@ -84,7 +84,7 @@ public class AccuracyMetrics {
         return score / gtView.size();
     }
 
-    public static double meanAveragePrecisionAtK(List<List<Integer>> gt, List<SearchResult> retrieved, int k) {
+    public static double meanAveragePrecisionAtK(List<? extends List<Integer>> gt, List<SearchResult> retrieved, int k) {
         if (gt.size() != retrieved.size()) {
             throw new IllegalArgumentException("We should have ground truth for each result");
         }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/AccuracyMetrics.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/AccuracyMetrics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.jbellis.jvector.example.util;
 
 import io.github.jbellis.jvector.graph.SearchResult;

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/AccuracyMetrics.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/AccuracyMetrics.java
@@ -48,6 +48,13 @@ public class AccuracyMetrics {
         if (kGT > kRetrieved) {
             throw new IllegalArgumentException("kGT: " + kGT + " > kRetrieved: " + kRetrieved);
         }
+        if (kGT > gt.size()) {
+            throw new IllegalArgumentException("kGT: " + kGT + " > Gt size: " + gt.size());
+        }
+        if (kRetrieved > retrieved.size()) {
+            throw new IllegalArgumentException("kRetrieved: " + kRetrieved + " > retrieved size: " + retrieved.size());
+        }
+
         var gtView = crop(gt, kGT);
         var retrievedView = crop(retrieved, kRetrieved);
 
@@ -82,6 +89,13 @@ public class AccuracyMetrics {
         var retrievedTemp = Arrays.stream(retrieved.getNodes()).mapToInt(nodeScore -> nodeScore.node)
                 .boxed()
                 .collect(Collectors.toList());
+
+        if (k > gt.size()) {
+            throw new IllegalArgumentException("k: " + k + " > Gt size: " + gt.size());
+        }
+        if (k > retrievedTemp.size()) {
+            throw new IllegalArgumentException("k: " + k + " > retrieved size: " + retrievedTemp.size());
+        }
 
         var gtView = crop(gt, k);
         var retrievedView = crop(retrievedTemp, k);

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/AccuracyMetrics.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/AccuracyMetrics.java
@@ -92,9 +92,10 @@ public class AccuracyMetrics {
 
         for (var p : retrievedView) {
             if (gtView.contains(p) && !retrievedView.subList(0, i).contains(p)) {
-                num_hits += 1.;
+                num_hits += 1;
                 score += num_hits / (i + 1.0);
             }
+            i++;
         }
 
         return score / gtView.size();

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/AccuracyMetrics.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/AccuracyMetrics.java
@@ -1,0 +1,77 @@
+package io.github.jbellis.jvector.example.util;
+
+import io.github.jbellis.jvector.graph.SearchResult;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class AccuracyMetrics {
+    /**
+     * Compute kGT-recall@kRetrieved, which is the fraction of
+     * the kGT ground-truth nearest neighbors that are in the kRetrieved
+     * first search results (with kGT ≤ kRetrieved)
+     * @param gt the ground truth
+     * @param retrieved the retrieved elements
+     * @param kGT the number of considered ground truth elements
+     * @param kRetrieved the number of retrieved elements
+     * @return the recall
+     */
+    public static double recallFromSearchResults(List<List<Integer>> gt, List<SearchResult> retrieved, int kGT, int kRetrieved) {
+        if (gt.size() != retrieved.size()) {
+            throw new IllegalArgumentException("We should have ground truth for each result");
+        }
+        Long correctCount = IntStream.range(0, gt.size())
+                .mapToObj(i -> topKCorrect(gt.get(i), retrieved.get(i), kGT, kRetrieved))
+                .reduce(0L, Long::sum);
+        return (double) correctCount / gt.size();
+    }
+
+    /**
+     * Compute kGT-recall@kRetrieved, which is the fraction of
+     * the kGT ground-truth nearest neighbors that are in the kRetrieved
+     * first search results (with kGT ≤ kRetrieved)
+     * @param gt the ground truth
+     * @param retrieved the retrieved elements
+     * @param kGT the number of considered ground truth elements
+     * @param kRetrieved the number of retrieved elements
+     * @return the recall
+     */
+    public static double recall(List<List<Integer>> gt, List<List<Integer>> retrieved, int kGT, int kRetrieved) {
+        if (gt.size() != retrieved.size()) {
+            throw new IllegalArgumentException("We should have ground truth for each result");
+        }
+        Long correctCount = IntStream.range(0, gt.size())
+                .mapToObj(i -> topKCorrect(gt.get(i), retrieved.get(i), kGT, kRetrieved))
+                .reduce(0L, Long::sum);
+        return (double) correctCount / (kGT * gt.size());
+    }
+
+    private static long topKCorrect(List<Integer> gt, List<Integer> retrieved, int kGT, int kRetrieved) {
+        if (kGT > kRetrieved) {
+            throw new IllegalArgumentException("kGT: " + kGT + " > kRetrieved: " + kRetrieved);
+        }
+        var gtView = crop(gt, kGT);
+        var retrievedView = crop(retrieved, kRetrieved);
+
+        if (gtView.size() > retrieved.size()) {
+            return gtView.stream().filter(retrievedView::contains).count();
+        } else {
+            return retrievedView.stream().filter(gtView::contains).count();
+        }
+    }
+
+    public static long topKCorrect(List<Integer> gt, SearchResult retrieved, int kGT, int kRetrieved) {
+        var temp = Arrays.stream(retrieved.getNodes()).mapToInt(nodeScore -> nodeScore.node)
+                .boxed()
+                .collect(Collectors.toList());
+        return topKCorrect(gt, temp, kGT, kRetrieved);
+    }
+
+    private static List<Integer> crop(List<Integer> list, int k) {
+        int count = Math.min(list.size(), k);
+        return list.subList(0, count);
+    }
+}

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/DataSet.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/DataSet.java
@@ -35,14 +35,14 @@ public class DataSet {
     public final VectorSimilarityFunction similarityFunction;
     public final List<VectorFloat<?>> baseVectors;
     public final List<VectorFloat<?>> queryVectors;
-    public final List<? extends Set<Integer>> groundTruth;
+    public final List<? extends List<Integer>> groundTruth;
     private RandomAccessVectorValues baseRavv;
 
     public DataSet(String name,
                    VectorSimilarityFunction similarityFunction,
                    List<VectorFloat<?>> baseVectors,
                    List<VectorFloat<?>> queryVectors,
-                   List<? extends Set<Integer>> groundTruth)
+                   List<? extends List<Integer>> groundTruth)
     {
         if (baseVectors.isEmpty()) {
             throw new IllegalArgumentException("Base vectors must not be empty");
@@ -79,12 +79,12 @@ public class DataSet {
                                              VectorSimilarityFunction vsf,
                                              List<VectorFloat<?>> baseVectors,
                                              List<VectorFloat<?>> queryVectors,
-                                             List<Set<Integer>> groundTruth)
+                                             List<List<Integer>> groundTruth)
     {
         // remove zero vectors and duplicates, noting that this will change the indexes of the ground truth answers
         List<VectorFloat<?>> scrubbedBaseVectors;
         List<VectorFloat<?>> scrubbedQueryVectors;
-        List<HashSet<Integer>> gtSet;
+        List<ArrayList<Integer>> gtSet;
         scrubbedBaseVectors = new ArrayList<>(baseVectors.size());
         scrubbedQueryVectors = new ArrayList<>(queryVectors.size());
         gtSet = new ArrayList<>(groundTruth.size());
@@ -119,7 +119,7 @@ public class DataSet {
             var dupe = uniqueVectors.contains(v);
             if (valid && !dupe) {
                 scrubbedQueryVectors.add(v);
-                var gt = new HashSet<Integer>();
+                var gt = new ArrayList<Integer>();
                 for (int j : groundTruth.get(i)) {
                     gt.add(rawToScrubbed.get(j));
                 }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/DataSetCreator.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/DataSetCreator.java
@@ -24,8 +24,8 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -57,7 +57,7 @@ public class DataSetCreator {
             float[] q = new float[] {gridWidth * R.nextFloat(), gridWidth * R.nextFloat()};
 
             // Compute the ground truth within a bounding box around the query point
-            Set<Integer> gt = IntStream.range(0, baseVectors.size())
+            List<Integer> gt = IntStream.range(0, baseVectors.size())
                 .filter(j -> {
                     VectorFloat<?> v = baseVectors.get(j);
                     return v.get(0) >= q[0] - topK && v.get(0) <= q[0] + topK && v.get(1) >= q[1] - topK && v.get(1) <= q[1] + topK;
@@ -65,7 +65,7 @@ public class DataSetCreator {
                 .boxed() // allows sorting with custom comparator
                 .sorted(Comparator.comparingDouble((Integer j) -> VectorSimilarityFunction.EUCLIDEAN.compare(vectorTypeSupport.createFloatVector(q), baseVectors.get(j))).reversed())
                 .limit(topK)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
 
             return new AbstractMap.SimpleEntry<>(vectorTypeSupport.createFloatVector(q), gt);
         }).collect(Collectors.toConcurrentMap(Map.Entry::getKey, Map.Entry::getValue)).entrySet();

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/Hdf5Loader.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/Hdf5Loader.java
@@ -27,8 +27,7 @@ import io.jhdf.object.datatype.FloatingPoint;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.IntStream;
 
 public class Hdf5Loader {
@@ -52,7 +51,7 @@ public class Hdf5Loader {
         VectorFloat<?>[] baseVectors;
         VectorFloat<?>[] queryVectors;
         Path path = Path.of(HDF5_DIR).resolve(filename);
-        var gtSets = new ArrayList<Set<Integer>>();
+        var gtSets = new ArrayList<List<Integer>>();
         try (HdfFile hdf = new HdfFile(path)) {
             var baseVectorsArray =
                     (float[][]) hdf.getDatasetByPath("train").getData();
@@ -75,7 +74,7 @@ public class Hdf5Loader {
             int[][] groundTruth = (int[][]) hdf.getDatasetByPath("neighbors").getData();
             gtSets = new ArrayList<>(groundTruth.length);
             for (int[] i : groundTruth) {
-                var gtSet = new HashSet<Integer>(i.length);
+                var gtSet = new ArrayList<Integer>(i.length);
                 for (int j : i) {
                     gtSet.add(j);
                 }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/SiftLoader.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/SiftLoader.java
@@ -29,12 +29,12 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
 public class SiftLoader {
     private static final VectorTypeSupport vectorTypeSupport = VectorizationProvider.getInstance().getVectorTypeSupport();
 
-    public static ArrayList<VectorFloat<?>> readFvecs(String filePath) throws IOException {
+    public static List<VectorFloat<?>> readFvecs(String filePath) throws IOException {
         var vectors = new ArrayList<VectorFloat<?>>();
         try (var dis = new DataInputStream(new BufferedInputStream(new FileInputStream(filePath)))) {
             while (dis.available() > 0) {
@@ -53,13 +53,13 @@ public class SiftLoader {
         return vectors;
     }
 
-    public static ArrayList<Set<Integer>> readIvecs(String filename) {
-        var groundTruthTopK = new ArrayList<Set<Integer>>();
+    public static List<List<Integer>> readIvecs(String filename) {
+        var groundTruthTopK = new ArrayList<List<Integer>>();
 
         try (var dis = new DataInputStream(new FileInputStream(filename))) {
             while (dis.available() > 0) {
                 var numNeighbors = Integer.reverseBytes(dis.readInt());
-                var neighbors = new HashSet<Integer>(numNeighbors);
+                var neighbors = new ArrayList<Integer>(numNeighbors);
 
                 for (var i = 0; i < numNeighbors; i++) {
                     var neighbor = Integer.reverseBytes(dis.readInt());


### PR DESCRIPTION
- Added the AccuracyMetrics class to have a single point where these computations happen. Easier to debug and reuse.
- Added mean average precision as an additional order-aware accuracy metric.
- Switched the ground truth from a List<Set<Integer>> to List<List<Integer>> to enable the computation of order-aware metrics like "n-recall@k" (see section 3.2 in [this paper](https://arxiv.org/pdf/2401.08281)) and mean average precision.