### PR TITLE
Fix minor bug in OnDiskGraphIndex.getNodes

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -190,7 +190,7 @@ public class OnDiskGraphIndex implements GraphIndex, AutoCloseable, Accountable
 
         long layer0NodeSize = (long) Integer.BYTES // ids
                 + inlineBlockSize // inline elements
-                + (Integer.BYTES * (long) (maxDegree + 1));
+                + (Integer.BYTES * (long) (getDegree(0) + 1));
         long layerUpperNodeSize = (long) Integer.BYTES // ids
                 + (Integer.BYTES * (long) (maxDegree + 1)); // neighbor count + neighbors)
         long thisLayerNodeSide = level == 0? layer0NodeSize : layerUpperNodeSize;


### PR DESCRIPTION
The method getNodes was using the maxDegree from the wrong layer to compute layer0NodeSize