### PR TITLE
Random vector index build jmh + setup scripts

### DIFF
--- a/benchmarks-jmh/README.md
+++ b/benchmarks-jmh/README.md
@@ -37,21 +37,21 @@ Common JMH command line options you can use in the configuration or command line
 
 2. Focus on specific benchmarks
 
-For example in the below command lines we are going to run only `IndexConstructionWithStaticSetBenchmark`
+For example in the below command lines we are going to run only `IndexConstructionWithRandomSetBenchmark`
 ```shell
 mvn clean install -DskipTests=true
-BENCHMARK_NAME="IndexConstructionWithStaticSetBenchmark"
+BENCHMARK_NAME="IndexConstructionWithRandomSetBenchmark"
 java --enable-native-access=ALL-UNNAMED \
   --add-modules=jdk.incubator.vector \
   -XX:+HeapDumpOnOutOfMemoryError \
-  -Xmx14G -Djvector.experimental.enable_native_vectorization=true \
-  -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar $BENCHMARK_NAME
+  -Xmx20G -Djvector.experimental.enable_native_vectorization=true \
+  -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.3-SNAPSHOT.jar $BENCHMARK_NAME
 ```
 
 If you want to rerun a specific benchmark without testing the entire grid of scenarios defined in the benchmark.
 You can just do the following to set M and beamWidth:
 ```shell
-java -jar target/benchmarks.jar IndexConstructionWithStaticSetBenchmark -p M=32 -p beamWidth=100 
+java -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.3-SNAPSHOT.jar IndexConstructionWithStaticSetBenchmark -p M=32 -p beamWidth=100 
 ```
 
 

--- a/benchmarks-jmh/scripts/test_node_setup.sh
+++ b/benchmarks-jmh/scripts/test_node_setup.sh
@@ -1,0 +1,47 @@
+###### Script for test node setup ######
+
+sudo apt-get update
+
+# Download JDK 22
+wget https://download.java.net/java/GA/jdk22.0.2/c9ecb94cd31b495da20a27d4581645e8/9/GPL/openjdk-22.0.2_linux-x64_bin.tar.gz
+
+# Extract JDK 22
+tar -xzf openjdk-22.0.2_linux-x64_bin.tar.gz
+
+sudo mkdir -p /usr/lib/jvm
+sudo mv jdk-22.0.2 /usr/lib/jvm/jdk-22.0.2
+
+########################################
+# Setup Alternatives
+########################################
+sudo update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/jdk-22.0.2/bin/java" 1
+sudo update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/jdk-22.0.2/bin/javac" 1
+
+########################################
+# Verification
+########################################
+
+echo
+echo "Installation complete. Current default Java version:"
+java -version
+
+# Install Maven
+sudo apt-get install maven -y
+
+# Install Git
+sudo apt-get install git -y
+
+# clone jvector
+git clone https://github.com/datastax/jvector.git
+
+# Build jvector
+cd jvector
+mvn clean install -DskipTests=true
+
+# Run benchmarks
+java --enable-native-access=ALL-UNNAMED \
+  --add-modules=jdk.incubator.vector \
+  -XX:+HeapDumpOnOutOfMemoryError \
+  -Xmx14G -Djvector.experimental.enable_native_vectorization=true \
+  -jar target/benchmarks-jmh-4.0.0-beta.3-SNAPSHOT.jar
+

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithRandomSetBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithRandomSetBenchmark.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jbellis.jvector.bench;
+
+import io.github.jbellis.jvector.example.util.SiftLoader;
+import io.github.jbellis.jvector.graph.GraphIndexBuilder;
+import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@Threads(1)
+public class IndexConstructionWithRandomSetBenchmark {
+    private static final Logger log = LoggerFactory.getLogger(IndexConstructionWithRandomSetBenchmark.class);
+    private static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
+    private RandomAccessVectorValues ravv;
+    private BuildScoreProvider bsp;
+    private int M = 32; // graph degree
+    private int beamWidth = 100;
+    @Param({"768", "1536"})
+    private int originalDimension;
+    @Param({"10000", "100000", "1000000"})
+    int numBaseVectors;
+
+    @Setup
+    public void setup() throws IOException {
+
+        final var baseVectors = new ArrayList<VectorFloat<?>>(numBaseVectors);
+        for (int i = 0; i < numBaseVectors; i++) {
+            VectorFloat<?> vector = createRandomVector(originalDimension);
+            baseVectors.add(vector);
+        }
+        // wrap the raw vectors in a RandomAccessVectorValues
+        ravv = new ListRandomAccessVectorValues(baseVectors, originalDimension);
+
+        // score provider using the raw, in-memory vectors
+        bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+
+    }
+
+    @Benchmark
+    public void buildIndexBenchmark(Blackhole blackhole) throws IOException {
+        // score provider using the raw, in-memory vectors
+        try (final var graphIndexBuilder = new GraphIndexBuilder(bsp, ravv.dimension(), M, beamWidth, 1.2f, 1.2f, true)) {
+            final var graphIndex = graphIndexBuilder.build(ravv);
+            blackhole.consume(graphIndex);
+        }
+    }
+
+    private VectorFloat<?> createRandomVector(int dimension) {
+        VectorFloat<?> vector = VECTOR_TYPE_SUPPORT.createFloatVector(dimension);
+        for (int i = 0; i < dimension; i++) {
+            vector.set(i, (float) Math.random());
+        }
+        return vector;
+    }
+}

--- a/rat-excludes.txt
+++ b/rat-excludes.txt
@@ -10,3 +10,4 @@ src/assembly/mrjar.xml
 src/assembly/sourcesjar.xml
 src/main/java/io/github/jbellis/jvector/vector/cnative/*
 src/main/resources/log4j2.xml
+scripts/test_node_setup.sh


### PR DESCRIPTION
# Overview
- Added setup scripts for node to run JMH benchmarks on.
- Added JMH for index buildup with random vectors

# Testing
Testing was done on a GCP c-2 machine type.