### PR TITLE
Reduce object creation in BSP#pqBuildScoreProvider

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
@@ -156,7 +156,7 @@ public interface BuildScoreProvider {
                 // instead of precomputedScoreFunctionFor; since we only perform a few dozen comparisons
                 // during diversity computation, this is cheaper than precomputing a lookup table
                 VectorFloat<?> v1 = reusableVector.get();
-                pqv.getCompressor().decode(pqv.get(node1), v1);
+                pqv.decode(node1, v1);
                 var asf = pqv.scoreFunctionFor(v1, vsf); // not precomputed!
                 return new SearchScoreProvider(asf);
             }
@@ -164,7 +164,7 @@ public interface BuildScoreProvider {
             @Override
             public SearchScoreProvider searchProviderFor(int node1) {
                 VectorFloat<?> decoded = reusableVector.get();
-                pqv.getCompressor().decode(pqv.get(node1), decoded);
+                pqv.decode(node1, decoded);
                 return searchProviderFor(decoded);
             }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/PQVectors.java
@@ -351,6 +351,17 @@ public abstract class PQVectors implements CompressedVectors {
         return pq;
     }
 
+    /**
+     * Decodes the vector at the given ordinal into the given target vector. More efficient than getting the compressor
+     * via {@link #getCompressor()} and then calling {@link ProductQuantization#decode(ByteSequence, VectorFloat)}.
+     *
+     * @param nodeId the ordinal of the vector to decode
+     * @param target the target vector to decode into
+     */
+    public void decode(int nodeId, VectorFloat<?> target) {
+        pq.decode(getChunk(nodeId), getOffsetInChunk(nodeId), target);
+    }
+
     @Override
     public long ramBytesUsed() {
         int REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/ProductQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/ProductQuantization.java
@@ -429,7 +429,14 @@ public class ProductQuantization implements VectorCompressor<ByteSequence<?>>, A
      * Decodes the quantized representation (ByteSequence) to its approximate original vector.
      */
     public void decode(ByteSequence<?> encoded, VectorFloat<?> target) {
-        decodeCentered(encoded, target);
+        decode(encoded, 0, target);
+    }
+
+    /**
+     * Decodes the quantized representation (ByteSequence) to its approximate original vector.
+     */
+    public void decode(ByteSequence<?> encoded, int encodedOffset, VectorFloat<?> target) {
+        decodeCentered(encoded, encodedOffset, target);
 
         if (globalCentroid != null) {
             // Add back the global centroid to get the approximate original vector.
@@ -440,9 +447,9 @@ public class ProductQuantization implements VectorCompressor<ByteSequence<?>>, A
     /**
      * Decodes the quantized representation (ByteSequence) to its approximate original vector, relative to the global centroid.
      */
-    void decodeCentered(ByteSequence<?> encoded, VectorFloat<?> target) {
+    void decodeCentered(ByteSequence<?> encoded, int encodedOffset, VectorFloat<?> target) {
         for (int m = 0; m < M; m++) {
-            int centroidIndex = Byte.toUnsignedInt(encoded.get(m));
+            int centroidIndex = Byte.toUnsignedInt(encoded.get(m + encodedOffset));
             target.copyFrom(codebooks[m], centroidIndex * subvectorSizesAndOffsets[m][0], subvectorSizesAndOffsets[m][1], subvectorSizesAndOffsets[m][0]);
         }
     }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestProductQuantization.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestProductQuantization.java
@@ -76,6 +76,10 @@ public class TestProductQuantization extends RandomizedTest {
         for (int i = 0; i < vectors.size(); i++) {
             pq.decode(cv.get(i), decodedScratch);
             assertEquals(vectors.get(i), decodedScratch);
+            // Now confirm with the other decode method
+            decodedScratch.zero();
+            pq.decode(cv.getChunk(i), cv.getOffsetInChunk(i), decodedScratch);
+            assertEquals(vectors.get(i), decodedScratch);
         }
     }
 


### PR DESCRIPTION
In a profile of the latest released version of jvector, I can see that during graph construction, we create many byte sequence slices due to the logic in the `pqBuildScoreProvider` method. We can leverage the additions from #403 to reduce allocations. In my testing, this code was responsible for ~17% of the total allocations during a 30 second profile.