### PR TITLE
bugfix for 429 - eliminate maven-resources-plugin warning

### DIFF
--- a/jvector-native/pom.xml
+++ b/jvector-native/pom.xml
@@ -27,7 +27,9 @@
             </plugin>
             <!--Disable filtering for resources plugin-->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
                 <configuration>
                     <nonFilteredFileExtensions>
                         <nonFilteredFileExtension>so</nonFilteredFileExtension>


### PR DESCRIPTION
## What this PR does?
Fixes #429 

## After this fix
We won't get any more warning. See here, https://github.com/datastax/jvector/actions/runs/14383784844/job/40333969624?pr=430#step:6:8