### PR TITLE
Sequential disk writer

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/BufferedRandomAccessWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/BufferedRandomAccessWriter.java
@@ -34,6 +34,7 @@ public class BufferedRandomAccessWriter implements RandomAccessWriter {
     // that we need to be careful to flush the buffer when seeking to a new position.
     private final RandomAccessFile raf;
     private final DataOutputStream stream;
+    private volatile long bytesWrittenSinceStart = 0;
 
     public BufferedRandomAccessWriter(Path path) throws FileNotFoundException {
         raf = new RandomAccessFile(path.toFile(), "rw");
@@ -77,9 +78,19 @@ public class BufferedRandomAccessWriter implements RandomAccessWriter {
     }
 
     @Override
+    public void resetStartWritingOffset() throws IOException {
+        bytesWrittenSinceStart = 0;
+    }
+
+    @Override
     public long position() throws IOException {
         flush();
         return raf.getFilePointer();
+    }
+
+    @Override
+    public long bytesWrittenSinceStart() {
+        return bytesWrittenSinceStart;
     }
 
     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/BufferedRandomAccessWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/BufferedRandomAccessWriter.java
@@ -34,7 +34,6 @@ public class BufferedRandomAccessWriter implements RandomAccessWriter {
     // that we need to be careful to flush the buffer when seeking to a new position.
     private final RandomAccessFile raf;
     private final DataOutputStream stream;
-    private volatile long bytesWrittenSinceStart = 0;
 
     public BufferedRandomAccessWriter(Path path) throws FileNotFoundException {
         raf = new RandomAccessFile(path.toFile(), "rw");
@@ -78,19 +77,9 @@ public class BufferedRandomAccessWriter implements RandomAccessWriter {
     }
 
     @Override
-    public void resetStartWritingOffset() throws IOException {
-        bytesWrittenSinceStart = 0;
-    }
-
-    @Override
     public long position() throws IOException {
         flush();
         return raf.getFilePointer();
-    }
-
-    @Override
-    public long bytesWrittenSinceStart() {
-        return bytesWrittenSinceStart;
     }
 
     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/ByteBufferReader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/ByteBufferReader.java
@@ -100,4 +100,9 @@ public class ByteBufferReader implements RandomAccessReader {
     @Override
     public void close() {
     }
+
+    @Override
+    public long length() throws IOException {
+        return bb.limit();
+    }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexWriter.java
@@ -16,13 +16,13 @@
 
 package io.github.jbellis.jvector.disk;
 
+import java.io.Closeable;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public interface IndexWriter extends DataOutput {
-    void resetStartWritingOffset() throws IOException;
-
+public interface IndexWriter extends DataOutput, Closeable {
+    /**
+     * @return the current position in the output
+     */
     long position() throws IOException;
-
-    long bytesWrittenSinceStart() throws IOException;
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexWriter.java
@@ -20,5 +20,9 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public interface IndexWriter extends DataOutput {
+    void resetStartWritingOffset() throws IOException;
+
     long position() throws IOException;
+
+    long bytesWrittenSinceStart() throws IOException;
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexWriter.java
@@ -1,0 +1,8 @@
+package io.github.jbellis.jvector.disk;
+
+import java.io.DataOutput;
+import java.io.IOException;
+
+public interface IndexWriter extends DataOutput {
+    long position() throws IOException;
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.jbellis.jvector.disk;
 
 import java.io.DataOutput;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessReader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessReader.java
@@ -57,4 +57,7 @@ public interface RandomAccessReader extends AutoCloseable {
     void read(float[] floats, int offset, int count) throws IOException;
 
     void close() throws IOException;
+
+    // Length of the reader slice
+    long length() throws IOException;
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessWriter.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 /**
  * A DataOutput that adds methods for random access writes
  */
-public interface RandomAccessWriter extends IndexWriter, Closeable {
+public interface RandomAccessWriter extends IndexWriter {
     void seek(long position) throws IOException;
 
     void flush() throws IOException;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessWriter.java
@@ -23,10 +23,8 @@ import java.io.IOException;
 /**
  * A DataOutput that adds methods for random access writes
  */
-public interface RandomAccessWriter extends DataOutput, Closeable {
+public interface RandomAccessWriter extends IndexWriter, Closeable {
     void seek(long position) throws IOException;
-
-    long position() throws IOException;
 
     void flush() throws IOException;
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleReader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleReader.java
@@ -100,6 +100,11 @@ public class SimpleReader implements RandomAccessReader {
         raf.close();
     }
 
+    @Override
+    public long length() throws IOException {
+        return raf.length();
+    }
+
     public static class Supplier implements ReaderSupplier {
         private final Path path;
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleWriter.java
@@ -130,6 +130,7 @@ public class SimpleWriter implements IndexWriter {
 
     @Override
     public void close() throws IOException {
+        dos.flush();
         dos.close();
         fos.close();
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleWriter.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.disk;
+
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.zip.CRC32;
+
+/**
+ * A simple implementation of IndexWriter that writes to a file.
+ * This implementation is primarily for testing purposes.
+ */
+public class SimpleWriter implements IndexWriter {
+    private final FileOutputStream fos;
+    private final DataOutputStream dos;
+    private volatile long bytesWrittenSinceStart = 0;
+    private long startPosition = 0;
+
+    public SimpleWriter(Path path) throws IOException {
+        fos = new FileOutputStream(path.toFile());
+        dos = new DataOutputStream(fos);
+    }
+
+    @Override
+    public long position() throws IOException {
+        dos.flush();
+        return fos.getChannel().position();
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        dos.write(b);
+        bytesWrittenSinceStart++;
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        dos.write(b);
+        bytesWrittenSinceStart += b.length;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        dos.write(b, off, len);
+        bytesWrittenSinceStart += len;
+    }
+
+    @Override
+    public void writeBoolean(boolean v) throws IOException {
+        dos.writeBoolean(v);
+        bytesWrittenSinceStart++;
+    }
+
+    @Override
+    public void writeByte(int v) throws IOException {
+        dos.writeByte(v);
+        bytesWrittenSinceStart++;
+    }
+
+    @Override
+    public void writeShort(int v) throws IOException {
+        dos.writeShort(v);
+        bytesWrittenSinceStart += 2;
+    }
+
+    @Override
+    public void writeChar(int v) throws IOException {
+        dos.writeChar(v);
+        bytesWrittenSinceStart += 2;
+    }
+
+    @Override
+    public void writeInt(int v) throws IOException {
+        dos.writeInt(v);
+        bytesWrittenSinceStart += 4;
+    }
+
+    @Override
+    public void writeLong(long v) throws IOException {
+        dos.writeLong(v);
+        bytesWrittenSinceStart += 8;
+    }
+
+    @Override
+    public void writeFloat(float v) throws IOException {
+        dos.writeFloat(v);
+        bytesWrittenSinceStart += 4;
+    }
+
+    @Override
+    public void writeDouble(double v) throws IOException {
+        dos.writeDouble(v);
+        bytesWrittenSinceStart += 8;
+    }
+
+    @Override
+    public void writeBytes(String s) throws IOException {
+        dos.writeBytes(s);
+        bytesWrittenSinceStart += s.length();
+    }
+
+    @Override
+    public void writeChars(String s) throws IOException {
+        dos.writeChars(s);
+        bytesWrittenSinceStart += s.length() * 2;
+    }
+
+    @Override
+    public void writeUTF(String s) throws IOException {
+        dos.writeUTF(s);
+        // UTF encoding adds variable length, so we need to recalculate position
+        bytesWrittenSinceStart = fos.getChannel().position() - startPosition;
+    }
+
+    @Override
+    public void close() throws IOException {
+        dos.close();
+        fos.close();
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/AbstractGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/AbstractGraphIndexWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.jbellis.jvector.graph.disk;
 
 import io.github.jbellis.jvector.disk.IndexWriter;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/AbstractGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/AbstractGraphIndexWriter.java
@@ -1,0 +1,154 @@
+package io.github.jbellis.jvector.graph.disk;
+
+import io.github.jbellis.jvector.disk.IndexWriter;
+import io.github.jbellis.jvector.graph.GraphIndex;
+import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
+import io.github.jbellis.jvector.graph.disk.feature.Feature;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.SeparatedFeature;
+import org.agrona.collections.Int2IntHashMap;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public abstract class AbstractGraphIndexWriter implements  GraphIndexWriter {
+    public static final int FOOTER_MAGIC = 0x4a564244; // "EOF magic"
+    public static final int FOOTER_OFFSET_SIZE = Long.BYTES; // The size of the offset in the footer
+    public static final int FOOTER_MAGIC_SIZE = Integer.BYTES; // The size of the magic number in the footer
+    public static final int FOOTER_SIZE = FOOTER_MAGIC_SIZE + FOOTER_OFFSET_SIZE; // The total size of the footer
+    final int version;
+    final GraphIndex graph;
+    final GraphIndex.View view;
+    final OrdinalMapper ordinalMapper;
+    final int dimension;
+    // we don't use Map features but EnumMap is the best way to make sure we don't
+    // accidentally introduce an ordering bug in the future
+    final EnumMap<FeatureId, Feature> featureMap;
+    final IndexWriter out; /* output for graph nodes and inline features */
+    final int headerSize;
+    volatile int maxOrdinalWritten = -1;
+    final List<Feature> inlineFeatures;
+
+    AbstractGraphIndexWriter(IndexWriter out,
+                                     int version,
+                                     GraphIndex graph,
+                                     OrdinalMapper oldToNewOrdinals,
+                                     int dimension,
+                                     EnumMap<FeatureId, Feature> features)
+    {
+        if (graph.getMaxLevel() > 0 && version < 4) {
+            throw new IllegalArgumentException("Multilayer graphs must be written with version 4 or higher");
+        }
+        this.version = version;
+        this.graph = graph;
+        this.view = graph instanceof OnHeapGraphIndex ? ((OnHeapGraphIndex) graph).getFrozenView() : graph.getView();
+        this.ordinalMapper = oldToNewOrdinals;
+        this.dimension = dimension;
+        this.featureMap = features;
+        this.inlineFeatures = features.values().stream().filter(f -> !(f instanceof SeparatedFeature)).collect(Collectors.toList());
+        this.out = out;
+
+        // create a mock Header to determine the correct size
+        var layerInfo = CommonHeader.LayerInfo.fromGraph(graph, ordinalMapper);
+        var ch = new CommonHeader(version, dimension, 0, layerInfo, 0);
+        var placeholderHeader = new Header(ch, featureMap);
+        this.headerSize = placeholderHeader.size();
+    }
+
+    /**
+     * @return the maximum ordinal written so far, or -1 if no ordinals have been written yet
+     */
+    public int getMaxOrdinal() {
+        return maxOrdinalWritten;
+    }
+
+    public Set<FeatureId> getFeatureSet() {
+        return featureMap.keySet();
+    }
+
+    long featureOffsetForOrdinal(long startOffset, int ordinal) {
+        int edgeSize = Integer.BYTES * (1 + graph.getDegree(0));
+        long inlineBytes = ordinal * (long) (Integer.BYTES + inlineFeatures.stream().mapToInt(Feature::featureSize).sum() + edgeSize);
+        return startOffset
+                + headerSize
+                + inlineBytes // previous nodes
+                + Integer.BYTES; // the ordinal of the node whose features we're about to write
+    }
+
+    boolean isSeparated(Feature feature) {
+        return feature instanceof SeparatedFeature;
+    }
+
+    /**
+     * @return a Map of old to new graph ordinals where the new ordinals are sequential starting at 0,
+     * while preserving the original relative ordering in `graph`.  That is, for all node ids i and j,
+     * if i &lt; j in `graph` then map[i] &lt; map[j] in the returned map.  "Holes" left by
+     * deleted nodes are filled in by shifting down the new ordinals.
+     */
+    public static Map<Integer, Integer> sequentialRenumbering(GraphIndex graph) {
+        try (var view = graph.getView()) {
+            Int2IntHashMap oldToNewMap = new Int2IntHashMap(-1);
+            int nextOrdinal = 0;
+            for (int i = 0; i < view.getIdUpperBound(); i++) {
+                if (graph.containsNode(i)) {
+                    oldToNewMap.put(i, nextOrdinal++);
+                }
+            }
+            return oldToNewMap;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Write the {@link Header} as a footer for the graph index.
+     * <p>
+     * To read the graph later, we will perform the following steps:
+     * <ol>
+     *     <li> Find the magic number at the end of the slice
+     *     <li> Read the header offset from the end of the slice
+     *     <li> Read the header
+     *     <li> Read the neighbors offsets and graph metadata
+     * </ol>
+     * @param headerOffset the offset of the header in the slice
+     * @throws IOException IOException
+     */
+    void writeFooter(long headerOffset) throws IOException {
+        var layerInfo = CommonHeader.LayerInfo.fromGraph(graph, ordinalMapper);
+        var commonHeader = new CommonHeader(version,
+                dimension,
+                ordinalMapper.oldToNew(view.entryNode().node),
+                layerInfo,
+                ordinalMapper.maxOrdinal() + 1);
+        var header = new Header(commonHeader, featureMap);
+        header.write(out); // write the header
+        out.writeLong(headerOffset); // We write the offset of the header at the end of the file
+        out.writeInt(FOOTER_MAGIC);
+        final long expectedPosition = headerOffset + headerSize + FOOTER_SIZE;
+        assert out.position() == expectedPosition : String.format("%d != %d", out.position(), expectedPosition);
+    }
+
+    /**
+     * Writes the index header, including the graph size, so that OnDiskGraphIndex can open it.
+     * The output IS flushed.
+     * <p>
+     * Public so that you can write the index size (and thus usefully open an OnDiskGraphIndex against the index)
+     * to read Features from it before writing the edges.
+     */
+    public synchronized void writeHeader(long startOffset) throws IOException {
+        // graph-level properties
+        var layerInfo = CommonHeader.LayerInfo.fromGraph(graph, ordinalMapper);
+        var commonHeader = new CommonHeader(version,
+                dimension,
+                ordinalMapper.oldToNew(view.entryNode().node),
+                layerInfo,
+                ordinalMapper.maxOrdinal() + 1);
+        var header = new Header(commonHeader, featureMap);
+        header.write(out);
+        assert out.position() == startOffset + headerSize : String.format("%d != %d", out.position(), startOffset + headerSize);
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/CommonHeader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/CommonHeader.java
@@ -17,6 +17,7 @@
 package io.github.jbellis.jvector.graph.disk;
 
 import io.github.jbellis.jvector.annotations.VisibleForTesting;
+import io.github.jbellis.jvector.disk.IndexWriter;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.RandomAccessWriter;
 import io.github.jbellis.jvector.graph.GraphIndex;
@@ -32,7 +33,30 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * Base header for OnDiskGraphIndex functionality.
+ * Base header for OnDiskGraphIndex functionality, containing essential metadata about the graph structure.
+ * <p>
+ * This class stores:
+ * - Version information for format compatibility
+ * - Vector dimension
+ * - Entry node for graph traversal
+ * - Layer information for multi-layer graphs (HNSW)
+ * - ID upper bound (maximum node ID + 1)
+ * <p>
+ * The format evolves across versions:
+ * - v2: Basic format with no magic number
+ * - v3: Added magic number and feature set support
+ * - v4: Added multi-layer support and ID upper bound
+ * <p>
+ * The on-disk layout for v4+ is:
+ * - Magic number (to identify JVector files)
+ * - Version
+ * - Base layer size
+ * - Vector dimension
+ * - Entry node ID
+ * - Base layer max degree
+ * - ID upper bound
+ * - Number of layers
+ * - Layer info (size and degree for each layer)
  */
 public class CommonHeader {
     private static final Logger logger = LoggerFactory.getLogger(CommonHeader.class);
@@ -53,7 +77,7 @@ public class CommonHeader {
         this.idUpperBound = idUpperBound;
     }
 
-    void write(RandomAccessWriter out) throws IOException {
+    void write(IndexWriter out) throws IOException {
         logger.debug("Writing common header at position {}", out.position());
         if (version >= 3) {
             out.writeInt(OnDiskGraphIndex.MAGIC);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/GraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/GraphIndexWriter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph.disk;
+
+import io.github.jbellis.jvector.graph.disk.feature.Feature;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.IntFunction;
+
+/**
+ * writes a graph index to a target
+ */
+public interface GraphIndexWriter extends Closeable {
+    /**
+     * Write the index header and completed edge lists to the given outputs.  Inline features given in
+     * `featureStateSuppliers` will also be written.  (Features that do not have a supplier are assumed
+     * to have already been written by calls to writeInline).
+     * <p>
+     * Each supplier takes a node ordinal and returns a FeatureState suitable for Feature.writeInline.
+     *
+     * @param featureStateSuppliers a map of FeatureId to a function that returns a Feature.State
+     */
+    void write(Map<FeatureId, IntFunction<Feature.State>> featureStateSuppliers) throws IOException;
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/Header.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/Header.java
@@ -16,6 +16,7 @@
 
 package io.github.jbellis.jvector.graph.disk;
 
+import io.github.jbellis.jvector.disk.IndexWriter;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.RandomAccessWriter;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
@@ -27,7 +28,15 @@ import java.util.EnumMap;
 import java.util.EnumSet;
 
 /**
- * Header information for an on-disk graph index, reflecting the common header and feature-specific headers.
+ * Header information for an on-disk graph index, containing both common metadata and feature-specific headers.
+ * <p>
+ * This class encapsulates:
+ * - Common header information (version, dimension, entry node, etc.)
+ * - Feature set information (which features are included in the index)
+ * - Feature-specific header data
+ * <p>
+ * The header can be written at the beginning of the index file or alternatively in a separate metadata file and is read when loading an index.
+ * It provides all the metadata needed to correctly interpret the on-disk format of the graph.
  */
 class Header {
     final CommonHeader common;
@@ -38,7 +47,7 @@ class Header {
         this.features = features;
     }
 
-    void write(RandomAccessWriter out) throws IOException {
+    void write(IndexWriter out) throws IOException {
         common.write(out);
 
         if (common.version >= 3) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -202,7 +202,6 @@ public class OnDiskGraphIndex implements GraphIndex, AutoCloseable, Accountable
                     header.common.entryNode,
                     header.common.layerInfo.size(),
                     in.getPosition());
-            // TODO: record neighbors offset in the footer
             return new OnDiskGraphIndex(readerSupplier, header, neighborsOffset);
         } catch (Exception e) {
             throw new RuntimeException("Error initializing OnDiskGraph", e);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -253,11 +253,12 @@ public class OnDiskGraphIndex implements GraphIndex, AutoCloseable, Accountable
             int[] validNodes = new int[size(level)];
             int upperBound = level == 0 ? getIdUpperBound() : size(level);
             int pos = 0;
-            for (int node = 0; node < upperBound; node++) {
-                long nodeOffset = layerOffset + (node * thisLayerNodeSide);
+            for (int nodeOrd = 0; nodeOrd < upperBound; nodeOrd++) {
+                long nodeOffset = layerOffset + (nodeOrd * thisLayerNodeSide);
                 reader.seek(nodeOffset);
-                if (reader.readInt() != -1) {
-                    validNodes[pos++] = node;
+                int nodeId = reader.readInt();
+                if (nodeId != -1) {
+                    validNodes[pos++] = nodeId;
                 }
             }
             return new NodesIterator.ArrayNodesIterator(validNodes, size);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskSequentialGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskSequentialGraphIndexWriter.java
@@ -16,19 +16,13 @@
 
 package io.github.jbellis.jvector.graph.disk;
 
-import io.github.jbellis.jvector.disk.BufferedRandomAccessWriter;
 import io.github.jbellis.jvector.disk.IndexWriter;
-import io.github.jbellis.jvector.disk.RandomAccessWriter;
 import io.github.jbellis.jvector.graph.GraphIndex;
 import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
 import io.github.jbellis.jvector.graph.disk.feature.*;
 import org.agrona.collections.Int2IntHashMap;
 
-import java.io.Closeable;
-import java.io.DataOutput;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -39,31 +33,35 @@ import java.util.stream.Collectors;
 /**
  * Writes a graph index to disk in a format that can be loaded as an OnDiskGraphIndex.
  * <p>
- * Unlike {@link OnDiskGraphIndexWriter}, this class always writes in a sequential order and separates header metadata into a separate file.
+ * Unlike {@link OnDiskGraphIndexWriter}, this class always writes in a sequential order and the header metadata is written as the footer.
  * <p>
  * Assumptions:
- * <l>
+ * <ul>
  * <li> The graph already exists and is not modified as it is being written, and therefore can be written sequentially in a single pass.
  * <li> This assumption is valid for two common cases in Log Structure Merge Tree-based systems such as Cassandra and Lucene:
  *   <ol>
  *   <li> The graph is being written as part of compaction
  *   <li> The graph is being written for addition of a small immutable segment.
- *   <ol>
- * </l>
+ *   </ol>
+ * </ul>
  * <p>
  * Goals:
- * <ol>
+ * <ul>
  * <li> Immutability: Every byte written to the index file is immutable. This allows for running calculation of checksums without needing to re-read the file.
  * <li> Performance: We can take advantage of sequential writes for performance.
- * </ol>
+ * </ul>
  * <p>
  * The above goals are driven by the following motivations:
- * <ol>
+ * <ul>
  * <li> When we work with either cloud object storage where random writes are not supported on a single stream
  * <li> When we embed jVector in frameworks such as Lucene that rely on sequential writes for performance and correctness
- * </ol>
+ * </ul>
  */
 public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
+    public static final int FOOTER_MAGIC = 0x4a564244; // "EOF magic"
+    public static final int FOOTER_OFFSET_SIZE = Long.BYTES; // The size of the offset in the footer
+    public static final int FOOTER_MAGIC_SIZE = Integer.BYTES; // The size of the magic number in the footer
+    public static final int FOOTER_SIZE = FOOTER_MAGIC_SIZE + FOOTER_OFFSET_SIZE; // The total size of the footer
     private final int version;
     private final GraphIndex graph;
     private final GraphIndex.View view;
@@ -72,14 +70,12 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
     // we don't use Map features but EnumMap is the best way to make sure we don't
     // accidentally introduce an ordering bug in the future
     private final EnumMap<FeatureId, Feature> featureMap;
-    private final IndexWriter dataOut; /* output for graph nodes and inline features */
-    private final IndexWriter metadataOut; /* output for graph {@link Header} metadata */
+    private final IndexWriter out; /* output for graph nodes and inline features */
     private final int headerSize;
     private volatile int maxOrdinalWritten = -1;
     private final List<Feature> inlineFeatures;
 
-    private OnDiskSequentialGraphIndexWriter(IndexWriter dataOut,
-                                             IndexWriter metadataOut,
+    private OnDiskSequentialGraphIndexWriter(IndexWriter out,
                                              int version,
                                              GraphIndex graph,
                                              OrdinalMapper oldToNewOrdinals,
@@ -96,8 +92,7 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
         this.dimension = dimension;
         this.featureMap = features;
         this.inlineFeatures = features.values().stream().filter(f -> !(f instanceof SeparatedFeature)).collect(Collectors.toList());
-        this.dataOut = dataOut;
-        this.metadataOut = metadataOut;
+        this.out = out;
 
         // create a mock Header to determine the correct size
         var layerInfo = CommonHeader.LayerInfo.fromGraph(graph, ordinalMapper);
@@ -123,11 +118,10 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
         return maxOrdinalWritten;
     }
 
-    private long featureOffsetForOrdinal(long startOffset, int ordinal) {
+    private long featureOffsetForOrdinal(int ordinal) {
         int edgeSize = Integer.BYTES * (1 + graph.getDegree(0));
         long inlineBytes = ordinal * (long) (Integer.BYTES + inlineFeatures.stream().mapToInt(Feature::featureSize).sum() + edgeSize);
-        return startOffset
-                + inlineBytes // previous nodes
+        return inlineBytes // previous nodes
                 + Integer.BYTES; // the ordinal of the node whose features we're about to write
     }
 
@@ -137,14 +131,16 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
 
     /**
      * Note: There are several limitations you should be aware of when using:
+     * <ul>
      * <li> This method doesn't persist (e.g. flush) the output streams.  The caller is responsible for doing so.
      * <li> This method does not support writing to "holes" in the ordinal space.  If your ordinal mapper
      *      maps a new ordinal to an old ordinal that does not exist in the graph, an exception will be thrown.
+     * </ul>
      */
     @Override
     public synchronized void write(Map<FeatureId, IntFunction<Feature.State>> featureStateSuppliers) throws IOException
     {
-        final long startOffset = dataOut.position();
+        out.resetStartWritingOffset();
         if (graph instanceof OnHeapGraphIndex) {
             var ohgi = (OnHeapGraphIndex) graph;
             if (ohgi.getDeletedNodes().cardinality() > 0) {
@@ -175,14 +171,14 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
                 var msg = String.format("Ordinal mapper mapped new ordinal %s to non-existing node %s", newOrdinal, originalOrdinal);
                 throw new IllegalStateException(msg);
             }
-            dataOut.writeInt(newOrdinal); // unnecessary, but a reasonable sanity check
-            assert dataOut.position() == featureOffsetForOrdinal(startOffset, newOrdinal) : String.format("%d != %d", dataOut.position(), featureOffsetForOrdinal(startOffset, newOrdinal));
+            out.writeInt(newOrdinal); // unnecessary, but a reasonable sanity check
+            assert out.bytesWrittenSinceStart() == featureOffsetForOrdinal(newOrdinal) : String.format("%d != %d", out.bytesWrittenSinceStart(), featureOffsetForOrdinal(newOrdinal));
             for (var feature : inlineFeatures) {
                 var supplier = featureStateSuppliers.get(feature.id());
                 if (supplier == null) {
                     throw new IllegalStateException("Supplier for feature " + feature.id() + " not found");
                 } else {
-                    feature.writeInline(dataOut, supplier.apply(originalOrdinal));
+                    feature.writeInline(out, supplier.apply(originalOrdinal));
                 }
             }
 
@@ -193,7 +189,7 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
                 throw new IllegalStateException(msg);
             }
             // write neighbors list
-            dataOut.writeInt(neighbors.size());
+            out.writeInt(neighbors.size());
             int n = 0;
             for (; n < neighbors.size(); n++) {
                 var newNeighborOrdinal = ordinalMapper.oldToNew(neighbors.nextInt());
@@ -201,13 +197,13 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
                     var msg = String.format("Neighbor ordinal out of bounds: %d/%d", newNeighborOrdinal, ordinalMapper.maxOrdinal());
                     throw new IllegalStateException(msg);
                 }
-                dataOut.writeInt(newNeighborOrdinal);
+                out.writeInt(newNeighborOrdinal);
             }
             assert !neighbors.hasNext();
 
             // pad out to maxEdgesPerNode
             for (; n < graph.getDegree(0); n++) {
-                dataOut.writeInt(-1);
+                out.writeInt(-1);
             }
         }
 
@@ -219,18 +215,18 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
             for (var it = graph.getNodes(level); it.hasNext(); ) {
                 int originalOrdinal = it.nextInt();
                 // node id
-                dataOut.writeInt(ordinalMapper.oldToNew(originalOrdinal));
+                out.writeInt(ordinalMapper.oldToNew(originalOrdinal));
                 // neighbors
                 var neighbors = view.getNeighborsIterator(level, originalOrdinal);
-                dataOut.writeInt(neighbors.size());
+                out.writeInt(neighbors.size());
                 int n = 0;
                 for ( ; n < neighbors.size(); n++) {
-                    dataOut.writeInt(ordinalMapper.oldToNew(neighbors.nextInt()));
+                    out.writeInt(ordinalMapper.oldToNew(neighbors.nextInt()));
                 }
                 assert !neighbors.hasNext() : "Mismatch between neighbor's reported size and actual size";
                 // pad out to degree
                 for (; n < layerDegree; n++) {
-                    dataOut.writeInt(-1);
+                    out.writeInt(-1);
                 }
                 nodesWritten++;
             }
@@ -250,13 +246,13 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
 
                 // Set the offset for this feature
                 var feature = (SeparatedFeature) featureEntry.getValue();
-                feature.setOffset(dataOut.position());
+                feature.setOffset(out.bytesWrittenSinceStart());
 
                 // Write separated data for each node
                 for (int newOrdinal = 0; newOrdinal <= ordinalMapper.maxOrdinal(); newOrdinal++) {
                     int originalOrdinal = ordinalMapper.newToOld(newOrdinal);
                     if (originalOrdinal != OrdinalMapper.OMITTED) {
-                        feature.writeSeparately(dataOut, supplier.apply(originalOrdinal));
+                        feature.writeSeparately(out, supplier.apply(originalOrdinal));
                     } else {
                         throw new IllegalStateException("Ordinal mapper mapped new ordinal" + newOrdinal + " to non-existing node. This behavior is not supported on OnDiskSequentialGraphIndexWriter. Use OnDiskGraphIndexWriter instead.");
                     }
@@ -264,18 +260,25 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
             }
         }
 
-        // Write the header with the offsets
-        writeHeader(startOffset);
+        // Writer the footer with all the metadata info about the graph
+        writeFooter(out.bytesWrittenSinceStart());
         // Note: flushing the data output is the responsibility of the caller we are not going to make assumptions about further uses of the data outputs
     }
 
     /**
-     * Writes the index header, including the graph size, so that OnDiskGraphIndex can open it.
+     * Write the {@link Header} as a footer for the graph index.
      * <p>
-     * Public so that you can write the index size (and thus usefully open an OnDiskGraphIndex against the index)
-     * to read Features from it before writing the edges.
+     * To read the graph later, we will perform the following steps:
+     * <ol>
+     *     <li> Find the magic number at the end of the slice
+     *     <li> Read the header offset from the end of the slice
+     *     <li> Read the header
+     *     <li> Read the neighbors offsets and graph metadata
+     * </ol>
+     * @param headerOffset the offset of the header in the slice
+     * @throws IOException IOException
      */
-    public synchronized void writeHeader(long startOffset) throws IOException {
+    private void writeFooter(long headerOffset) throws IOException {
         var layerInfo = CommonHeader.LayerInfo.fromGraph(graph, ordinalMapper);
         var commonHeader = new CommonHeader(version,
                 dimension,
@@ -283,8 +286,11 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
                 layerInfo,
                 ordinalMapper.maxOrdinal() + 1);
         var header = new Header(commonHeader, featureMap);
-        header.write(metadataOut);
-        assert metadataOut.position() == startOffset + headerSize : String.format("%d != %d", metadataOut.position(), startOffset + headerSize);
+        header.write(out); // write the header
+        out.writeLong(headerOffset); // We write the offset of the header at the end of the file
+        out.writeInt(FOOTER_MAGIC);
+        final long expectedPosition = headerOffset + headerSize + FOOTER_SIZE;
+        assert out.bytesWrittenSinceStart() == expectedPosition : String.format("%d != %d", out.bytesWrittenSinceStart(), expectedPosition);
     }
 
     /**
@@ -367,7 +373,7 @@ public class OnDiskSequentialGraphIndexWriter implements GraphIndexWriter {
             if (ordinalMapper == null) {
                 ordinalMapper = new OrdinalMapper.MapMapper(sequentialRenumbering(graphIndex));
             }
-            return new OnDiskSequentialGraphIndexWriter(dataOut, metadataOut, version, graphIndex, ordinalMapper, dimension, features);
+            return new OnDiskSequentialGraphIndexWriter(dataOut, version, graphIndex, ordinalMapper, dimension, features);
         }
 
         public Builder withMap(Map<Integer, Integer> oldToNewOrdinals) {

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/MMapReader.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/MMapReader.java
@@ -137,6 +137,11 @@ public class MMapReader implements RandomAccessReader {
     }
 
     @Override
+    public long length() {
+        return buffer.memory().length();
+    }
+
+    @Override
     public void close() {
         // don't close buffer, let the Supplier handle that
     }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/disk/MemorySegmentReader.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/disk/MemorySegmentReader.java
@@ -126,6 +126,11 @@ public class MemorySegmentReader implements RandomAccessReader {
         position += count * 4L;
     }
 
+    @Override
+    public long length() {
+        return memory.byteSize();
+    }
+
     /**
      * Loads the contents of the mapped segment into physical memory.
      * This is a best-effort mechanism.

--- a/jvector-tests/pom.xml
+++ b/jvector-tests/pom.xml
@@ -135,6 +135,21 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
+        <!-- Log4j Core implementation -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.20.0</version>
+            <scope>test</scope>
+        </dependency>
+        
+        <!-- SLF4J to Log4j bridge -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.20.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
@@ -218,7 +218,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
         }
     }
 
-    private static void validateVectors(OnDiskGraphIndex.View view, RandomAccessVectorValues ravv) {
+    public static void validateVectors(OnDiskGraphIndex.View view, RandomAccessVectorValues ravv) {
         for (int i = 0; i < view.size(); i++) {
             assertEquals("Incorrect vector at " + i, ravv.getVector(i), view.getVector(i));
         }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskSequentialGraphIndexWriter.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskSequentialGraphIndexWriter.java
@@ -1,0 +1,159 @@
+package io.github.jbellis.jvector.graph.disk;
+
+import io.github.jbellis.jvector.disk.SimpleMappedReader;
+import io.github.jbellis.jvector.disk.SimpleWriter;
+import io.github.jbellis.jvector.graph.GraphIndex;
+import io.github.jbellis.jvector.graph.GraphIndexBuilder;
+import io.github.jbellis.jvector.graph.MockVectorValues;
+import io.github.jbellis.jvector.graph.TestUtil;
+import io.github.jbellis.jvector.graph.disk.feature.Feature;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class OnDiskSequentialGraphIndexWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    private float[][] createRandomFloatVectors(int size, int dimension, Random random) {
+        float[][] vectors = new float[size][dimension];
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < dimension; j++) {
+                vectors[i][j] = random.nextFloat();
+            }
+        }
+        return vectors;
+    }
+
+    @Test
+    public void testWriteAndLoadFromFooter() throws IOException {
+        // Setup test parameters
+        int dimension = 16;
+        int size = 50;
+        int maxConnections = 8;
+        Random random = new Random(42);
+        
+        // Create random vectors and build a graph
+        var ravv = MockVectorValues.fromValues(createRandomFloatVectors(size, dimension, random));
+        var builder = new GraphIndexBuilder(ravv, VectorSimilarityFunction.COSINE, 2, maxConnections, 1.0f, 1.0f, true);
+        GraphIndex graph = TestUtil.buildSequentially(builder, ravv);
+        
+        // Create a sequential writer and write the graph
+        Path indexPath = tempDir.resolve("sequential_graph.data");
+        try (var out = new SimpleWriter(indexPath)) {
+            var ordinalMapper = new OrdinalMapper.MapMapper(OnDiskSequentialGraphIndexWriter.sequentialRenumbering(graph));
+            var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, out)
+                    .with(new InlineVectors(dimension))
+                    .withMapper(ordinalMapper)
+                    .build();
+            
+            // Create feature state suppliers
+            var suppliers = Feature.singleStateFactory(FeatureId.INLINE_VECTORS,
+                    nodeId -> new InlineVectors.State(ravv.getVector(nodeId)));
+            
+            // Write the graph
+            writer.write(suppliers);
+            
+            // Write the footer
+            long headerOffset = out.bytesWrittenSinceStart();
+            writer.writeFooter(headerOffset);
+        }
+        
+        // Load the graph using loadFromFooter
+        try (var readerSupplier = new SimpleMappedReader.Supplier(indexPath)) {
+            var loadedGraph = OnDiskGraphIndex.loadFromFooter(readerSupplier);
+            
+            // Validate the loaded graph
+            assertNotNull(loadedGraph);
+            assertEquals(size, loadedGraph.size());
+            assertEquals(dimension, loadedGraph.getDimension());
+            
+            // Verify graph structure by checking a few nodes
+            try (var view = loadedGraph.getView()) {
+                // Check entry node exists
+                assertNotNull(view.entryNode());
+                
+                // Check a few random nodes have neighbors
+                for (int i = 0; i < 5; i++) {
+                    int nodeId = random.nextInt(size);
+                    var neighbors = view.getNeighborsIterator(0, nodeId);
+                    // At least the entry node should have neighbors
+                    if (nodeId == view.entryNode().node) {
+                        assert(neighbors.size() > 0);
+                    }
+                }
+            }
+        }
+    }
+    
+    @Test
+    public void testMultiLayerGraphWriteAndLoad() throws IOException {
+        // Setup test parameters for multi-layer graph
+        int dimension = 16;
+        int size = 100;
+        int maxConnections = 8;
+        Random random = new Random(42);
+        
+        // Create random vectors and build a multi-layer graph
+        var ravv = MockVectorValues.fromValues(createRandomFloatVectors(size, dimension, random));
+        var builder = new GraphIndexBuilder(ravv, VectorSimilarityFunction.COSINE, 2, maxConnections, 1.0f, 1.0f, true);
+        builder.setNumLayers(2); // Set multiple layers
+        GraphIndex graph = TestUtil.buildSequentially(builder, ravv);
+        
+        // Create a sequential writer and write the graph
+        Path indexPath = tempDir.resolve("multilayer_graph.data");
+        try (var out = new SimpleWriter(indexPath)) {
+            var ordinalMapper = new OrdinalMapper.MapMapper(OnDiskSequentialGraphIndexWriter.sequentialRenumbering(graph));
+            var writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, out)
+                    .with(new InlineVectors(dimension))
+                    .withMapper(ordinalMapper)
+                    .build();
+            
+            // Create feature state suppliers
+            var suppliers = Feature.singleStateFactory(FeatureId.INLINE_VECTORS,
+                    nodeId -> new InlineVectors.State(ravv.getVector(nodeId)));
+            
+            // Write the graph
+            writer.write(suppliers);
+            
+            // Write the footer
+            long headerOffset = out.bytesWrittenSinceStart();
+            writer.writeFooter(headerOffset);
+        }
+        
+        // Load the graph using loadFromFooter
+        try (var readerSupplier = new SimpleMappedReader.Supplier(indexPath)) {
+            var loadedGraph = OnDiskGraphIndex.loadFromFooter(readerSupplier);
+            
+            // Validate the loaded graph
+            assertNotNull(loadedGraph);
+            assertEquals(size, loadedGraph.size());
+            assertEquals(dimension, loadedGraph.getDimension());
+            assertEquals(2, loadedGraph.getMaxLevel()); // Verify multiple layers
+            
+            // Verify graph structure by checking nodes in different layers
+            try (var view = loadedGraph.getView()) {
+                // Check entry node exists in the highest layer
+                assertEquals(2, view.entryNode().level);
+                
+                // Verify we have nodes in layer 1
+                assert(graph.size(1) > 0);
+                
+                // Check that entry node has neighbors in its layer
+                var entryNeighbors = view.getNeighborsIterator(view.entryNode().level, view.entryNode().node);
+                assert(entryNeighbors.size() > 0);
+            }
+        }
+    }
+}

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskSequentialGraphIndexWriter.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskSequentialGraphIndexWriter.java
@@ -29,11 +29,8 @@ import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -42,7 +39,6 @@ import java.util.ArrayList;
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class TestOnDiskSequentialGraphIndexWriter extends LuceneTestCase {
-    private static final Logger log = LoggerFactory.getLogger(TestOnDiskSequentialGraphIndexWriter.class);
     private Path testDirectory;
 
     @Before
@@ -74,7 +70,7 @@ public class TestOnDiskSequentialGraphIndexWriter extends LuceneTestCase {
     public void testMultiLayerGraphWriteAndLoad() throws IOException {
         // Setup test parameters
         int dimension = 2;
-        int size = 20;
+        int size = 50;
         int maxConnections = 8;
         int beamWidth = 100;
         float alpha = 1.2f;

--- a/jvector-tests/src/test/resources/log4j2-test.xml
+++ b/jvector-tests/src/test/resources/log4j2-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+    <!-- Configure specific package log levels -->
+    <Logger name="io.github.jbellis.jvector" level="debug" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
+  </Loggers>
+</Configuration>

--- a/rat-excludes.txt
+++ b/rat-excludes.txt
@@ -12,5 +12,6 @@ src/assembly/mrjar.xml
 src/assembly/sourcesjar.xml
 src/main/java/io/github/jbellis/jvector/vector/cnative/*
 src/main/resources/log4j2.xml
+src/test/resources/log4j2-test.xml
 scripts/test_node_setup.sh
 yaml-configs/*.yml


### PR DESCRIPTION
### Description
Main motivation for this change is to introduce a disk writer that keeps immutability and is pure sequential.
This is essential for integration with frameworks such as Lucene and OpenSearch.

### Changes
Additional changes in this PR
- Introduce `OnDiskSequentialGraphIndexWriter` and abstract the `GraphWriter` interface
- Fix serialization issue where previously written nodeIds were include when calling `getNodes`
- Reuse cache for in memory loaded layers to remove unnecessary disk seeks and bugs due to branching of logic related to offset calculation.

### Tests
Introduce tests for `TestOnDiskSequentialGraphIndexWriter` and add proper configuration for log4j debug logs in tests.