### PR TITLE
Update test resume

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
@@ -402,11 +402,7 @@ public class GraphSearcher implements Closeable {
         rerankedResults.setMaxSize(topK);
 
         // add evicted results from the last call back to the candidates
-        var previouslyEvicted = evictedResults.size() > 0 ? new SparseBits() : Bits.NONE;
-        evictedResults.foreach((node, score) -> {
-            candidates.push(node, score);
-            ((SparseBits) previouslyEvicted).set(node);
-        });
+        evictedResults.foreach(candidates::push);
         evictedResults.clear();
 
         searchOneLayer(scoreProvider, rerankK, threshold, 0, acceptOrds);


### PR DESCRIPTION
Test resume was assuming a strict equivalence between a full search and a resumed search. Of course, they are not exactly equivalent, so we are relaxing the test to avoid flakiness in its output.