### PR TITLE
Fix/refactor NodeScoreIterator, BoundedLongHeap, and GrowableLongHeap bulk addition implementations

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeQueue.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeQueue.java
@@ -93,7 +93,7 @@ public class NodeQueue {
      * Encodes then adds all elements from the given iterator to this heap, in bulk.
      *
      * @param nodeScoreIterator the node and score pairs to add
-     * @param count             the number of elements to add
+     * @param count             the maximum number of elements to pull from the nodeScoreIterator
      */
     public void pushAll(NodeScoreIterator nodeScoreIterator, int count) {
         heap.pushAll(new NodeScoreIteratorConverter(nodeScoreIterator, this), count);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeQueue.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeQueue.java
@@ -90,13 +90,14 @@ public class NodeQueue {
     }
 
     /**
-     * Encodes then adds all elements from the given iterator to this heap, in bulk.
+     * Encodes then adds N elements from the given iterator to this heap, in bulk. If the nodeScoreIterator
+     * has fewer than N elements, all elements will be added.
      *
      * @param nodeScoreIterator the node and score pairs to add
-     * @param count             the maximum number of elements to pull from the nodeScoreIterator
+     * @param n                 the maximum number of elements to pull from the nodeScoreIterator
      */
-    public void pushAll(NodeScoreIterator nodeScoreIterator, int count) {
-        heap.pushAll(new NodeScoreIteratorConverter(nodeScoreIterator, this), count);
+    public void pushN(NodeScoreIterator nodeScoreIterator, int n) {
+        heap.pushN(new NodeScoreIteratorConverter(nodeScoreIterator, this), n);
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeQueue.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeQueue.java
@@ -274,11 +274,11 @@ public class NodeQueue {
         /** @return true if there are more elements */
         boolean hasNext();
 
-        /** @return the next node id */
-        int nextNode();
+        /** @return the next node id and advance the iterator */
+        int pop();
 
-        /** @return the next node score and advance the iterator */
-        float nextScore();
+        /** @return the next node score */
+        float topScore();
     }
 
     /**
@@ -315,8 +315,10 @@ public class NodeQueue {
 
         @Override
         public long nextLong() {
-            // Call to nextScore() advances the iterator
-            return queue.encode(it.nextNode(), it.nextScore());
+            // pop() advances the iterator
+            float score = it.topScore();
+            int node = it.pop();
+            return queue.encode(node, score);
         }
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeQueue.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeQueue.java
@@ -90,14 +90,14 @@ public class NodeQueue {
     }
 
     /**
-     * Encodes then adds N elements from the given iterator to this heap, in bulk. If the nodeScoreIterator
-     * has fewer than N elements, all elements will be added.
+     * Encodes then adds elements from the given iterator to this heap until elementsSize elements have been added or
+     * the iterator is exhausted. The heap then re-heapifies in O(n) time (Floyd's build-heap).
      *
-     * @param nodeScoreIterator the node and score pairs to add
-     * @param n                 the maximum number of elements to pull from the nodeScoreIterator
+     * @param nodeScoreIterator the node/score pairs to add
+     * @param count             the maximum number of elements to pull from the nodeScoreIterator
      */
-    public void pushN(NodeScoreIterator nodeScoreIterator, int n) {
-        heap.pushN(new NodeScoreIteratorConverter(nodeScoreIterator, this), n);
+    public void pushMany(NodeScoreIterator nodeScoreIterator, int count) {
+        heap.pushMany(new NodeScoreIteratorConverter(nodeScoreIterator, this), count);
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/AbstractLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/AbstractLongHeap.java
@@ -66,12 +66,12 @@ public abstract class AbstractLongHeap {
     public abstract boolean push(long element);
 
     /**
-     * Adds all elements from the given iterator to this heap, in bulk.
+     * Adds `elementsSize` elements from the given iterator to this heap, in bulk.
      *
      * @param elements the elements to add
      * @param elementsSize the maximum number of elements to pull from the elements iterator
      */
-    public abstract void pushAll(PrimitiveIterator.OfLong elements, int elementsSize);
+    public abstract void pushN(PrimitiveIterator.OfLong elements, int elementsSize);
 
     protected long add(long element) {
         size++;
@@ -84,14 +84,14 @@ public abstract class AbstractLongHeap {
     }
 
     /**
-     * Bulk-adds all elements from the given iterator to this heap, then re-heapifies
+     * Bulk-adds `elementsSize` elements from the given iterator to this heap, then re-heapifies
      * in O(n) time (Floyd's build-heap). For a proof explaining the linear time
      * complexity, see <a href="https://stackoverflow.com/a/18742428">this stackoverflow answer</a>.
      *
      * @param elements the elements to add
      * @param elementsSize the maximum number of elements to pull from the elements iterator
      */
-    protected void addAll(PrimitiveIterator.OfLong elements, int elementsSize) {
+    protected void addN(PrimitiveIterator.OfLong elements, int elementsSize) {
         if (!elements.hasNext()) {
             return; // nothing to do
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/AbstractLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/AbstractLongHeap.java
@@ -69,7 +69,7 @@ public abstract class AbstractLongHeap {
      * Adds all elements from the given iterator to this heap, in bulk.
      *
      * @param elements the elements to add
-     * @param elementsSize the number of elements to add
+     * @param elementsSize the maximum number of elements to pull from the elements iterator
      */
     public abstract void pushAll(PrimitiveIterator.OfLong elements, int elementsSize);
 
@@ -89,7 +89,7 @@ public abstract class AbstractLongHeap {
      * complexity, see <a href="https://stackoverflow.com/a/18742428">this stackoverflow answer</a>.
      *
      * @param elements the elements to add
-     * @param elementsSize the number of elements to add
+     * @param elementsSize the maximum number of elements to pull from the elements iterator
      */
     protected void addAll(PrimitiveIterator.OfLong elements, int elementsSize) {
         if (!elements.hasNext()) {
@@ -97,19 +97,22 @@ public abstract class AbstractLongHeap {
         }
 
         // 1) Ensure we have enough capacity
-        int newSize = size + elementsSize;
-        if (newSize >= heap.length) {
+        // NOTE: we add +1 to size because all access to heap is 1-based not 0-based.  heap[0] is unused.
+        int newSize = (size + 1) + elementsSize;
+        if (newSize > heap.length) {
             heap = ArrayUtil.grow(heap, newSize);
         }
 
         // 2) Copy the new elements directly into the array
-        while (elements.hasNext()) {
+        int added = 0;
+        while (elements.hasNext() && added++ < elementsSize) {
             heap[++size] = elements.nextLong();
         }
 
         // 3) "Bottom-up" re-heapify:
         //    Start from the last non-leaf node (size >>> 1) down to the root (1).
         //    This is Floyd's build-heap algorithm.
+        // The loop goes down to 1 as heap is 1-based not 0-based.
         for (int i = size >>> 1; i >= 1; i--) {
             downHeap(i);
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/AbstractLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/AbstractLongHeap.java
@@ -66,12 +66,13 @@ public abstract class AbstractLongHeap {
     public abstract boolean push(long element);
 
     /**
-     * Adds `elementsSize` elements from the given iterator to this heap, in bulk.
+     * Adds elements from the given iterator to this heap until elementsSize elements have been added or the iterator
+     * is exhausted. Then re-heapifies in O(n) time (Floyd's build-heap).
      *
-     * @param elements the elements to add
+     * @param elements the iterator to pull elements from
      * @param elementsSize the maximum number of elements to pull from the elements iterator
      */
-    public abstract void pushN(PrimitiveIterator.OfLong elements, int elementsSize);
+    public abstract void pushMany(PrimitiveIterator.OfLong elements, int elementsSize);
 
     protected long add(long element) {
         size++;
@@ -84,14 +85,14 @@ public abstract class AbstractLongHeap {
     }
 
     /**
-     * Bulk-adds `elementsSize` elements from the given iterator to this heap, then re-heapifies
-     * in O(n) time (Floyd's build-heap). For a proof explaining the linear time
+     * Bulk-adds the minimum between elementsSize and the number of elements in the iterator from the given iterator
+     * to this heap, then re-heapifies in O(n) time (Floyd's build-heap). For a proof explaining the linear time
      * complexity, see <a href="https://stackoverflow.com/a/18742428">this stackoverflow answer</a>.
      *
-     * @param elements the elements to add
+     * @param elements the iterator to pull elements from
      * @param elementsSize the maximum number of elements to pull from the elements iterator
      */
-    protected void addN(PrimitiveIterator.OfLong elements, int elementsSize) {
+    protected void addMany(PrimitiveIterator.OfLong elements, int elementsSize) {
         if (!elements.hasNext()) {
             return; // nothing to do
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/BoundedLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/BoundedLongHeap.java
@@ -69,11 +69,11 @@ public class BoundedLongHeap extends AbstractLongHeap {
     }
 
     @Override
-    public void pushN(PrimitiveIterator.OfLong elements, int elementsSize)
+    public void pushMany(PrimitiveIterator.OfLong elements, int elementsSize)
     {
         if (elementsSize + size > maxSize)
             throw new IllegalArgumentException("Cannot add more elements than maxSize");
-        addN(elements, elementsSize);
+        addMany(elements, elementsSize);
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/BoundedLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/BoundedLongHeap.java
@@ -69,11 +69,11 @@ public class BoundedLongHeap extends AbstractLongHeap {
     }
 
     @Override
-    public void pushAll(PrimitiveIterator.OfLong elements, int elementsSize)
+    public void pushN(PrimitiveIterator.OfLong elements, int elementsSize)
     {
         if (elementsSize + size > maxSize)
             throw new IllegalArgumentException("Cannot add more elements than maxSize");
-        addAll(elements, elementsSize);
+        addN(elements, elementsSize);
     }
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/BoundedLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/BoundedLongHeap.java
@@ -71,9 +71,8 @@ public class BoundedLongHeap extends AbstractLongHeap {
     @Override
     public void pushAll(PrimitiveIterator.OfLong elements, int elementsSize)
     {
-        if (elementsSize + size >= maxSize) {
+        if (elementsSize + size > maxSize)
             throw new IllegalArgumentException("Cannot add more elements than maxSize");
-        }
         addAll(elements, elementsSize);
     }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/GrowableLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/GrowableLongHeap.java
@@ -51,8 +51,8 @@ public class GrowableLongHeap extends AbstractLongHeap {
     }
 
     @Override
-    public void pushAll(PrimitiveIterator.OfLong elements, int elementsSize)
+    public void pushN(PrimitiveIterator.OfLong elements, int elementsSize)
     {
-        addAll(elements, elementsSize);
+        addN(elements, elementsSize);
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/GrowableLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/GrowableLongHeap.java
@@ -51,8 +51,8 @@ public class GrowableLongHeap extends AbstractLongHeap {
     }
 
     @Override
-    public void pushN(PrimitiveIterator.OfLong elements, int elementsSize)
+    public void pushMany(PrimitiveIterator.OfLong elements, int elementsSize)
     {
-        addN(elements, elementsSize);
+        addMany(elements, elementsSize);
     }
 }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeQueue.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeQueue.java
@@ -159,14 +159,8 @@ public class TestNodeQueue extends RandomizedTest {
     // Bulk-add all pairs in one go
     queue.pushN(it, nodes.length);
 
-    // The queue should now contain 5 elements
-    assertEquals(5, queue.size());
-
-    // Because it's a MIN_HEAP, the top (root) should be the "smallest" score
-    // We have scores: [2.2, -1.0, 0.5, 2.1, -0.9]
-    // The minimum is -1.0. Let's see which node that corresponds to: node=1
-    assertEquals(-1.0f, queue.topScore(), 0.000001);
-    assertEquals(1, queue.topNode());
+    // The queue should now contain 3 elements
+    assertEquals(3, queue.size());
   }
 
   @Test

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeQueue.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeQueue.java
@@ -220,13 +220,13 @@ public class TestNodeQueue extends RandomizedTest {
     }
 
     @Override
-    public int nextNode() {
-      return nodes[index];
+    public int pop() {
+      return nodes[index++];
     }
 
     @Override
-    public float nextScore() {
-      return scores[index++];
+    public float topScore() {
+      return scores[index];
     }
   }
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeQueue.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeQueue.java
@@ -119,7 +119,7 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushAllMinHeap() {
+  public void testPushNMinHeap() {
     // Build a NodeQueue with a GrowableLongHeap, using MIN_HEAP order
     NodeQueue queue = new NodeQueue(new GrowableLongHeap(2), NodeQueue.Order.MIN_HEAP);
 
@@ -131,7 +131,7 @@ public class TestNodeQueue extends RandomizedTest {
     TestNodeScoreIterator it = new TestNodeScoreIterator(nodes, scores);
 
     // Bulk-add all pairs in one go
-    queue.pushAll(it, nodes.length);
+    queue.pushN(it, nodes.length);
 
     // The queue should now contain 5 elements
     assertEquals(5, queue.size());
@@ -144,7 +144,7 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushAllMinHeapEdgeCase() {
+  public void testPushNMinHeapEdgeCase() {
     // Build a NodeQueue with a GrowableLongHeap, using MIN_HEAP order
     NodeQueue queue = new NodeQueue(new GrowableLongHeap(2), NodeQueue.Order.MIN_HEAP);
 
@@ -157,7 +157,7 @@ public class TestNodeQueue extends RandomizedTest {
     TestNodeScoreIterator it = new TestNodeScoreIterator(nodes, scores);
 
     // Bulk-add all pairs in one go
-    queue.pushAll(it, nodes.length);
+    queue.pushN(it, nodes.length);
 
     // The queue should now contain 5 elements
     assertEquals(5, queue.size());
@@ -170,7 +170,7 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushAllMaxHeap() {
+  public void testPushNMaxHeap() {
     // Build a NodeQueue with a GrowableLongHeap, using MAX_HEAP order
     NodeQueue queue = new NodeQueue(new GrowableLongHeap(2), NodeQueue.Order.MAX_HEAP);
 
@@ -182,7 +182,7 @@ public class TestNodeQueue extends RandomizedTest {
     TestNodeScoreIterator it = new TestNodeScoreIterator(nodes, scores);
 
     // Bulk-add all pairs in one go
-    queue.pushAll(it, nodes.length);
+    queue.pushN(it, nodes.length);
 
     // The queue should now contain 5 elements
     assertEquals(5, queue.size());
@@ -194,24 +194,24 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushAllBoundedHeapAtCapacity() {
+  public void testPushNBoundedHeapAtCapacity() {
     NodeQueue queue = new NodeQueue(new BoundedLongHeap(2), NodeQueue.Order.MAX_HEAP);
-    queue.pushAll(new TestNodeScoreIterator(new int[] { 1, 2 }, new float[] { 1, 2 }), 2);
+    queue.pushN(new TestNodeScoreIterator(new int[] { 1, 2 }, new float[] { 1, 2 }), 2);
     assertEquals(2, queue.size());
     assertEquals(2, queue.topNode());
     assertEquals(2, queue.topScore(), 0.000001);
   }
 
   @Test
-  public void testPushAllBoundedHeapExceedsCapacity() {
+  public void testPushNBoundedHeapExceedsCapacity() {
     assertThrows(IllegalArgumentException.class, () -> {
       NodeQueue queue = new NodeQueue(new BoundedLongHeap(2), NodeQueue.Order.MAX_HEAP);
-      queue.pushAll(new TestNodeScoreIterator(new int[] { 1, 2, 3 }, new float[] { 1, 2, 3 }), 3);
+      queue.pushN(new TestNodeScoreIterator(new int[] { 1, 2, 3 }, new float[] { 1, 2, 3 }), 3);
     });
     NodeQueue queue = new NodeQueue(new BoundedLongHeap(2), NodeQueue.Order.MAX_HEAP);
     queue.push(1, 1);
     assertThrows(IllegalArgumentException.class, () -> {
-      queue.pushAll(new TestNodeScoreIterator(new int[] { 1, 2 }, new float[] { 1, 2 }), 2);
+      queue.pushN(new TestNodeScoreIterator(new int[] { 1, 2 }, new float[] { 1, 2 }), 2);
     });
   }
 
@@ -226,7 +226,7 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushAllPartialIterator() {
+  public void testPushNPartialIterator() {
     // Test with MIN_HEAP
     NodeQueue minQueue = new NodeQueue(new GrowableLongHeap(2), NodeQueue.Order.MIN_HEAP);
     int[] nodes = { 1, 2, 3, 4, 5 };
@@ -234,7 +234,7 @@ public class TestNodeQueue extends RandomizedTest {
     TestNodeScoreIterator it = new TestNodeScoreIterator(nodes, scores);
 
     // Only add first 3 elements from a 5-element iterator
-    minQueue.pushAll(it, 3);
+    minQueue.pushN(it, 3);
     assertEquals(3, minQueue.size());
     assertEquals(1.0f, minQueue.topScore(), 0.000001); // Smallest among 2.0, 1.0, 3.0
     assertEquals(2, minQueue.topNode());
@@ -247,7 +247,7 @@ public class TestNodeQueue extends RandomizedTest {
     it = new TestNodeScoreIterator(nodes, scores);
 
     // Only add first 2 elements from a 5-element iterator
-    maxQueue.pushAll(it, 2);
+    maxQueue.pushN(it, 2);
     assertEquals(2, maxQueue.size());
     assertEquals(3.0f, maxQueue.topScore(), 0.000001); // Largest among 1.0, 3.0
     assertEquals(20, maxQueue.topNode());
@@ -255,14 +255,14 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushAllBoundedHeapPartial() {
+  public void testPushNBoundedHeapPartial() {
     NodeQueue queue = new NodeQueue(new BoundedLongHeap(3), NodeQueue.Order.MAX_HEAP);
     int[] nodes = { 1, 2, 3, 4, 5 };
     float[] scores = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f };
     TestNodeScoreIterator it = new TestNodeScoreIterator(nodes, scores);
 
     // Add 2 elements to a heap with capacity 3
-    queue.pushAll(it, 2);
+    queue.pushN(it, 2);
     assertEquals(2, queue.size());
     assertEquals(2.0f, queue.topScore(), 0.000001);
     assertEquals(2, queue.topNode());

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeQueue.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeQueue.java
@@ -119,7 +119,7 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushNMinHeap() {
+  public void testPushManyMinHeap() {
     // Build a NodeQueue with a GrowableLongHeap, using MIN_HEAP order
     NodeQueue queue = new NodeQueue(new GrowableLongHeap(2), NodeQueue.Order.MIN_HEAP);
 
@@ -131,7 +131,7 @@ public class TestNodeQueue extends RandomizedTest {
     TestNodeScoreIterator it = new TestNodeScoreIterator(nodes, scores);
 
     // Bulk-add all pairs in one go
-    queue.pushN(it, nodes.length);
+    queue.pushMany(it, nodes.length);
 
     // The queue should now contain 5 elements
     assertEquals(5, queue.size());
@@ -144,7 +144,7 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushNMinHeapEdgeCase() {
+  public void testPushManyMinHeapEdgeCase() {
     // Build a NodeQueue with a GrowableLongHeap, using MIN_HEAP order
     NodeQueue queue = new NodeQueue(new GrowableLongHeap(2), NodeQueue.Order.MIN_HEAP);
 
@@ -157,14 +157,14 @@ public class TestNodeQueue extends RandomizedTest {
     TestNodeScoreIterator it = new TestNodeScoreIterator(nodes, scores);
 
     // Bulk-add all pairs in one go
-    queue.pushN(it, nodes.length);
+    queue.pushMany(it, nodes.length);
 
     // The queue should now contain 3 elements
     assertEquals(3, queue.size());
   }
 
   @Test
-  public void testPushNMaxHeap() {
+  public void testPushManyMaxHeap() {
     // Build a NodeQueue with a GrowableLongHeap, using MAX_HEAP order
     NodeQueue queue = new NodeQueue(new GrowableLongHeap(2), NodeQueue.Order.MAX_HEAP);
 
@@ -176,7 +176,7 @@ public class TestNodeQueue extends RandomizedTest {
     TestNodeScoreIterator it = new TestNodeScoreIterator(nodes, scores);
 
     // Bulk-add all pairs in one go
-    queue.pushN(it, nodes.length);
+    queue.pushMany(it, nodes.length);
 
     // The queue should now contain 5 elements
     assertEquals(5, queue.size());
@@ -188,24 +188,24 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushNBoundedHeapAtCapacity() {
+  public void testPushManyBoundedHeapAtCapacity() {
     NodeQueue queue = new NodeQueue(new BoundedLongHeap(2), NodeQueue.Order.MAX_HEAP);
-    queue.pushN(new TestNodeScoreIterator(new int[] { 1, 2 }, new float[] { 1, 2 }), 2);
+    queue.pushMany(new TestNodeScoreIterator(new int[] { 1, 2 }, new float[] { 1, 2 }), 2);
     assertEquals(2, queue.size());
     assertEquals(2, queue.topNode());
     assertEquals(2, queue.topScore(), 0.000001);
   }
 
   @Test
-  public void testPushNBoundedHeapExceedsCapacity() {
+  public void testPushManyBoundedHeapExceedsCapacity() {
     assertThrows(IllegalArgumentException.class, () -> {
       NodeQueue queue = new NodeQueue(new BoundedLongHeap(2), NodeQueue.Order.MAX_HEAP);
-      queue.pushN(new TestNodeScoreIterator(new int[] { 1, 2, 3 }, new float[] { 1, 2, 3 }), 3);
+      queue.pushMany(new TestNodeScoreIterator(new int[] { 1, 2, 3 }, new float[] { 1, 2, 3 }), 3);
     });
     NodeQueue queue = new NodeQueue(new BoundedLongHeap(2), NodeQueue.Order.MAX_HEAP);
     queue.push(1, 1);
     assertThrows(IllegalArgumentException.class, () -> {
-      queue.pushN(new TestNodeScoreIterator(new int[] { 1, 2 }, new float[] { 1, 2 }), 2);
+      queue.pushMany(new TestNodeScoreIterator(new int[] { 1, 2 }, new float[] { 1, 2 }), 2);
     });
   }
 
@@ -220,7 +220,7 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushNPartialIterator() {
+  public void testPushManyPartialIterator() {
     // Test with MIN_HEAP
     NodeQueue minQueue = new NodeQueue(new GrowableLongHeap(2), NodeQueue.Order.MIN_HEAP);
     int[] nodes = { 1, 2, 3, 4, 5 };
@@ -228,7 +228,7 @@ public class TestNodeQueue extends RandomizedTest {
     TestNodeScoreIterator it = new TestNodeScoreIterator(nodes, scores);
 
     // Only add first 3 elements from a 5-element iterator
-    minQueue.pushN(it, 3);
+    minQueue.pushMany(it, 3);
     assertEquals(3, minQueue.size());
     assertEquals(1.0f, minQueue.topScore(), 0.000001); // Smallest among 2.0, 1.0, 3.0
     assertEquals(2, minQueue.topNode());
@@ -241,7 +241,7 @@ public class TestNodeQueue extends RandomizedTest {
     it = new TestNodeScoreIterator(nodes, scores);
 
     // Only add first 2 elements from a 5-element iterator
-    maxQueue.pushN(it, 2);
+    maxQueue.pushMany(it, 2);
     assertEquals(2, maxQueue.size());
     assertEquals(3.0f, maxQueue.topScore(), 0.000001); // Largest among 1.0, 3.0
     assertEquals(20, maxQueue.topNode());
@@ -249,14 +249,14 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
-  public void testPushNBoundedHeapPartial() {
+  public void testPushManyBoundedHeapPartial() {
     NodeQueue queue = new NodeQueue(new BoundedLongHeap(3), NodeQueue.Order.MAX_HEAP);
     int[] nodes = { 1, 2, 3, 4, 5 };
     float[] scores = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f };
     TestNodeScoreIterator it = new TestNodeScoreIterator(nodes, scores);
 
     // Add 2 elements to a heap with capacity 3
-    queue.pushN(it, 2);
+    queue.pushMany(it, 2);
     assertEquals(2, queue.size());
     assertEquals(2.0f, queue.topScore(), 0.000001);
     assertEquals(2, queue.topNode());

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeQueue.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNodeQueue.java
@@ -168,6 +168,15 @@ public class TestNodeQueue extends RandomizedTest {
   }
 
   @Test
+  public void testPushAllBoundedHeapAtCapacity() {
+    NodeQueue queue = new NodeQueue(new BoundedLongHeap(2), NodeQueue.Order.MAX_HEAP);
+    queue.pushAll(new TestNodeScoreIterator(new int[] { 1, 2 }, new float[] { 1, 2 }), 2);
+    assertEquals(2, queue.size());
+    assertEquals(2, queue.topNode());
+    assertEquals(2, queue.topScore(), 0.000001);
+  }
+
+  @Test
   public void testPushAllBoundedHeapExceedsCapacity() {
     assertThrows(IllegalArgumentException.class, () -> {
       NodeQueue queue = new NodeQueue(new BoundedLongHeap(2), NodeQueue.Order.MAX_HEAP);


### PR DESCRIPTION
- **Fix boundary check on BoundedLongHeap::pushAll**
Test added that fails without fix
- **Breaking change: refactor NodeScoreIterator**
The methods in the NodeScoreIterator
had opposite semantics from the NodeQueue.
One key problem was that nextScore
advanced the iterator. I propose instead
that we align with the NodeQueue names
and add topScore along with pop as the
key methods and pop will advance the
iterator. This is a breaking change
both in terms of the API and the semantics,
but because this interface was only
just released last week and we are
also breaking the compile-compatibility,
I view this as pretty low risk.
- **Fix missed requirement that heap is 1-based, not 0-based**
- **Rename pushAll to pushN to match actual semantics**