### PR TITLE
Find insertion point before performing copy in ConcurrentNeighborMap

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
@@ -57,7 +57,7 @@ public class ConcurrentNeighborMap {
         while (true) {
             var old = neighbors.get(fromId);
             var next = old.insert(toId, score, overflow, this);
-            if (next == old || neighbors.compareAndPut(fromId, old, next)) {
+            if (next == null || neighbors.compareAndPut(fromId, old, next)) {
                 break;
             }
         }
@@ -293,6 +293,7 @@ public class ConcurrentNeighborMap {
         /**
          * Insert a new neighbor, maintaining our size cap by removing the least diverse neighbor if
          * necessary. "Overflow" is the factor by which to allow going over the size cap temporarily.
+         * @return the new Neighbors, or null if the neighbor already existed
          */
         private Neighbors insert(int neighborId, float score, float overflow, ConcurrentNeighborMap map) {
             assert neighborId != nodeId : "can't add self as neighbor at node " + nodeId;
@@ -301,12 +302,14 @@ public class ConcurrentNeighborMap {
             assert hardMax <= map.maxOverflowDegree
                     : String.format("overflow %s could exceed max overflow degree %d", overflow, map.maxOverflowDegree);
 
-            var next = copy(map.nodeArrayLength());
-            int insertionPoint = next.insertSorted(neighborId, score);
+            var insertionPoint = insertionPoint(neighborId, score);
             if (insertionPoint == -1) {
                 // "new" node already existed
-                return this;
+                return null;
             }
+
+            var next = copy(map.nodeArrayLength());
+            next.insertSorted(insertionPoint, neighborId, score);
 
             // batch up the enforcement of the max connection limit, since otherwise
             // we do a lot of duplicate work scanning nodes that we won't remove

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
@@ -309,7 +309,7 @@ public class ConcurrentNeighborMap {
             }
 
             var next = copy(map.nodeArrayLength());
-            next.insertSorted(insertionPoint, neighborId, score);
+            next.insertAt(insertionPoint, neighborId, score);
 
             // batch up the enforcement of the max connection limit, since otherwise
             // we do a lot of duplicate work scanning nodes that we won't remove

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
@@ -163,6 +163,10 @@ public class NodeArray {
         ++size;
     }
 
+    /**
+     * Returns the index at which the given node should be inserted to maintain sorted order,
+     * or -1 if the node already exists in the array (with the same score).
+     */
     public int insertionPoint(int newNode, float newScore) {
         int insertionPoint = descSortFindRightMostInsertionPoint(newScore);
         return duplicateExistsNear(insertionPoint, newNode, newScore) ? -1 : insertionPoint;
@@ -183,22 +187,20 @@ public class NodeArray {
             return -1;
         }
 
-        return insertSortedInternal(insertionPoint, newNode, newScore);
+        return insertInternal(insertionPoint, newNode, newScore);
     }
 
     /**
      * Add a new node to the NodeArray into the specified insertion point.
-     *
-     * @return the insertion point of the new node
      */
-    public int insertSorted(int insertionPoint, int newNode, float newScore) {
+    public void insertAt(int insertionPoint, int newNode, float newScore) {
         if (size == nodes.length) {
             growArrays();
         }
-        return insertSortedInternal(insertionPoint, newNode, newScore);
+        insertInternal(insertionPoint, newNode, newScore);
     }
 
-    private int insertSortedInternal(int insertionPoint, int newNode, float newScore) {
+    private int insertInternal(int insertionPoint, int newNode, float newScore) {
         System.arraycopy(nodes, insertionPoint, nodes, insertionPoint + 1, size - insertionPoint);
         System.arraycopy(scores, insertionPoint, scores, insertionPoint + 1, size - insertionPoint);
         nodes[insertionPoint] = newNode;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
@@ -167,7 +167,7 @@ public class NodeArray {
      * Returns the index at which the given node should be inserted to maintain sorted order,
      * or -1 if the node already exists in the array (with the same score).
      */
-    public int insertionPoint(int newNode, float newScore) {
+    int insertionPoint(int newNode, float newScore) {
         int insertionPoint = descSortFindRightMostInsertionPoint(newScore);
         return duplicateExistsNear(insertionPoint, newNode, newScore) ? -1 : insertionPoint;
     }
@@ -193,7 +193,7 @@ public class NodeArray {
     /**
      * Add a new node to the NodeArray into the specified insertion point.
      */
-    public void insertAt(int insertionPoint, int newNode, float newScore) {
+    void insertAt(int insertionPoint, int newNode, float newScore) {
         if (size == nodes.length) {
             growArrays();
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
@@ -163,6 +163,11 @@ public class NodeArray {
         ++size;
     }
 
+    public int insertionPoint(int newNode, float newScore) {
+        int insertionPoint = descSortFindRightMostInsertionPoint(newScore);
+        return duplicateExistsNear(insertionPoint, newNode, newScore) ? -1 : insertionPoint;
+    }
+
     /**
      * Add a new node to the NodeArray into a correct sort position according to its score.
      * Duplicate node + score pairs are ignored.
@@ -173,11 +178,27 @@ public class NodeArray {
         if (size == nodes.length) {
             growArrays();
         }
-        int insertionPoint = descSortFindRightMostInsertionPoint(newScore);
-        if (duplicateExistsNear(insertionPoint, newNode, newScore)) {
+        int insertionPoint = insertionPoint(newNode, newScore);
+        if (insertionPoint == -1) {
             return -1;
         }
 
+        return insertSortedInternal(insertionPoint, newNode, newScore);
+    }
+
+    /**
+     * Add a new node to the NodeArray into the specified insertion point.
+     *
+     * @return the insertion point of the new node
+     */
+    public int insertSorted(int insertionPoint, int newNode, float newScore) {
+        if (size == nodes.length) {
+            growArrays();
+        }
+        return insertSortedInternal(insertionPoint, newNode, newScore);
+    }
+
+    private int insertSortedInternal(int insertionPoint, int newNode, float newScore) {
         System.arraycopy(nodes, insertionPoint, nodes, insertionPoint + 1, size - insertionPoint);
         System.arraycopy(scores, insertionPoint, scores, insertionPoint + 1, size - insertionPoint);
         nodes[insertionPoint] = newNode;


### PR DESCRIPTION
Relates to https://github.com/riptano/cndb/issues/14077

I see a large number of allocations from within the `ConcurrentNeighborMap::insert` method. We can reduce some of these by finding the insertion point before copying the array.

Anecdotally, we hit this early exit code 54 times in the sift 10k vector dataset. I am not sure how representative this dataset is, but for such a minor code change, the optimization seems worth it.