### PR TITLE
TestADCGraphIndex edgeSimilarities and fusedEdgeSimilarities comparision issue fix

### DIFF
--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestADCGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestADCGraphIndex.java
@@ -89,9 +89,10 @@ public class TestADCGraphIndex extends RandomizedTest {
                             assertEquals(pqScoreFunction.similarityTo(neighbor), edgeSimilarities.get(j), 0.01);
                         }
                         // third pass compares fused ADC's edge similarity after quantization to edge similarity before quantization
-                        var fusedEdgeSimilarities = fusedScoreFunction.edgeLoadingSimilarityTo(ordinal);
+                        var edgeSimilaritiesCopy = edgeSimilarities.copy(); // results of second pass
+                        var fusedEdgeSimilarities = fusedScoreFunction.edgeLoadingSimilarityTo(ordinal); // results of third pass
                         for (int j = 0; j < fusedEdgeSimilarities.length(); j++) {
-                            assertEquals(fusedEdgeSimilarities.get(j), edgeSimilarities.get(j), 0.01);
+                            assertEquals(fusedEdgeSimilarities.get(j), edgeSimilaritiesCopy.get(j), 0.01);
                         }
                     }
                 }


### PR DESCRIPTION
fusedEdgeSimilarities and edgeSimilarities are referring to same object underneath which is io.github.jbellis.jvector.quantization.FusedADCPQDecoder.results, as these are references pointing to same object. 
So the comparison in third pass is actually a == a which is always true now.
The comparison should be with copy of second pass vs result of third pass for correct check as its intended to check the second pass with third pass results.