### PR TITLE
Upgrade YAML files to v5 after the format was introduced in the last update

### DIFF
--- a/jvector-examples/yaml-configs/ada002-100k.yml
+++ b/jvector-examples/yaml-configs/ada002-100k.yml
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 dataset: ada002-100k
 

--- a/jvector-examples/yaml-configs/colbert-1M.yml
+++ b/jvector-examples/yaml-configs/colbert-1M.yml
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 dataset: colbert-1M
 

--- a/jvector-examples/yaml-configs/default.yml
+++ b/jvector-examples/yaml-configs/default.yml
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 dataset: cohere-english-v3-100k
 


### PR DESCRIPTION
The YAML files have a version specified so that we are sure to be writing in the right format. The last update bumped the format to v5, but the YAML files were not updated. This PR updates them.