### PR TITLE
Fix FusedADC.writeInline

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FusedADC.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FusedADC.java
@@ -105,13 +105,13 @@ public class FusedADC implements Feature {
 
         var neighbors = state.view.getNeighborsIterator(0, state.nodeId); // TODO
         int n = 0;
-        var neighborSize = neighbors.size();
         compressedNeighbors.zero();
-        for (; n < neighborSize; n++) {
+        while (neighbors.hasNext()) {
             var compressed = pqv.get(neighbors.nextInt());
             for (int j = 0; j < pqv.getCompressedSize(); j++) {
                 compressedNeighbors.set(j * maxDegree + n, compressed.get(j));
             }
+            n++;
         }
 
         vectorTypeSupport.writeByteSequence(out, compressedNeighbors);


### PR DESCRIPTION
Addresses #416. The method FusedADC.writeInline was calling this [method](https://github.com/datastax/jvector/blob/41ce85d7efde7ff4893ee8258f89909d04e5aadb/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java#L380). This small PR fixes the error.