### PR TITLE
Null dataset collection

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/yaml/DatasetCollection.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/yaml/DatasetCollection.java
@@ -47,7 +47,10 @@ public class DatasetCollection {
     public List<String> getAll() {
         List<String> allDatasetNames = new ArrayList<>();
         for (var key : datasetNames.keySet()) {
-            allDatasetNames.addAll(datasetNames.get(key));
+            var subList = datasetNames.get(key);
+            if (subList != null) {
+                allDatasetNames.addAll(subList);
+            }
         }
         return allDatasetNames;
     }

--- a/jvector-examples/yaml-configs/colbert-1M.yml
+++ b/jvector-examples/yaml-configs/colbert-1M.yml
@@ -1,0 +1,33 @@
+version: 4
+
+dataset: colbert-1M
+
+construction:
+  outDegree: [32]
+  efConstruction: [100]
+  neighborOverflow: [1.2f]
+  addHierarchy: [Yes]
+  compression:
+    - type: PQ
+      parameters:
+        m: 32 # we can either specify the integer m or the integer mFactor. In this case, m will be set to the data dimensionality divided by mFactor
+        # mFactor: 8
+        # k: 256 # optional parameter. By default, k=256
+        centerData: No
+        anisotropicThreshold: -1.0 # optional parameter. By default, anisotropicThreshold=-1 (i.e., no anisotropy)
+  reranking:
+    - NVQ
+  useSavedIndexIfExists: Yes
+
+search:
+  topKOverquery:
+    10: [1.0, 2.0, 5.0, 10.0]
+    100: [1.0, 2.0]
+  useSearchPruning: [Yes]
+  compression:
+    - type: PQ
+      parameters:
+        m: 32
+        # k: 256 # optional parameter. By default, k=256
+        centerData: No
+        anisotropicThreshold: -1.0 # optional parameter. By default, anisotropicThreshold=-1 (i.e., no anisotropy)


### PR DESCRIPTION
This PR:
- Fixes a bug where, if one of the sections in the YAML file is empty, the key in datasetNames will have a null value. In that case, DatasetCollection.load was failing.
- Adds a YAML file for colbert-1M because its lower dimensionality was not compatible with the default 192 segments used by the other datasets
