### PR TITLE
New GHA workflow to create new tag and update changelog

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,58 @@
+# @author Madhavan Sridharan
+name: Prepare new tag & changelog PR
+
+# runs on
+# * manually triggered
+on:
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        description: 'Tag version to create'
+        required: true
+
+# global env vars, available in all jobs and steps
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  new_tag_and_changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Git config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Generate changelog
+        continue-on-error: true
+        run: ./update_changelog.sh
+
+      # Note: the tag version will be pushed right away at this step prior to changelog pr merging
+      - name: Create and push tag
+        run: |
+          git tag -a "v${{ github.event.inputs.tag_version }}" -m "Release tag version ${{ github.event.inputs.tag_version }}"
+          git push origin "${{ github.event.inputs.tag_version }}"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        env:
+          GITHUB_TOKEN:
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "release/bump-tag-version-and-update-changelog"
+          branch-suffix: "short-commit-hash"
+          base: "main"
+          title: "chore(release): Bump tag version and update changelog"
+          commit-message: "chore(release): Bump tag version and update changelog"
+          body: |
+            This pull request bumps the tag version to ${{ github.event.inputs.tag_version }} and updates changelog as part of the release process.
+            Please review and merge.

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -7,7 +7,10 @@ on:
   workflow_dispatch:
     inputs:
       tag_version:
-        description: 'Tag version to create'
+        description: 'Tag version to create (e.g. X.Y.Z-beta.M)'
+        required: true
+      new_revision:
+        description: 'New revision to update in pom.xml (e.g. X.Y.Z-beta.N-SNAPSHOT)'
         required: true
 
 # global env vars, available in all jobs and steps
@@ -36,6 +39,12 @@ jobs:
         continue-on-error: true
         run: ./update_changelog.sh
 
+      - name: Update revision in pom.xml
+        run: |
+          sed -i '' 's|<revision>.*</revision>|<revision>${{ github.event.inputs.new_revision }}</revision>|' pom.xml
+          git add pom.xml
+          git commit -m "chore (release): Start development on ${{ github.event.inputs.new_revision }}"
+
       # Note: the tag version will be pushed right away at this step prior to changelog pr merging
       - name: Create and push tag
         run: |
@@ -54,5 +63,8 @@ jobs:
           title: "chore(release): Bump tag version and update changelog"
           commit-message: "chore(release): Bump tag version and update changelog"
           body: |
-            This pull request bumps the tag version to ${{ github.event.inputs.tag_version }} and updates changelog as part of the release process.
+            This pull request does the following as part of the release process,
+            - bumps the tag version to ${{ github.event.inputs.tag_version }}
+            - updates changelog
+            - bumps the revision in pom.xml to ${{ github.event.inputs.new_revision }}
             Please review and merge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [0.9.0](https://github.com/datastax/jvector/releases/tag/0.9.0) (2023-10-06)
+Initial Release

--- a/rat-excludes.txt
+++ b/rat-excludes.txt
@@ -1,8 +1,10 @@
 .github/workflows/unit-tests.yaml
+.github/workflows/tag-release.yml
 .mvn/wrapper/maven-wrapper.properties
 .mvn/jvm.config
 README.md
 UPGRADING.md
+CHANGELOG.md
 rat-excludes.txt
 pom.xml
 src/main/assembly/test-jar-with-dependencies.xml

--- a/update_changelog.sh
+++ b/update_changelog.sh
@@ -1,0 +1,44 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#!/bin/bash
+# @author Madhavan Sridharan
+set -euo pipefail
+
+which docker > /dev/null || (echoerr "Please ensure that docker is installed" && exit 1)
+
+cd -P -- "$(dirname -- "$0")" # switch to this dir
+
+CHANGELOG_FILE=CHANGELOG.md
+previous_version_line_number=$(awk '/## \[[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?\]/ {print NR; exit}' "$CHANGELOG_FILE"
+)
+previous_version=$(head -$previous_version_line_number $CHANGELOG_FILE | grep "## \[" | awk -F']' '{print $1}' | cut -c 5-)
+echo "previous_version:" $previous_version
+# Remove the header so we can append the additions
+tail -n +$previous_version_line_number "$CHANGELOG_FILE" > "$CHANGELOG_FILE.tmp" && mv "$CHANGELOG_FILE.tmp" "$CHANGELOG_FILE"
+
+if [[ -z ${GITHUB_TOKEN-} ]]; then
+  echo "**WARNING** GITHUB_TOKEN is not currently set" >&2
+  exit 1
+fi
+
+INTERACTIVE=""
+if [[ -t 1 ]]; then
+  INTERACTIVE="-it"
+fi
+
+docker run $INTERACTIVE --rm -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator -u datastax -p jvector -t $GITHUB_TOKEN --since-tag $previous_version --base $CHANGELOG_FILE --output $CHANGELOG_FILE --release-branch 'main' --exclude-labels 'duplicate,question,invalid,wontfix'
+
+# Remove the additional footer added by the changelog generator
+head -n $(( $(wc -l < $CHANGELOG_FILE) - 3 )) $CHANGELOG_FILE > "$CHANGELOG_FILE.tmp" && mv "$CHANGELOG_FILE.tmp" "$CHANGELOG_FILE"


### PR DESCRIPTION
The idea is when [this GHA workflow](https://github.com/datastax/jvector/blob/main/.github/workflows/tag-release.yml) is manually kicked off, it will do 3 things:

1. Create a new tag based on the user input and push it to `main` branch
2. Update the changelog and automatically add the changes based on PRs merged with appropriate tags (sans any chore labels) and creates a PR to review and merge
3. Update the `pom.xml`'s *\<revision\>* tag to the next development version based on user's 2nd input

Today, there is no changelog and it is hard to understand what is available in a new tag release. This will make it easier for developers/viewers to look into the changelog file.

I hope this helps.