### PR TITLE
avx512 test runners, jobs, and assertions

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Verify Panama Vector Support (JDK ${{ matrix.jdk }})
         if: matrix.jdk == '20'
         run: >-
-          mvn -X -B -Pjdk20 -pl jvector-tests -am test
+          mvn -B -Pjdk20 -pl jvector-tests -am test
           -Dsurefire.failIfNoSpecifiedTests=false
           -Dtest=TestVectorizationProvider
           -DTest_RequireSpecificVectorizationProvider=PanamaVectorizationProvider
@@ -59,13 +59,13 @@ jobs:
       - name: Test Panama Support (JDK ${{ matrix.jdk }})
         if: matrix.jdk == '20'
         run: >-
-          mvn -X -B -Pjdk20 -pl jvector-tests test -am test
+          mvn -B -Pjdk20 -pl jvector-tests test -am test
           -DTest_RequireSpecificVectorizationProvider=PanamaVectorizationProvider
 
       - name: Verify native-access vector support (JDK ${{ matrix.jdk }})
         if: matrix.jdk == '24'
         run: >-
-          mvn -X -B -Punix-amd64-profile -pl jvector-tests -am test
+          mvn -B -Punix-amd64-profile -pl jvector-tests -am test
           -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider
           -Dsurefire.failIfNoSpecifiedTests=false
           -Dtest=TestVectorizationProvider
@@ -73,7 +73,7 @@ jobs:
       - name: Compile, run tests and package (JDK ${{ matrix.jdk }})
         if: matrix.jdk == '24'
         run: >-
-          mvn -X -B -Punix-amd64-profile -pl jvector-tests -am test
+          mvn -B -Punix-amd64-profile -pl jvector-tests -am test
           -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider
 
       - name: Test Summary for (ISA:${{ matrix.isa}},JDK${{ matrix.jdk }})

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -63,13 +63,13 @@ jobs:
       - name: Verify native-access vector support (JDK 24)
         if: matrix.jdk == '24'
         run: >-
-          mvn -X -B -Punix-amd64-profile -pl jvector-native -am test
+          mvn -X -B -Punix-amd64-profile -pl jvector-tests -am test
           -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider
           -Dsurefire.failIfNoSpecifiedTests=false
           -Dtest=TestVectorizationProvider
       - name: Compile, run tests and package (JDK 24)
         run: >-
-          mvn -X -B -Punix-amd64-profile test
+          mvn -X -B -Punix-amd64-profile -pl jvector-tests -am test
           -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider
 
       - name: Test Summary

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -63,13 +63,13 @@ jobs:
       - name: Verify native-access vector support (JDK 24)
         if: matrix.jdk == '24'
         run: >-
-          mvn -X -B -Punix-amd64-profile -pl jvector-native -am verify
+          mvn -X -B -Punix-amd64-profile -pl jvector-native -am test
           -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider
           -Dsurefire.failIfNoSpecifiedTests=false
           -Dtest=TestVectorizationProvider
       - name: Compile, run tests and package (JDK 24)
         run: >-
-          mvn -X -B -Punix-amd64-profile verify
+          mvn -X -B -Punix-amd64-profile test
           -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider
 
       - name: Test Summary

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -48,7 +48,7 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - name: Verify Panama Vector Support
+      - name: Verify Panama Vector Support (JDK ${{ matrix.jdk }})
         if: matrix.jdk == '20'
         run: >-
           mvn -X -B -Pjdk20 -pl jvector-tests -am test
@@ -56,13 +56,13 @@ jobs:
           -Dtest=TestVectorizationProvider
           -DTest_RequireSpecificVectorizationProvider=PanamaVectorizationProvider
 
-      - name: Test Panama Support (JDK 20)
+      - name: Test Panama Support (JDK ${{ matrix.jdk }})
         if: matrix.jdk == '20'
         run: >-
           mvn -X -B -Pjdk20 -pl jvector-tests test -am test
           -DTest_RequireSpecificVectorizationProvider=PanamaVectorizationProvider
 
-      - name: Verify native-access vector support (JDK 24)
+      - name: Verify native-access vector support (JDK ${{ matrix.jdk }})
         if: matrix.jdk == '24'
         run: >-
           mvn -X -B -Punix-amd64-profile -pl jvector-tests -am test
@@ -70,13 +70,13 @@ jobs:
           -Dsurefire.failIfNoSpecifiedTests=false
           -Dtest=TestVectorizationProvider
 
-      - name: Compile, run tests and package (JDK 24)
+      - name: Compile, run tests and package (JDK ${{ matrix.jdk }})
         if: matrix.jdk == '24'
         run: >-
           mvn -X -B -Punix-amd64-profile -pl jvector-tests -am test
           -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider
 
-      - name: Test Summary
+      - name: Test Summary for (ISA:${{ matrix.isa}},JDK${{ matrix.jdk }})
         if: always()
         uses: test-summary/action@v2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,6 +12,33 @@ on:
       - '**/pom.xml'
 
 jobs:
+  build-avx512-proto:
+    concurrency:
+      group: ${{ github.ref }}-${{ github.job }}-${{ matrix.jdk }}-${{ matrix.isa }}
+      cancel-in-progress: true
+    strategy:
+      matrix:
+        jdk: [ 11, 20, 22]
+        isa: [ isa-avx512f ]
+    runs-on: ${{ matrix.isa }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: temurin
+          cache: maven
+      - name: Compile, run tests, and package (JDK 22)
+        run: mvn -B verify
+        if: matrix.jdk == '22'
+      - name: Compile, run tests, and package (JDK 20)
+        run: mvn -B -Pjdk20 -am -pl jvector-tests test
+        if: matrix.jdk == '20'
+      - name: Compile and run tests (JDK 11)
+        run: mvn -B -Pjdk11 -am -pl jvector-tests test
+        if: matrix.jdk == '11'
+
   build:
     concurrency:
         group: ${{ github.ref }}-${{ github.job }}-${{ matrix.jdk }}-${{ matrix.os }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -41,7 +41,7 @@ jobs:
         run: |
           sudo apt install -y gcc
       - uses: actions/checkout@v4
-      - name: Set up JDK
+      - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.jdk }}
@@ -55,7 +55,9 @@ jobs:
           -Dsurefire.failIfNoSpecifiedTests=false
           -Dtest=TestVectorizationProvider
           -DTest_RequireSpecificVectorizationProvider=PanamaVectorizationProvider
+
       - name: Test Panama Support (JDK 20)
+        if: matrix.jdk == '20'
         run: >-
           mvn -X -B -Pjdk20 -pl jvector-tests test -am test
           -DTest_RequireSpecificVectorizationProvider=PanamaVectorizationProvider
@@ -67,7 +69,9 @@ jobs:
           -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider
           -Dsurefire.failIfNoSpecifiedTests=false
           -Dtest=TestVectorizationProvider
+
       - name: Compile, run tests and package (JDK 24)
+        if: matrix.jdk == '24'
         run: >-
           mvn -X -B -Punix-amd64-profile -pl jvector-tests -am test
           -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,16 +12,34 @@ on:
       - '**/pom.xml'
 
 jobs:
-  build-avx512-proto:
+  build-avx512:
     concurrency:
-      group: ${{ github.ref }}-${{ github.job }}-${{ matrix.jdk }}-${{ matrix.isa }}
-      cancel-in-progress: true
+      group: ${{ matrix.isa }}-${{ matrix.jdk }}
+      cancel-in-progress: false
     strategy:
       matrix:
-        jdk: [ 11, 20, 22]
+        jdk: [ 20, 24 ]
+#        jdk: [ 24 ]
         isa: [ isa-avx512f ]
     runs-on: ${{ matrix.isa }}
     steps:
+      - name: verify-avx512
+        run: |
+          # avx2 is included just for illustration
+          required="avx2 avx512f avx512cd avx512bw avx512dq avx512v"
+          printf "required ISA feature flags: %s\n" "${required}" 
+          flags="$(lscpu|grep '^Flags'|cut -d: -f2)"
+          output=""
+          for flag in ${required} ; do
+           if [[ " $flags " == *"${flag}"* ]]
+           then output="${output} $flag(OK)"
+           else output="${output} $flag(FAIL)"
+          fi ; done
+          printf "%s\n" ${output}
+          if [[ " $output " == *"FAIL"* ]] ; then exit 2 ; fi
+      - name: Set up GCC
+        run: |
+          sudo apt install -y gcc
       - uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -29,15 +47,38 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: temurin
           cache: maven
-      - name: Compile, run tests, and package (JDK 22)
-        run: mvn -B verify
-        if: matrix.jdk == '22'
-      - name: Compile, run tests, and package (JDK 20)
-        run: mvn -B -Pjdk20 -am -pl jvector-tests test
+
+      - name: Verify Panama Vector Support
         if: matrix.jdk == '20'
-      - name: Compile and run tests (JDK 11)
-        run: mvn -B -Pjdk11 -am -pl jvector-tests test
-        if: matrix.jdk == '11'
+        run: >-
+          mvn -X -B -Pjdk20 -pl jvector-tests -am test
+          -Dsurefire.failIfNoSpecifiedTests=false
+          -Dtest=TestVectorizationProvider
+          -DTest_RequireSpecificVectorizationProvider=PanamaVectorizationProvider
+      - name: Test Panama Support (JDK 20)
+        run: >-
+          mvn -X -B -Pjdk20 -pl jvector-tests test -am test
+          -DTest_RequireSpecificVectorizationProvider=PanamaVectorizationProvider
+
+      - name: Verify native-access vector support (JDK 24)
+        if: matrix.jdk == '24'
+        run: >-
+          mvn -X -B -Punix-amd64-profile -pl jvector-native -am verify
+          -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider
+          -Dsurefire.failIfNoSpecifiedTests=false
+          -Dtest=TestVectorizationProvider
+      - name: Compile, run tests and package (JDK 24)
+        run: >-
+          mvn -X -B -Punix-amd64-profile verify
+          -DTest_RequireSpecificVectorizationProvider=NativeVectorizationProvider
+
+      - name: Test Summary
+        if: always()
+        uses: test-summary/action@v2
+        with:
+          paths: |
+            **/target/surefire-reports/TEST-*.xml
+
 
   build:
     concurrency:
@@ -56,6 +97,10 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: temurin
           cache: maven
+      - name: Set up GCC
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt install -y gcc
       - name: Compile, run tests, and package (JDK 22)
         run: mvn -B verify
         if: matrix.jdk == '22'
@@ -65,3 +110,11 @@ jobs:
       - name: Compile and run tests (JDK 11)
         run: mvn -B -Pjdk11 -am -pl jvector-tests test
         if: matrix.jdk == '11'
+      - name: Test Summary
+        if: always()
+        uses: test-summary/action@v2
+        with:
+          paths: |
+            **/target/surefire-reports/TEST-*.xml
+
+        

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorizationProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorizationProvider.java
@@ -27,6 +27,7 @@ package io.github.jbellis.jvector.vector;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 
 import java.lang.Runtime.Version;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -101,7 +102,10 @@ public abstract class VectorizationProvider {
       // this is an experimental feature subject to change
       if (Boolean.getBoolean("jvector.experimental.enable_native_vectorization")) {
         try {
-          var provider = (VectorizationProvider) Class.forName("io.github.jbellis.jvector.vector.NativeVectorizationProvider").getConstructor().newInstance();
+          Class<?> clazz = Class.forName("io.github.jbellis.jvector.vector.NativeVectorizationProvider");
+          Constructor<?> ctor = clazz.getConstructor();
+          Object instance = ctor.newInstance();
+          var provider = (VectorizationProvider) instance;
           LOG.info("Native Vector API enabled. Using NativeVectorizationProvider.");
           return provider;
         } catch (UnsupportedOperationException uoe) {

--- a/jvector-native/pom.xml
+++ b/jvector-native/pom.xml
@@ -42,6 +42,11 @@
                 <version>3.1.2</version>
                 <configuration>
                     <skip>false</skip>
+                    <argLine>
+                        --add-modules jdk.incubator.vector
+                        --enable-native-access=ALL-UNNAMED
+                        -Djvector.experimental.enable_native_vectorization=true
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>
@@ -57,6 +62,28 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-java</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>[20,)</version>
+                                        </requireJavaVersion>
+                                        <requireProfileIdsExist/>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>

--- a/jvector-native/src/main/c/jextract_vector_simd.sh
+++ b/jvector-native/src/main/c/jextract_vector_simd.sh
@@ -17,6 +17,9 @@ set -e
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [ "$1" == "--auto-install-gcc" ] ; then AUTO_INSTALL_GCC=true ; shift ; fi
+printf "AUTO_INSTALL_GCC=%s\n" "${AUTO_INSTALL_GCC}"
+
 mkdir -p ../resources
 # compile jvector_simd_check.c as x86-64
 # compile jvector_simd.c as skylake-avx512
@@ -25,20 +28,32 @@ mkdir -p ../resources
 # Desired minimum GCC version
 MIN_GCC_VERSION=11
 
-# Check if GCC is installed
 if ! command -v gcc &> /dev/null; then
-    echo "GCC is not installed. Please install GCC 11+ to build supporting native libraries."
-else
-    CURRENT_GCC_VERSION=$(gcc -dumpversion)
-
-    # Check if the current GCC version is greater than or equal to the minimum required version
-    if [ "$(printf '%s\n' "$MIN_GCC_VERSION" "$CURRENT_GCC_VERSION" | sort -V | head -n1)" = "$MIN_GCC_VERSION" ]; then
-        gcc -fPIC -O3 -march=icelake-server -c jvector_simd.c -o jvector_simd.o
-        gcc -fPIC -O3 -march=x86-64 -c jvector_simd_check.c -o jvector_simd_check.o
-        gcc -shared -o ../resources/libjvector.so jvector_simd_check.o jvector_simd.o
-    else
-        echo "WARNING: GCC version $CURRENT_GCC_VERSION is too old. Please upgrade to GCC $MIN_GCC_VERSION or newer."
+  if [ "$AUTO_INSTALL_GCC" == "true" ]
+  then
+    LSB_RELEASE=$(lsb_release --id --short)
+    printf "LSB_RELEASE=%s\n" "${LSB_RELEASE}"
+    if [ "${LSB_RELEASE}" == "Ubuntu" ]
+    then sudo apt update && sudo apt install -y gcc
+    else printf "distribution %s needs a gcc install command in %s\n" "${LSB_RELEASE}" "${0}" ; exit 2
     fi
+  else
+    echo "GCC is not installed. Please install GCC 11+ to build supporting native libraries."
+    exit 2
+  fi
+fi
+
+# Check if GCC is installed
+CURRENT_GCC_VERSION=$(gcc -dumpversion)
+
+# Check if the current GCC version is greater than or equal to the minimum required version
+if [ "$(printf '%s\n' "$MIN_GCC_VERSION" "$CURRENT_GCC_VERSION" | sort -V | head -n1)" = "$MIN_GCC_VERSION" ]; then
+    rm -rf ../resources/libjvector.so
+    gcc -fPIC -O3 -march=icelake-server -c jvector_simd.c -o jvector_simd.o
+    gcc -fPIC -O3 -march=x86-64 -c jvector_simd_check.c -o jvector_simd_check.o
+    gcc -shared -o ../resources/libjvector.so jvector_simd_check.o jvector_simd.o
+else
+    echo "WARNING: GCC version $CURRENT_GCC_VERSION is too old. Please upgrade to GCC $MIN_GCC_VERSION or newer."
 fi
 
 # Generate Java source code

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestVectorizationProvider.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestVectorizationProvider.java
@@ -24,6 +24,8 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 public class TestVectorizationProvider extends RandomizedTest {
     static final boolean hasSimd = VectorizationProvider.vectorModulePresentAndReadable();
@@ -74,4 +76,45 @@ public class TestVectorizationProvider extends RandomizedTest {
             Assert.assertEquals(b.getVectorUtilSupport().sum(v3), b.getVectorUtilSupport().assembleAndSum(v2, 0, vectorTypeSupport.createByteSequence(offsets)), 0.0001);
         }
     }
+
+    public static String REQUIRE_SPECIFIC_VECTORIZATION_PROVIDER="Test_RequireSpecificVectorizationProvider";
+
+    /**
+     * To run with native-access vector support, use
+     * <pre>{@code
+     *   -ea
+     *   --add-modules jdk.incubator.vector
+     *   --enable-native-access=ALL-UNNAMED
+     *   -Djvector.experimental.enable_native_vectorization=true
+     * }</pre>
+     *
+     * To run with panama support, use
+     * <pre>{@code
+     *   --ea
+     *   --add-modules jdk.incubator.vector
+     * }</pre>
+     *
+     * If <pre>{@code -DTest_RequireSpecificVectorizationProvider=<simplename>}</pre>
+     * is provided, then this test will error out if the chosen vector support type is different.
+     */
+    @Test
+    public void testVectorSupportTypeIsExpected() {
+        VectorizationProvider provider = VectorizationProvider.getInstance();
+        System.out.println("PROVIDER: using " + provider.getClass().getSimpleName());
+
+        boolean readable = VectorizationProvider.vectorModulePresentAndReadable();
+        System.out.println("VECTOR MODULE READABLE: " + readable);
+
+        String requiredProvider = System.getProperty(REQUIRE_SPECIFIC_VECTORIZATION_PROVIDER);
+        if (requiredProvider != null) {
+            System.out.println("REQUIRED PROVIDER: " + requiredProvider);
+            assertEquals(
+                    requiredProvider,
+                    provider.getClass().getSimpleName(),
+                    "Provider mismatch, " + "required " + requiredProvider + ", detected "
+                            + provider.getClass().getSimpleName()
+            );
+        }
+    }
+
 }

--- a/jvector-twenty/pom.xml
+++ b/jvector-twenty/pom.xml
@@ -20,12 +20,28 @@
                 <configuration>
                     <release>20</release>
                     <compilerArgs>
+<!--                        <arg>&#45;&#45;enable-preview</arg>-->
                         <arg>--add-modules</arg>
                         <arg>jdk.incubator.vector</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <skip>false</skip>
+                    <argLine>
+                        --enable-preview
+                        --add-modules jdk.incubator.vector
+                        --enable-native-access=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+
         </plugins>
+
     </build>
     <dependencies>
         <dependency>


### PR DESCRIPTION
This completes bring-up of a test path for both panama and native test modes.
A summary of how it works:
* A separate arch-specific test matrix is run focusing only on ubuntu runners with avx512+ support
* The job verifies that the ISA has all the feature flags that are tested for in our native code stubs.
* GCC is installed, and the profiles which build the native library are used to build it fresh
* For native access mode (in Java 24)
  * A single base test is run to ensure that the native provider is active with the command options.
  * All tests in jvector-tests are run with the same options and assertion.
* For Panama mode (in java 20)
  * A single base test is run to ensure that the panama provider is active with the given options.
  * All tests in jvector-tests are run with the same options and assertion.

Additionally, the unit test jobs have been given a summary output that makes it easy to jump directly to the cause of any errors without going into the logs. Otherwise, a green "all good" indicator is given for each job summary.

An example that illustrates all this is here: https://github.com/datastax/jvector/actions/runs/15006463091
