### PR TITLE
add jvector-native to build

### DIFF
--- a/jvector-native/pom.xml
+++ b/jvector-native/pom.xml
@@ -13,6 +13,7 @@
     <name>Native</name>
     <properties>
         <maven.install.skip>false</maven.install.skip>
+        <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
     <build>
         <plugins>
@@ -49,7 +50,49 @@
             </plugin>
         </plugins>
     </build>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
     <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.13</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <arg>--pinentry-mode</arg>
+                                    <arg>loopback</arg>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>unix-amd64-profile</id>
             <activation>

--- a/jvector-native/pom.xml
+++ b/jvector-native/pom.xml
@@ -11,6 +11,9 @@
     </parent>
     <artifactId>jvector-native</artifactId>
     <name>Native</name>
+    <properties>
+        <maven.install.skip>false</maven.install.skip>
+    </properties>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
# Description
Adding `jvector-native` to installation and sonatype release so that we would have it published as well as it's a required dependency.

# Testing
run `mvn clean install`

verify `jvector-native` is published
```
% ls -lah ~/.m2/repository/io/github/jbellis/jvector-native
total 8
drwxr-xr-x  4 sam.herman  staff   128B May  5 16:28 .
drwxr-xr-x  4 sam.herman  staff   128B May  5 16:28 ..
drwxr-xr-x  7 sam.herman  staff   224B May  5 16:28 4.0.0-beta.5-SNAPSHOT
-rw-r--r--  1 sam.herman  staff   298B May  5 16:28 maven-metadata-local.xml
```
TODO:
verify publish to sonatype