### PR TITLE
Implement NodeQueue#pushAll and AbstractLongHeap#addAll

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/AbstractLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/AbstractLongHeap.java
@@ -25,6 +25,7 @@
 package io.github.jbellis.jvector.util;
 
 import io.github.jbellis.jvector.annotations.VisibleForTesting;
+import java.util.PrimitiveIterator;
 
 /**
  * A min heap that stores longs; a primitive priority queue that like all priority queues maintains
@@ -64,6 +65,14 @@ public abstract class AbstractLongHeap {
      */
     public abstract boolean push(long element);
 
+    /**
+     * Adds all elements from the given iterator to this heap, in bulk.
+     *
+     * @param elements the elements to add
+     * @param elementsSize the number of elements to add
+     */
+    public abstract void pushAll(PrimitiveIterator.OfLong elements, int elementsSize);
+
     protected long add(long element) {
         size++;
         if (size == heap.length) {
@@ -72,6 +81,37 @@ public abstract class AbstractLongHeap {
         heap[size] = element;
         upHeap(size);
         return heap[1];
+    }
+
+    /**
+     * Bulk-adds all elements from the given iterator to this heap, then re-heapifies
+     * in O(n) time (Floyd's build-heap).
+     *
+     * @param elements the elements to add
+     * @param elementsSize the number of elements to add
+     */
+    protected void addAll(PrimitiveIterator.OfLong elements, int elementsSize) {
+        if (!elements.hasNext()) {
+            return; // nothing to do
+        }
+
+        // 1) Ensure we have enough capacity
+        int newSize = size + elementsSize;
+        if (newSize >= heap.length) {
+            heap = ArrayUtil.grow(heap, newSize);
+        }
+
+        // 2) Copy the new elements directly into the array
+        while (elements.hasNext()) {
+            heap[++size] = elements.nextLong();
+        }
+
+        // 3) "Bottom-up" re-heapify:
+        //    Start from the last non-leaf node (size >>> 1) down to the root (1).
+        //    This is Floyd's build-heap algorithm.
+        for (int i = size >>> 1; i >= 1; i--) {
+            downHeap(i);
+        }
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/BoundedLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/BoundedLongHeap.java
@@ -25,6 +25,7 @@
 package io.github.jbellis.jvector.util;
 
 import io.github.jbellis.jvector.annotations.VisibleForTesting;
+import java.util.PrimitiveIterator;
 
 /**
  * An AbstractLongHeap with an adjustable maximum size.
@@ -65,6 +66,15 @@ public class BoundedLongHeap extends AbstractLongHeap {
         }
         add(value);
         return true;
+    }
+
+    @Override
+    public void pushAll(PrimitiveIterator.OfLong elements, int elementsSize)
+    {
+        if (elementsSize + size >= maxSize) {
+            throw new IllegalArgumentException("Cannot add more elements than maxSize");
+        }
+        addAll(elements, elementsSize);
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/GrowableLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/GrowableLongHeap.java
@@ -24,6 +24,8 @@
 
 package io.github.jbellis.jvector.util;
 
+import java.util.PrimitiveIterator;
+
 /**
  * An AbstractLongHeap that can grow in size (unbounded, except for memory and array size limits).
  */
@@ -46,5 +48,11 @@ public class GrowableLongHeap extends AbstractLongHeap {
     public boolean push(long element) {
         add(element);
         return true;
+    }
+
+    @Override
+    public void pushAll(PrimitiveIterator.OfLong elements, int elementsSize)
+    {
+        addAll(elements, elementsSize);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/datastax/jvector/issues/409

Adds bulk add operations to the AbstractLongHeap
and to the NodeQueue to reduce comparisons
required when adding many elements at once.

The current NodeQueue implementation forces users to add elements one at a time, which requires O(n*log(n)) time. A bulk addition of elements followed by a single heapify operation is instead O(n) time. In some brute force scenarios, I found that we could add 400k elements to a queue at a time, which makes for a significant difference in the time to build the queue. This is particularly relevant for a brute force scenario https://github.com/datastax/cassandra/pull/1643.

I propose that we add an option for the NodeQueue (and the AbstractLongHeap) to consume an iterator that produces the node id and score, adds those scores to the heap without running upheap, and then applies the bulk downheap operation to re-heapify the heap. The iterator solution would help keep the space complexity down.

It's not clear to me if there are applications for this logic within jvector, which might determine the utility of this feature to the project. Note that there are several places where we call push() iteratively, which suggests they might benefit from this change. However, for small cardinalities, the performance difference is likely negligible.

Further, if this library takes on brute force calculations, this change will become meaningful, so I propose we add it.

Back of the envelope math (a.k.a chatgpt) suggests that for the 400k example I provided, we're talking about 800k comparisons in the bulk add scenario and 8M in the iterative add scenario.
