### PR TITLE
Fix NPE in GraphIndexBuilder.load

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -754,7 +754,7 @@ public class GraphIndexBuilder implements Closeable {
                 if (level > 0 || searchProvider.reranker() == null) {
                     sf = searchProvider.scoreFunction();
                 } else {
-                    sf = scoreProvider.searchProviderFor(nodeId).exactScoreFunction();
+                    sf = searchProvider.exactScoreFunction();
                 }
 
                 var ca = new NodeArray(nNeighbors);
@@ -794,7 +794,7 @@ public class GraphIndexBuilder implements Closeable {
             if (searchProvider.reranker() == null) {
                 sf = searchProvider.scoreFunction();
             } else {
-                sf = scoreProvider.searchProviderFor(nodeId).exactScoreFunction();
+                sf = searchProvider.exactScoreFunction();
             }
 
             var ca = new NodeArray(nNeighbors);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -748,7 +748,15 @@ public class GraphIndexBuilder implements Closeable {
             for (int i = 0; i < layerSize; i++) {
                 int nodeId = in.readInt();
                 int nNeighbors = in.readInt();
-                var sf = scoreProvider.searchProviderFor(nodeId).exactScoreFunction();
+
+                var searchProvider = scoreProvider.searchProviderFor(nodeId);
+                ScoreFunction sf;
+                if (level > 0 || searchProvider.reranker() == null) {
+                    sf = searchProvider.scoreFunction();
+                } else {
+                    sf = scoreProvider.searchProviderFor(nodeId).exactScoreFunction();
+                }
+
                 var ca = new NodeArray(nNeighbors);
                 for (int j = 0; j < nNeighbors; j++) {
                     int neighbor = in.readInt();
@@ -780,7 +788,15 @@ public class GraphIndexBuilder implements Closeable {
         for (int i = 0; i < size; i++) {
             int nodeId = in.readInt();
             int nNeighbors = in.readInt();
-            var sf = scoreProvider.searchProviderFor(nodeId).exactScoreFunction();
+
+            var searchProvider = scoreProvider.searchProviderFor(nodeId);
+            ScoreFunction sf;
+            if (searchProvider.reranker() == null) {
+                sf = searchProvider.scoreFunction();
+            } else {
+                sf = scoreProvider.searchProviderFor(nodeId).exactScoreFunction();
+            }
+
             var ca = new NodeArray(nNeighbors);
             for (int j = 0; j < nNeighbors; j++) {
                 int neighbor = in.readInt();


### PR DESCRIPTION
When using a scoreProvider that does not have a reranker, GraphIndexBuilder.load was throwing a null pointer exception. This checks whether a reranker is available and use it. If not, it will use the primary score function.