### PR TITLE
Add a new graph node using a search score

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
@@ -26,6 +26,7 @@ package io.github.jbellis.jvector.graph;
 
 import io.github.jbellis.jvector.annotations.Experimental;
 import io.github.jbellis.jvector.graph.GraphIndex.NodeAtLevel;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.util.Bits;
@@ -113,7 +114,7 @@ public class GraphSearcher implements Closeable {
      */
     public static SearchResult search(VectorFloat<?> queryVector, int topK, RandomAccessVectorValues vectors, VectorSimilarityFunction similarityFunction, GraphIndex graph, Bits acceptOrds) {
         try (var searcher = new GraphSearcher(graph)) {
-            var ssp = SearchScoreProvider.exact(queryVector, similarityFunction, vectors);
+            var ssp = DefaultSearchScoreProvider.exact(queryVector, similarityFunction, vectors);
             return searcher.search(ssp, topK, acceptOrds);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -126,7 +127,7 @@ public class GraphSearcher implements Closeable {
      */
     public static SearchResult search(VectorFloat<?> queryVector, int topK, int rerankK, RandomAccessVectorValues vectors, VectorSimilarityFunction similarityFunction, GraphIndex graph, Bits acceptOrds) {
         try (var searcher = new GraphSearcher(graph)) {
-            var ssp = SearchScoreProvider.exact(queryVector, similarityFunction, vectors);
+            var ssp = DefaultSearchScoreProvider.exact(queryVector, similarityFunction, vectors);
             return searcher.search(ssp, topK, rerankK, 0.f, 0.f, acceptOrds);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
@@ -113,7 +113,7 @@ public interface BuildScoreProvider {
             @Override
             public SearchScoreProvider searchProviderFor(VectorFloat<?> vector) {
                 var vc = vectorsCopy.get();
-                return SearchScoreProvider.exact(vector, similarityFunction, vc);
+                return DefaultSearchScoreProvider.exact(vector, similarityFunction, vc);
             }
 
             @Override
@@ -128,7 +128,7 @@ public interface BuildScoreProvider {
                 RandomAccessVectorValues randomAccessVectorValues = vectors.get();
                 var v = randomAccessVectorValues.getVector(node1);
                 var vc = vectorsCopy.get();
-                return SearchScoreProvider.exact(v, similarityFunction, vc);
+                return DefaultSearchScoreProvider.exact(v, similarityFunction, vc);
             }
         };
     }
@@ -158,7 +158,7 @@ public interface BuildScoreProvider {
                 VectorFloat<?> v1 = reusableVector.get();
                 pqv.getCompressor().decode(pqv.get(node1), v1);
                 var asf = pqv.scoreFunctionFor(v1, vsf); // not precomputed!
-                return new SearchScoreProvider(asf);
+                return new DefaultSearchScoreProvider(asf);
             }
 
             @Override
@@ -171,7 +171,7 @@ public interface BuildScoreProvider {
             @Override
             public SearchScoreProvider searchProviderFor(VectorFloat<?> vector) {
                 // deliberately skips reranking even though we are using an approximate score function
-                return new SearchScoreProvider(pqv.precomputedScoreFunctionFor(vector, vsf));
+                return new DefaultSearchScoreProvider(pqv.precomputedScoreFunctionFor(vector, vsf));
             }
 
             @Override
@@ -196,13 +196,13 @@ public interface BuildScoreProvider {
 
             @Override
             public SearchScoreProvider searchProviderFor(VectorFloat<?> vector) {
-                return new SearchScoreProvider(bqv.scoreFunctionFor(vector, null));
+                return new DefaultSearchScoreProvider(bqv.scoreFunctionFor(vector, null));
             }
 
             @Override
             public SearchScoreProvider searchProviderFor(int node1) {
                 var encoded1 = bqv.get(node1);
-                return new SearchScoreProvider(new ScoreFunction() {
+                return new DefaultSearchScoreProvider(new ScoreFunction() {
                     @Override
                     public boolean isExact() {
                         return false;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/DefaultSearchScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/DefaultSearchScoreProvider.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph.similarity;
+
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+
+/** Encapsulates comparing node distances to a specific vector for GraphSearcher. */
+public final class DefaultSearchScoreProvider implements SearchScoreProvider {
+    private final ScoreFunction scoreFunction;
+    private final ScoreFunction.ExactScoreFunction reranker;
+
+    /**
+     * @param scoreFunction the primary, fast scoring function
+     * <p>
+     * No reranking is performed.
+     */
+    public DefaultSearchScoreProvider(ScoreFunction scoreFunction) {
+        this(scoreFunction, null);
+    }
+
+    /**
+     * @param scoreFunction the primary, fast scoring function
+     * @param reranker optional reranking function
+     * Generally, reranker will be null iff scoreFunction is an ExactScoreFunction.  However,
+     * it is allowed, and sometimes useful, to only perform approximate scoring without reranking.
+     * <p>
+     * Most often it will be convenient to get the reranker either using `RandomAccessVectorValues.rerankerFor`
+     * or `ScoringView.rerankerFor`.
+     */
+    public DefaultSearchScoreProvider(ScoreFunction scoreFunction, ScoreFunction.ExactScoreFunction reranker) {
+        assert scoreFunction != null;
+        this.scoreFunction = scoreFunction;
+        this.reranker = reranker;
+    }
+
+    public ScoreFunction scoreFunction() {
+        return scoreFunction;
+    }
+
+    public ScoreFunction.ExactScoreFunction reranker() {
+        return reranker;
+    }
+
+    public ScoreFunction.ExactScoreFunction exactScoreFunction() {
+        return scoreFunction.isExact()
+                ? (ScoreFunction.ExactScoreFunction) scoreFunction
+                : reranker;
+    }
+
+    /**
+     * A SearchScoreProvider for a single-pass search based on exact similarity.
+     * Generally only suitable when your RandomAccessVectorValues is entirely in-memory,
+     * e.g. during construction.
+     */
+    public static DefaultSearchScoreProvider exact(VectorFloat<?> v, VectorSimilarityFunction vsf, RandomAccessVectorValues ravv) {
+        // don't use ESF.reranker, we need thread safety here
+        var sf = new ScoreFunction.ExactScoreFunction() {
+            @Override
+            public float similarityTo(int node2) {
+                return vsf.compare(v, ravv.getVector(node2));
+            }
+        };
+        return new DefaultSearchScoreProvider(sf);
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/ScoreFunction.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/ScoreFunction.java
@@ -16,8 +16,6 @@
 
 package io.github.jbellis.jvector.graph.similarity;
 
-import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
-import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/SearchScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/SearchScoreProvider.java
@@ -21,61 +21,11 @@ import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
 /** Encapsulates comparing node distances to a specific vector for GraphSearcher. */
-public final class SearchScoreProvider {
-    private final ScoreFunction scoreFunction;
-    private final ScoreFunction.ExactScoreFunction reranker;
+public interface SearchScoreProvider {
 
-    /**
-     * @param scoreFunction the primary, fast scoring function
-     * <p>
-     * No reranking is performed.
-     */
-    public SearchScoreProvider(ScoreFunction scoreFunction) {
-        this(scoreFunction, null);
-    }
+    public ScoreFunction scoreFunction();
 
-    /**
-     * @param scoreFunction the primary, fast scoring function
-     * @param reranker optional reranking function
-     * Generally, reranker will be null iff scoreFunction is an ExactScoreFunction.  However,
-     * it is allowed, and sometimes useful, to only perform approximate scoring without reranking.
-     * <p>
-     * Most often it will be convenient to get the reranker either using `RandomAccessVectorValues.rerankerFor`
-     * or `ScoringView.rerankerFor`.
-     */
-    public SearchScoreProvider(ScoreFunction scoreFunction, ScoreFunction.ExactScoreFunction reranker) {
-        assert scoreFunction != null;
-        this.scoreFunction = scoreFunction;
-        this.reranker = reranker;
-    }
+    public ScoreFunction.ExactScoreFunction reranker();
 
-    public ScoreFunction scoreFunction() {
-        return scoreFunction;
-    }
-
-    public ScoreFunction.ExactScoreFunction reranker() {
-        return reranker;
-    }
-
-    public ScoreFunction.ExactScoreFunction exactScoreFunction() {
-        return scoreFunction.isExact()
-                ? (ScoreFunction.ExactScoreFunction) scoreFunction
-                : reranker;
-    }
-
-    /**
-     * A SearchScoreProvider for a single-pass search based on exact similarity.
-     * Generally only suitable when your RandomAccessVectorValues is entirely in-memory,
-     * e.g. during construction.
-     */
-    public static SearchScoreProvider exact(VectorFloat<?> v, VectorSimilarityFunction vsf, RandomAccessVectorValues ravv) {
-        // don't use ESF.reranker, we need thread safety here
-        var sf = new ScoreFunction.ExactScoreFunction() {
-            @Override
-            public float similarityTo(int node2) {
-                return vsf.compare(v, ravv.getVector(node2));
-            }
-        };
-        return new SearchScoreProvider(sf);
-    }
+    public ScoreFunction.ExactScoreFunction exactScoreFunction();
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/SearchScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/SearchScoreProvider.java
@@ -16,16 +16,12 @@
 
 package io.github.jbellis.jvector.graph.similarity;
 
-import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
-import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
-import io.github.jbellis.jvector.vector.types.VectorFloat;
-
 /** Encapsulates comparing node distances to a specific vector for GraphSearcher. */
 public interface SearchScoreProvider {
 
-    public ScoreFunction scoreFunction();
+    ScoreFunction scoreFunction();
 
-    public ScoreFunction.ExactScoreFunction reranker();
+    ScoreFunction.ExactScoreFunction reranker();
 
-    public ScoreFunction.ExactScoreFunction exactScoreFunction();
+    ScoreFunction.ExactScoreFunction exactScoreFunction();
 }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -36,6 +36,7 @@ import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
 import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.quantization.CompressedVectors;
@@ -463,7 +464,7 @@ public class Grid {
         public SearchScoreProvider scoreProviderFor(VectorFloat<?> queryVector, GraphIndex.View view) {
             // if we're not compressing then just use the exact score function
             if (cv == null) {
-                return SearchScoreProvider.exact(queryVector, ds.similarityFunction, ds.getBaseRavv());
+                return DefaultSearchScoreProvider.exact(queryVector, ds.similarityFunction, ds.getBaseRavv());
             }
 
             var scoringView = (GraphIndex.ScoringView) view;
@@ -474,7 +475,7 @@ public class Grid {
                 asf = cv.precomputedScoreFunctionFor(queryVector, ds.similarityFunction);
             }
             var rr = scoringView.rerankerFor(queryVector, ds.similarityFunction);
-            return new SearchScoreProvider(asf, rr);
+            return new DefaultSearchScoreProvider(asf, rr);
         }
 
         public GraphSearcher getSearcher() {

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/IPCService.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/IPCService.java
@@ -25,6 +25,7 @@ import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.quantization.CompressedVectors;
@@ -261,7 +262,7 @@ public class IPCService
                     var rr = view instanceof GraphIndex.ScoringView
                             ? ((GraphIndex.ScoringView) view).rerankerFor(queryVector, ctx.similarityFunction)
                             : ctx.ravv.rerankerFor(queryVector, ctx.similarityFunction);
-                    var ssp = new SearchScoreProvider(sf, rr);
+                    var ssp = new DefaultSearchScoreProvider(sf, rr);
                     r = new GraphSearcher(ctx.index).search(ssp, searchEf, Bits.ALL);
                 } catch (Exception e) {
                     throw new RuntimeException(e);

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -36,6 +36,7 @@ import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
 import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction.ApproximateScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction.ExactScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
@@ -116,7 +117,7 @@ public class SiftSmall {
             // search for a random vector using a GraphSearcher and SearchScoreProvider
             VectorFloat<?> q = randomVector(originalDimension);
             try (GraphSearcher searcher = new GraphSearcher(index)) {
-                SearchScoreProvider ssp = SearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, ravv);
+                SearchScoreProvider ssp = DefaultSearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, ravv);
                 SearchResult sr = searcher.search(ssp, 10, Bits.ALL);
                 for (SearchResult.NodeScore ns : sr.getNodes()) {
                     System.out.println(ns);
@@ -134,7 +135,7 @@ public class SiftSmall {
         try (GraphIndexBuilder builder = new GraphIndexBuilder(bsp, ravv.dimension(), 16, 100, 1.2f, 1.2f, false)) {
             OnHeapGraphIndex index = builder.build(ravv);
             // measure our recall against the (exactly computed) ground truth
-            Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> SearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, ravv);
+            Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> DefaultSearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, ravv);
             testRecall(index, queryVectors, groundTruth, sspFactory);
         }
     }
@@ -158,7 +159,7 @@ public class SiftSmall {
         try (ReaderSupplier rs = ReaderSupplierFactory.open(indexPath)) {
             OnDiskGraphIndex index = OnDiskGraphIndex.load(rs);
             // measure our recall against the (exactly computed) ground truth
-            Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> SearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, index.getView());
+            Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> DefaultSearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, index.getView());
             testRecall(index, queryVectors, groundTruth, sspFactory);
         }
     }
@@ -200,7 +201,7 @@ public class SiftSmall {
                 Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> {
                     ApproximateScoreFunction asf = pqv.precomputedScoreFunctionFor(q, VectorSimilarityFunction.EUCLIDEAN);
                     ExactScoreFunction reranker = index.getView().rerankerFor(q, VectorSimilarityFunction.EUCLIDEAN);
-                    return new SearchScoreProvider(asf, reranker);
+                    return new DefaultSearchScoreProvider(asf, reranker);
                 };
                 // measure our recall against the (exactly computed) ground truth
                 testRecall(index, queryVectors, groundTruth, sspFactory);
@@ -263,7 +264,7 @@ public class SiftSmall {
             Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> {
                 ApproximateScoreFunction asf = pqvSearch.precomputedScoreFunctionFor(q, VectorSimilarityFunction.EUCLIDEAN);
                 ExactScoreFunction reranker = index.getView().rerankerFor(q, VectorSimilarityFunction.EUCLIDEAN);
-                return new SearchScoreProvider(asf, reranker);
+                return new DefaultSearchScoreProvider(asf, reranker);
             };
             testRecall(index, queryVectors, groundTruth, sspFactory);
         }
@@ -326,7 +327,7 @@ public class SiftSmall {
             Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> {
                 ApproximateScoreFunction asf = pqvSearch.precomputedScoreFunctionFor(q, VectorSimilarityFunction.EUCLIDEAN);
                 ExactScoreFunction reranker = index.getView().rerankerFor(q, VectorSimilarityFunction.EUCLIDEAN);
-                return new SearchScoreProvider(asf, reranker);
+                return new DefaultSearchScoreProvider(asf, reranker);
             };
             testRecall(index, queryVectors, groundTruth, sspFactory);
         }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/Test2DThreshold.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/Test2DThreshold.java
@@ -19,6 +19,7 @@ package io.github.jbellis.jvector.graph;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import io.github.jbellis.jvector.LuceneTestCase;
 import io.github.jbellis.jvector.TestUtil;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
@@ -67,7 +68,7 @@ public class Test2DThreshold extends LuceneTestCase {
             TestParams tp = createTestParams(vectors);
 
             var sf = ravv.rerankerFor(tp.q, VectorSimilarityFunction.EUCLIDEAN);
-            var result = searcher.search(new SearchScoreProvider(sf), vectors.length, tp.th, Bits.ALL);
+            var result = searcher.search(new DefaultSearchScoreProvider(sf), vectors.length, tp.th, Bits.ALL);
 
             meanVisitedRatio += ((float) result.getVisitedCount()) / (vectors.length * nQueries);
             meanRecall += ((float) result.getNodes().length) / (tp.exactCount * nQueries);

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
@@ -28,6 +28,7 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import io.github.jbellis.jvector.LuceneTestCase;
 import io.github.jbellis.jvector.TestUtil;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.quantization.PQVectors;
@@ -154,7 +155,7 @@ public class TestVectorGraph extends LuceneTestCase {
         var searcher = new GraphSearcher(graph);
         searcher.usePruning(false);
 
-        var ssp = new SearchScoreProvider(vectors.rerankerFor(query, similarityFunction));
+        var ssp = new DefaultSearchScoreProvider(vectors.rerankerFor(query, similarityFunction));
         var initial = searcher.search(ssp, initialTopK, acceptOrds);
         assertEquals(initialTopK, initial.getNodes().length);
 
@@ -200,8 +201,10 @@ public class TestVectorGraph extends LuceneTestCase {
         var query = randomVector(dim);
         var searcher = new GraphSearcher(graph);
 
-        var ssp = new SearchScoreProvider(pqv.scoreFunctionFor(query, similarityFunction),
-                                          vectors.rerankerFor(query, similarityFunction));
+        var ssp = new DefaultSearchScoreProvider(
+                pqv.scoreFunctionFor(query, similarityFunction),
+                vectors.rerankerFor(query, similarityFunction)
+        );
         var initial = searcher.search(ssp, topK, rerankK, 0.0f, 0.0f, Bits.ALL);
         assertEquals(topK, initial.getNodes().length);
         assertEquals(rerankK, initial.getRerankedCount());
@@ -261,7 +264,7 @@ public class TestVectorGraph extends LuceneTestCase {
         };
 
         var searcher = new GraphSearcher(graph);
-        var ssp = new SearchScoreProvider(wrappedVectors.rerankerFor(getTargetVector(), similarityFunction));
+        var ssp = new DefaultSearchScoreProvider(wrappedVectors.rerankerFor(getTargetVector(), similarityFunction));
 
         assertThrows(RuntimeException.class, () -> {
             searcher.search(ssp, 10, Bits.ALL);


### PR DESCRIPTION
Adds a new method in GraphIndexBuilder to add a new graph node with the signature
` public long addGraphNode(int node, SearchScoreProvider searchScoreProvider)`
The search score provider needs to be compatible (as in yielding comparable distances) to the BuildScoreProvider provided in the constructor.

The rationale behind this new method is to avoid copies when working with systems that do not work with VectorFloat<?> internally. OpenSearch, for example.

Additionally, this PR changes the SearchScoreProvider final class into an interface. The goal is to add further flexibility in its implementation. The PR also adds a final class DefaultSearchScoreProvider that implements the interface.