### PR TITLE
Factorize the computation of diverse edges

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
@@ -18,14 +18,13 @@ package io.github.jbellis.jvector.graph;
 
 import io.github.jbellis.jvector.annotations.VisibleForTesting;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
-import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.util.BitSet;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.util.DenseIntMap;
-import io.github.jbellis.jvector.util.DocIdSetIterator;
 import io.github.jbellis.jvector.util.FixedBitSet;
 import io.github.jbellis.jvector.util.IntMap;
 
+import static io.github.jbellis.jvector.graph.diversity.VamanaDiversityProvider.retainDiverse;
 import static java.lang.Math.min;
 
 /**
@@ -35,10 +34,10 @@ public class ConcurrentNeighborMap {
     final IntMap<Neighbors> neighbors;
 
     /** the diversity threshold; 1.0 is equivalent to HNSW; Vamana uses 1.2 or more */
-    final float alpha;
+    public final float alpha;
 
     /** used to compute diversity */
-    final BuildScoreProvider scoreProvider;
+    public final BuildScoreProvider scoreProvider;
 
     /** the maximum number of neighbors desired per node */
     public final int maxDegree;
@@ -222,7 +221,7 @@ public class ConcurrentNeighborMap {
                 return new NeighborWithShortEdges(this, Double.NaN);
             }
             var next = copy();
-            double shortEdges = retainDiverse(next, diverseBefore, map);
+            double shortEdges = retainDiverseInternal(next, diverseBefore, map);
             next.diverseBefore = next.size();
             return new NeighborWithShortEdges(next, shortEdges);
         }
@@ -239,7 +238,7 @@ public class ConcurrentNeighborMap {
 
             // merge the remaining neighbors with the candidates and keep the diverse results
             NodeArray merged = NodeArray.merge(liveNeighbors, candidates);
-            retainDiverse(merged, 0, map);
+            retainDiverseInternal(merged, 0, map);
             return new Neighbors(nodeId, merged);
         }
 
@@ -259,10 +258,10 @@ public class ConcurrentNeighborMap {
             NodeArray merged;
             if (size() > 0) {
                 merged = NodeArray.merge(this, toMerge);
-                retainDiverse(merged, 0, map);
+                retainDiverseInternal(merged, 0, map);
             } else {
                 merged = toMerge.copy(); // still need to copy in case we lose the race
-                retainDiverse(merged, 0, map);
+                retainDiverseInternal(merged, 0, map);
             }
             // insertDiverse usually gets called with a LOT of candidates, so trim down the resulting NodeArray
             var nextNodes = merged.getArrayLength() <= map.nodeArrayLength()
@@ -288,65 +287,11 @@ public class ConcurrentNeighborMap {
          * Retain the diverse neighbors, updating `neighbors` in place
          * @return post-diversity short edges fraction
          */
-        private double retainDiverse(NodeArray neighbors, int diverseBefore, ConcurrentNeighborMap map) {
+        private double retainDiverseInternal(NodeArray neighbors, int diverseBefore, ConcurrentNeighborMap map) {
             BitSet selected = new FixedBitSet(neighbors.size());
-            for (int i = 0; i < min(diverseBefore, map.maxDegree); i++) {
-                selected.set(i);
-            }
-
-            double shortEdges = retainDiverseInternal(neighbors, diverseBefore, selected, map);
+            double shortEdges = retainDiverse(map, neighbors, diverseBefore, selected);
             neighbors.retain(selected);
             return shortEdges;
-        }
-
-        /**
-         * update `selected` with the diverse members of `neighbors`.  `neighbors` is not modified
-         * @return the fraction of short edges (neighbors within alpha=1.0)
-         */
-        private double retainDiverseInternal(NodeArray neighbors, int diverseBefore, BitSet selected, ConcurrentNeighborMap map) {
-            int nSelected = diverseBefore;
-            double shortEdges = Double.NaN;
-            // add diverse candidates, gradually increasing alpha to the threshold
-            // (so that the nearest candidates are prioritized)
-            for (float a = 1.0f; a <= map.alpha + 1E-6 && nSelected < map.maxDegree; a += 0.2f) {
-                for (int i = diverseBefore; i < neighbors.size() && nSelected < map.maxDegree; i++) {
-                    if (selected.get(i)) {
-                        continue;
-                    }
-
-                    int cNode = neighbors.getNode(i);
-                    float cScore = neighbors.getScore(i);
-                    var sf = map.scoreProvider.diversityProviderFor(cNode).scoreFunction();
-                    if (isDiverse(cNode, cScore, neighbors, sf, selected, a)) {
-                        selected.set(i);
-                        nSelected++;
-                    }
-                }
-
-                if (a == 1.0f) {
-                    // this isn't threadsafe, but (for now) we only care about the result after calling cleanup(),
-                    // when we don't have to worry about concurrent changes
-                    shortEdges = nSelected / (float) map.maxDegree;
-                }
-            }
-            return shortEdges;
-        }
-
-        // is the candidate node with the given score closer to the base node than it is to any of the
-        // already-selected neighbors
-        private boolean isDiverse(int node, float score, NodeArray others, ScoreFunction sf, BitSet selected, float alpha) {
-            assert others.size() > 0;
-
-            for (int i = selected.nextSetBit(0); i != DocIdSetIterator.NO_MORE_DOCS; i = selected.nextSetBit(i + 1)) {
-                int otherNode = others.getNode(i);
-                if (node == otherNode) {
-                    break;
-                }
-                if (sf.similarityTo(otherNode) > score * alpha) {
-                    return false;
-                }
-            }
-            return true;
         }
 
         /**
@@ -371,7 +316,7 @@ public class ConcurrentNeighborMap {
             // we do a lot of duplicate work scanning nodes that we won't remove
             next.diverseBefore = min(insertionPoint, diverseBefore);
             if (next.size() > hardMax) {
-                retainDiverse(next, next.diverseBefore, map);
+                retainDiverseInternal(next, next.diverseBefore, map);
                 next.diverseBefore = next.size();
             }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -20,6 +20,7 @@ import io.github.jbellis.jvector.annotations.VisibleForTesting;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.graph.GraphIndex.NodeAtLevel;
 import io.github.jbellis.jvector.graph.SearchResult.NodeScore;
+import io.github.jbellis.jvector.graph.diversity.VamanaDiversityProvider;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
@@ -252,7 +253,7 @@ public class GraphIndexBuilder implements Closeable {
         this.simdExecutor = simdExecutor;
         this.parallelExecutor = parallelExecutor;
 
-        this.graph = new OnHeapGraphIndex(maxDegrees, neighborOverflow, scoreProvider, alpha, BUILD_BATCH_SIZE);
+        this.graph = new OnHeapGraphIndex(maxDegrees, neighborOverflow, new VamanaDiversityProvider(scoreProvider, alpha), BUILD_BATCH_SIZE);
         this.searchers = ExplicitThreadLocal.withInitial(() -> {
             var gs = new GraphSearcher(graph);
             gs.usePruning(false);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/DiversityProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/DiversityProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph.diversity;
+
+import io.github.jbellis.jvector.graph.NodeArray;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
+import io.github.jbellis.jvector.util.BitSet;
+import io.github.jbellis.jvector.util.DocIdSetIterator;
+
+import static java.lang.Math.min;
+
+public interface DiversityProvider {
+    /**
+     * update `selected` with the diverse members of `neighbors`.  `neighbors` is not modified
+     * @return the fraction of short edges (neighbors within alpha=1.0)
+     */
+    double retainDiverse(NodeArray neighbors, int maxDegree, int diverseBefore, BitSet selected);
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
@@ -73,11 +73,7 @@ public class VamanaDiversityProvider implements DiversityProvider {
                 shortEdges = nSelected / (float) maxDegree;
             }
 
-            if (alpha > 1) {
-                currentAlpha *= alpha;
-            } else {
-                currentAlpha = alpha + 1;
-            }
+            currentAlpha += 0.2f;
         }
         return shortEdges;
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
@@ -39,7 +39,7 @@ public class VamanaDiversityProvider implements DiversityProvider {
 
     /**
      * Update `selected` with the diverse members of `neighbors`.  `neighbors` is not modified
-     * It assumes that the i-th neighbor with 0 <= i < diverseBefore is already diverse.
+     * It assumes that the i-th neighbor with 0 {@literal <=} i {@literal <} diverseBefore is already diverse.
      * @return the fraction of short edges (neighbors within alpha=1.0)
      */
     public double retainDiverse(NodeArray neighbors, int maxDegree, int diverseBefore, BitSet selected) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
@@ -31,7 +31,7 @@ public class VamanaDiversityProvider implements DiversityProvider {
     /** used to compute diversity */
     public final BuildScoreProvider scoreProvider;
 
-
+    /** Create a new diversity provider */
     public VamanaDiversityProvider(BuildScoreProvider scoreProvider, float alpha) {
         this.scoreProvider = scoreProvider;
         this.alpha = alpha;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
@@ -73,7 +73,11 @@ public class VamanaDiversityProvider implements DiversityProvider {
                 shortEdges = nSelected / (float) maxDegree;
             }
 
-            currentAlpha *= alpha;
+            if (alpha > 1) {
+                currentAlpha *= alpha;
+            } else {
+                currentAlpha = alpha + 1;
+            }
         }
         return shortEdges;
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph.diversity;
+
+import io.github.jbellis.jvector.graph.ConcurrentNeighborMap;
+import io.github.jbellis.jvector.graph.NodeArray;
+import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
+import io.github.jbellis.jvector.util.BitSet;
+import io.github.jbellis.jvector.util.DocIdSetIterator;
+
+import static java.lang.Math.min;
+
+public class VamanaDiversityProvider {
+    /**
+     * update `selected` with the diverse members of `neighbors`.  `neighbors` is not modified
+     * @return the fraction of short edges (neighbors within alpha=1.0)
+     */
+    public static double retainDiverse(ConcurrentNeighborMap map, NodeArray neighbors, int diverseBefore, BitSet selected) {
+        for (int i = 0; i < min(diverseBefore, map.maxDegree); i++) {
+            selected.set(i);
+        }
+
+        int nSelected = diverseBefore;
+        double shortEdges = Double.NaN;
+        // add diverse candidates, gradually increasing alpha to the threshold
+        // (so that the nearest candidates are prioritized)
+        float currentAlpha = 1.0f;
+        while (currentAlpha <= map.alpha + 1E-6 && nSelected < map.maxDegree) {
+            for (int i = diverseBefore; i < neighbors.size() && nSelected < map.maxDegree; i++) {
+                if (selected.get(i)) {
+                    continue;
+                }
+
+                int cNode = neighbors.getNode(i);
+                float cScore = neighbors.getScore(i);
+                var sf = map.scoreProvider.diversityProviderFor(cNode).scoreFunction();
+                if (isDiverse(cNode, cScore, neighbors, sf, selected, currentAlpha)) {
+                    selected.set(i);
+                    nSelected++;
+                }
+            }
+
+            if (currentAlpha == 1.0f) {
+                // this isn't threadsafe, but (for now) we only care about the result after calling cleanup(),
+                // when we don't have to worry about concurrent changes
+                shortEdges = nSelected / (float) map.maxDegree;
+            }
+
+            currentAlpha *= map.alpha;
+        }
+        return shortEdges;
+    }
+
+    // is the candidate node with the given score closer to the base node than it is to any of the
+    // already-selected neighbors
+    private static boolean isDiverse(int node, float score, NodeArray others, ScoreFunction sf, BitSet selected, float alpha) {
+        assert others.size() > 0;
+
+        for (int i = selected.nextSetBit(0); i != DocIdSetIterator.NO_MORE_DOCS; i = selected.nextSetBit(i + 1)) {
+            int otherNode = others.getNode(i);
+            if (node == otherNode) {
+                break;
+            }
+            if (sf.similarityTo(otherNode) > score * alpha) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
@@ -38,7 +38,8 @@ public class VamanaDiversityProvider implements DiversityProvider {
     }
 
     /**
-     * update `selected` with the diverse members of `neighbors`.  `neighbors` is not modified
+     * Update `selected` with the diverse members of `neighbors`.  `neighbors` is not modified
+     * It assumes that the i-th neighbor with 0 <= i < diverseBefore is already diverse.
      * @return the fraction of short edges (neighbors within alpha=1.0)
      */
     public double retainDiverse(NodeArray neighbors, int maxDegree, int diverseBefore, BitSet selected) {

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNeighbors.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestNeighbors.java
@@ -17,6 +17,7 @@
 package io.github.jbellis.jvector.graph;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
+import io.github.jbellis.jvector.graph.diversity.VamanaDiversityProvider;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class TestNeighbors extends RandomizedTest {
     assert candidates.size() == 9;
 
     // only nodes 6 and 8 are diverse wrt 7
-    var cnm = new ConcurrentNeighborMap(bsp, 10, 10, 1.0f);
+    var cnm = new ConcurrentNeighborMap(new VamanaDiversityProvider(bsp, 1.0f), 10, 10);
     cnm.addNode(7);
     var neighbors = cnm.insertDiverse(7, candidates);
     assertEquals(2, neighbors.size());
@@ -71,7 +72,7 @@ public class TestNeighbors extends RandomizedTest {
             i -> concurrent.insertSorted(i, scoreBetween(bsp, 7, i)));
 
     // only nodes 6 and 8 are diverse wrt 7
-    var cnm = new ConcurrentNeighborMap(bsp, 10, 10, 1.0f);
+    var cnm = new ConcurrentNeighborMap(new VamanaDiversityProvider(bsp, 1.0f), 10, 10);
     cnm.addNode(7);
     var neighbors = cnm.insertDiverse(7, NodeArray.merge(natural, concurrent));
     assertEquals(2, neighbors.size());
@@ -94,7 +95,7 @@ public class TestNeighbors extends RandomizedTest {
     var cna2 = new NodeArray(1);
     cna2.addInOrder(8, scoreBetween(bsp, 7, 8));
 
-    var cnm = new ConcurrentNeighborMap(bsp, 10, 10, 1.0f);
+    var cnm = new ConcurrentNeighborMap(new VamanaDiversityProvider(bsp, 1.0f), 10, 10);
     cnm.addNode(7, cna);
     var neighbors = cnm.insertDiverse(7, cna2);
     assertEquals(2, neighbors.size());


### PR DESCRIPTION
This PR does not change anything algorithmically but it separates the computation of diversity from the graph (i.e., ConcurrentNeighborMap). It is only meant to improve code clarity and separate responsibilities.