### PR TITLE
Fused ADC vectorized implementation with new selectFrom and saturated additions Java Vector API for edgeLoadingSimilarityTo (QuickerADC lookup)

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -28,6 +28,7 @@ import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 /** Utilities for computations with numeric arrays */
 public final class VectorUtil {
@@ -170,15 +171,16 @@ public final class VectorUtil {
     return impl.assembleAndSum(data, dataBase, dataOffsets, dataOffsetsOffset, dataOffsetsLength);
   }
 
-  public static void bulkShuffleQuantizedSimilarity(ByteSequence<?> shuffles, int codebookCount, ByteSequence<?> quantizedPartials, float delta, float minDistance, VectorFloat<?> results, VectorSimilarityFunction vsf) {
+  public static void bulkShuffleQuantizedSimilarity(ByteSequence<?> shuffles, int codebookCount, AtomicReference<Object> quantizedPartials, float delta, float minDistance, VectorFloat<?> results, VectorSimilarityFunction vsf) {
     impl.bulkShuffleQuantizedSimilarity(shuffles, codebookCount, quantizedPartials, delta, minDistance, vsf, results);
   }
 
   public static void bulkShuffleQuantizedSimilarityCosine(ByteSequence<?> shuffles, int codebookCount,
-                                                          ByteSequence<?> quantizedPartialSums, float sumDelta, float minDistance,
-                                                          ByteSequence<?> quantizedPartialMagnitudes, float magnitudeDelta, float minMagnitude,
-                                                          float queryMagnitudeSquared, VectorFloat<?> results) {
-    impl.bulkShuffleQuantizedSimilarityCosine(shuffles, codebookCount, quantizedPartialSums, sumDelta, minDistance, quantizedPartialMagnitudes, magnitudeDelta, minMagnitude, queryMagnitudeSquared, results);
+          AtomicReference<Object> quantizedPartialSums, float sumDelta, float minDistance,
+          AtomicReference<Object> quantizedPartialMagnitudes, float magnitudeDelta, float minMagnitude,
+          float queryMagnitudeSquared, VectorFloat<?> results) {
+    impl.bulkShuffleQuantizedSimilarityCosine(shuffles, codebookCount, quantizedPartialSums, sumDelta, minDistance,
+            quantizedPartialMagnitudes, magnitudeDelta, minMagnitude, queryMagnitudeSquared, results);
   }
 
   public static int hammingDistance(long[] v1, long[] v2) {
@@ -193,7 +195,7 @@ public final class VectorUtil {
     impl.calculatePartialSums(codebook, codebookIndex, size, clusterCount, query, offset, vsf, partialSums);
   }
 
-  public static void quantizePartials(float delta, VectorFloat<?> partials, VectorFloat<?> partialBase, ByteSequence<?> quantizedPartials) {
+  public static void quantizePartials(float delta, VectorFloat<?> partials, VectorFloat<?> partialBase, AtomicReference<Object> quantizedPartials) {
     impl.quantizePartials(delta, partials, partialBase, quantizedPartials);
   }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorizationProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorizationProvider.java
@@ -124,6 +124,23 @@ public abstract class VectorizationProvider {
         }
       }
 
+      if (runtimeVersion >= 24) {
+        try {
+          var provider = (VectorizationProvider) Class.forName("io.github.jbellis.jvector.vector.PanamaVectorizationProviderJava24Plus").getConstructor().newInstance();
+          LOG.info("Java version is 24 or greater. Java incubating Vector API enabled. Using PanamaVectorizationProviderJava24Plus.");
+          return provider;
+        } catch (UnsupportedOperationException uoe) {
+          // not supported because preferred vector size too small or similar
+          LOG.warning("Java 24 vector API was not enabled. " + uoe.getMessage());
+        } catch (ClassNotFoundException e) {
+          LOG.warning("Java 24 version provider class not found");
+        } catch (RuntimeException | Error e) {
+          throw e;
+        } catch (Throwable th) {
+          throw new AssertionError(th);
+        }
+      }
+
       try {
         var provider = (VectorizationProvider) Class.forName("io.github.jbellis.jvector.vector.PanamaVectorizationProvider").getConstructor().newInstance();
         LOG.info("Java incubating Vector API enabled. Using PanamaVectorizationProvider.");

--- a/jvector-multirelease/src/assembly/mrjar.xml
+++ b/jvector-multirelease/src/assembly/mrjar.xml
@@ -36,6 +36,22 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
+                <include>io.github.jbellis:jvector-twenty</include>
+            </includes>
+            <binaries>
+                <outputDirectory>META-INF/versions/24</outputDirectory>
+                <unpack>true</unpack>
+                <includeDependencies>false</includeDependencies>
+                <unpackOptions>
+                    <excludes>
+                        <exclude>/META-INF/**</exclude>
+                    </excludes>
+                </unpackOptions>
+            </binaries>
+        </moduleSet>
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
+            <includes>
                 <include>io.github.jbellis:jvector-native</include>
             </includes>
             <binaries>

--- a/jvector-multirelease/src/assembly/sourcesjar.xml
+++ b/jvector-multirelease/src/assembly/sourcesjar.xml
@@ -34,6 +34,10 @@
                         <outputDirectory>${module.artifactId}</outputDirectory>
                         <directory>src/main/java</directory>
                     </fileSet>
+                    <fileSet>
+                        <outputDirectory>${module.artifactId}/META-INF/versions/24</outputDirectory>
+                        <directory>src/main/versions/24</directory>
+                    </fileSet>
                 </fileSets>
             </sources>
         </moduleSet>

--- a/jvector-twenty/pom.xml
+++ b/jvector-twenty/pom.xml
@@ -11,6 +11,10 @@
     </parent>
     <artifactId>jvector-twenty</artifactId>
     <name>Twenty</name>
+    <properties>
+        <maven.compiler.release>20</maven.compiler.release>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -18,12 +22,24 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>20</release>
+                    <release>${maven.compiler.release}</release>
                     <compilerArgs>
-<!--                        <arg>&#45;&#45;enable-preview</arg>-->
                         <arg>--add-modules</arg>
                         <arg>jdk.incubator.vector</arg>
                     </compilerArgs>
+                </configuration>
+            </plugin>
+            <!-- Package as multi-release JAR -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>
@@ -82,4 +98,39 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>java24</id>
+            <activation>
+                <jdk>[24,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>24</maven.compiler.release>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- Add Java 24-specific source directory -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.4.0</version>
+                        <executions>
+                            <execution>
+                                <id>add-24-sources</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/main/versions/24</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -20,8 +20,9 @@ import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
-final class PanamaVectorUtilSupport implements VectorUtilSupport {
+class PanamaVectorUtilSupport implements VectorUtilSupport {
     @Override
     public float dotProduct(VectorFloat<?> a, VectorFloat<?> b) {
         return SimdOps.dotProduct((ArrayVectorFloat)a, (ArrayVectorFloat)b);
@@ -178,8 +179,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
 
     @Override
-    public void quantizePartials(float delta, VectorFloat<?> partials, VectorFloat<?> partialBases, ByteSequence<?> quantizedPartials) {
-        SimdOps.quantizePartials(delta, (ArrayVectorFloat) partials, (ArrayVectorFloat) partialBases, (ArrayByteSequence) quantizedPartials);
+    public void quantizePartials(float delta, VectorFloat<?> partials, VectorFloat<?> partialBases, AtomicReference<Object> quantizedPartials) {
+        SimdOps.quantizePartials(delta, (ArrayVectorFloat) partials, (ArrayVectorFloat) partialBases, quantizedPartials);
     }
 
     @Override

--- a/jvector-twenty/src/main/versions/24/io/github/jbellis/jvector/vector/PanamaVectorUtilSupportJava24Plus.java
+++ b/jvector-twenty/src/main/versions/24/io/github/jbellis/jvector/vector/PanamaVectorUtilSupportJava24Plus.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.vector;
+
+import io.github.jbellis.jvector.vector.types.ByteSequence;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+final class PanamaVectorUtilSupportJava24Plus
+        extends PanamaVectorUtilSupport implements VectorUtilSupport
+{
+    @Override
+    public void quantizePartials(float delta, VectorFloat<?> partials, VectorFloat<?> partialBases, AtomicReference<Object> quantizedPartialsShorts) {
+        SimdOpsJava24Plus.quantizePartials(delta, (ArrayVectorFloat) partials, (ArrayVectorFloat) partialBases, quantizedPartialsShorts);
+    }
+
+    @Override
+    public void bulkShuffleQuantizedSimilarity(ByteSequence<?> shuffles,
+            int codebookCount,
+            AtomicReference<Object> quantizedPartialSumsShorts,
+            float delta,
+            float minDistance,
+            VectorSimilarityFunction vsf, VectorFloat<?> results) {
+        SimdOpsJava24Plus.bulkShuffleQuantizedSimilarity((ArrayByteSequence) shuffles,
+                codebookCount,
+                (short []) quantizedPartialSumsShorts.get(),
+                delta,
+                minDistance,
+                vsf, (ArrayVectorFloat) results);
+    }
+
+    @Override
+    public void bulkShuffleQuantizedSimilarityCosine(ByteSequence<?> shuffles,
+            int codebookCount,
+            AtomicReference<Object> quantizedPartialSums,  float sumDelta, float minDistance,
+            AtomicReference<Object> quantizedPartialMagnitudes,  float magnitudeDelta, float minMagnitude,
+            float queryMagnitudeSquared, VectorFloat<?> results) {
+        SimdOpsJava24Plus.bulkShuffleQuantizedSimilarityCosine((ArrayByteSequence) shuffles,
+                codebookCount,
+                (short []) quantizedPartialSums.get(),  sumDelta, minDistance,
+                (short []) quantizedPartialMagnitudes.get(), magnitudeDelta, minMagnitude,
+                queryMagnitudeSquared, (ArrayVectorFloat) results);
+    }
+}

--- a/jvector-twenty/src/main/versions/24/io/github/jbellis/jvector/vector/PanamaVectorizationProviderJava24Plus.java
+++ b/jvector-twenty/src/main/versions/24/io/github/jbellis/jvector/vector/PanamaVectorizationProviderJava24Plus.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.vector;
+
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import jdk.incubator.vector.FloatVector;
+
+/**
+ * Vectorization provider for Java 24 and above versions that uses on-heap arrays and SIMD operations through Panama SIMD API.
+ */
+public class PanamaVectorizationProviderJava24Plus
+        extends VectorizationProvider
+{
+    static {
+        System.setProperty("jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK", "0");
+    }
+
+    private final VectorUtilSupport vectorUtilSupport;
+    private final VectorTypeSupport vectorTypeSupport;
+
+    public PanamaVectorizationProviderJava24Plus() {
+        this.vectorUtilSupport = new PanamaVectorUtilSupportJava24Plus();
+        LOG.info("Preferred f32 species is " + FloatVector.SPECIES_PREFERRED.vectorBitSize());
+        this.vectorTypeSupport = new ArrayVectorProvider();
+    }
+
+    @Override
+    public VectorUtilSupport getVectorUtilSupport() {
+        return vectorUtilSupport;
+    }
+
+    @Override
+    public VectorTypeSupport getVectorTypeSupport() {
+        return vectorTypeSupport;
+    }
+}

--- a/jvector-twenty/src/main/versions/24/io/github/jbellis/jvector/vector/SimdOpsJava24Plus.java
+++ b/jvector-twenty/src/main/versions/24/io/github/jbellis/jvector/vector/SimdOpsJava24Plus.java
@@ -80,7 +80,7 @@ final class SimdOpsJava24Plus
             ShortVector shuffle512 = (ShortVector) ByteVector.fromArray(byteVectorSpecies256, shuffles.get(),
                             i * byteVectorSpecies256.length())
                     .convertShape(VectorOperators.ZERO_EXTEND_B2S, shortSpecies512, 0);
-            var partialsVec = lookUpPartialSums(shuffle512, quantizedPartialsShorts, /*quantizedPartials,*/ i);
+            var partialsVec = lookUpPartialSums(shuffle512, quantizedPartialsShorts, i);
             sum = sum.lanewise(VectorOperators.SUADD, partialsVec);
         }
         ShortVector quantizedResultsLeftRaw = (ShortVector) sum.reinterpretShape(ShortVector.SPECIES_256, 0);
@@ -119,7 +119,7 @@ final class SimdOpsJava24Plus
             ShortVector shuffle512 = (ShortVector) ByteVector.fromArray(byteVectorSpecies256, shuffles.get(),
                             i * byteVectorSpecies256.length())
                     .convertShape(VectorOperators.ZERO_EXTEND_B2S, shortSpecies512, 0);
-            var partialsVec = lookUpPartialSums(shuffle512, /*quantizedPartialSums,*/quantizedPartialSumsShorts, i);
+            var partialsVec = lookUpPartialSums(shuffle512, quantizedPartialSumsShorts, i);
             sum = sum.lanewise(VectorOperators.SUADD, partialsVec);
 
             var partialsMag = lookUpPartialSums(shuffle512, quantizedPartialSquaredMagnitudesShorts, i);
@@ -158,7 +158,7 @@ final class SimdOpsJava24Plus
         return floatVec.fma(deltaVec, baseVec);
     }
 
-    private static ShortVector lookUpPartialSums(ShortVector shuffle512, short[] quantizedPartialsShorts,/*ArrayByteSequence quantizedPartials*/ int i)
+    private static ShortVector lookUpPartialSums(ShortVector shuffle512, short[] quantizedPartialsShorts, int i)
     {
         VectorSpecies<Short> shortVectorSpecies512 = ShortVector.SPECIES_512;
         int baseOffset = (i * 256);

--- a/jvector-twenty/src/main/versions/24/io/github/jbellis/jvector/vector/SimdOpsJava24Plus.java
+++ b/jvector-twenty/src/main/versions/24/io/github/jbellis/jvector/vector/SimdOpsJava24Plus.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.vector;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * SimdOpsJava24Plus contains the implementation of vectorized solutions with compatibility of apis available in Java 24 and above
+ */
+final class SimdOpsJava24Plus
+        extends SimdOps
+{
+    public static void quantizePartials(float delta, ArrayVectorFloat partials, ArrayVectorFloat partialBases, AtomicReference<Object> quantizedPartials) {
+        var codebookSize = partials.length() / partialBases.length();
+        var codebookCount = partialBases.length();
+        quantizedPartials.set(java.lang.reflect.Array.newInstance(short.class, partials.length()));
+        short[] quantizedPartialsShortsArray = (short[]) (quantizedPartials.get());
+
+        for (int i = 0; i < codebookCount; i++) {
+            var vectorizedLength = FloatVector.SPECIES_512.loopBound(codebookSize);
+            var codebookBase = partialBases.get(i);
+            var codebookBaseVector = FloatVector.broadcast(FloatVector.SPECIES_512, codebookBase);
+            int j = 0;
+            for (; j < vectorizedLength; j += FloatVector.SPECIES_512.length()) {
+                var partialVector = FloatVector.fromArray(FloatVector.SPECIES_512, partials.get(), i * codebookSize + j);
+                var quantized = (partialVector.sub(codebookBaseVector)).div(delta);
+                quantized = quantized.max(FloatVector.zero(FloatVector.SPECIES_512)).min(FloatVector.broadcast(FloatVector.SPECIES_512, 65535));
+                var quantizedBytes = (ShortVector) quantized.convertShape(VectorOperators.F2S, ShortVector.SPECIES_256, 0);
+                quantizedBytes.intoArray(quantizedPartialsShortsArray, i * codebookSize + j);
+            }
+            for (; j < codebookSize; j++) {
+                var val = partials.get(i * codebookSize + j);
+                var quantized = (short) Math.min((val - codebookBase) / delta, 65535);
+                quantizedPartialsShortsArray[i * codebookSize + j] = quantized;
+            }
+        }
+    }
+
+    //--------------------------------------------------------------------------------
+    // edgeLoadingSimilarity quantized similarity implementation using Java Vector API.
+    // selectFrom and SaturatedAddition operations are available from Java 24 and above.
+    //--------------------------------------------------------------------------------
+    static final FloatVector CONSTANT1F = FloatVector.broadcast(FloatVector.SPECIES_512, 1.f);
+    static final FloatVector CONSTANT2F = FloatVector.broadcast(FloatVector.SPECIES_512, 2.f);
+    public static void bulkShuffleQuantizedSimilarity(ArrayByteSequence shuffles,
+            int codebookCount,
+            short[] quantizedPartialsShorts,
+            float delta,
+            float minDistance,
+            VectorSimilarityFunction vsf, ArrayVectorFloat results)
+    {
+        VectorSpecies<Short> shortSpecies512 = ShortVector.SPECIES_512;
+        VectorSpecies<Byte> byteVectorSpecies256 = ByteVector.SPECIES_256;
+        var sum = ShortVector.zero(shortSpecies512);
+
+        // Lookup table implementation
+        for (int i = 0; i < codebookCount; i++) {
+            ShortVector shuffle512 = (ShortVector) ByteVector.fromArray(byteVectorSpecies256, shuffles.get(),
+                            i * byteVectorSpecies256.length())
+                    .convertShape(VectorOperators.ZERO_EXTEND_B2S, shortSpecies512, 0);
+            var partialsVec = lookUpPartialSums(shuffle512, quantizedPartialsShorts, /*quantizedPartials,*/ i);
+            sum = sum.lanewise(VectorOperators.SUADD, partialsVec);
+        }
+        ShortVector quantizedResultsLeftRaw = (ShortVector) sum.reinterpretShape(ShortVector.SPECIES_256, 0);
+        ShortVector quantizedResultsRightRaw = (ShortVector) sum.reinterpretShape(ShortVector.SPECIES_256, 1);
+        FloatVector resultsLeft = dequantize(quantizedResultsLeftRaw, delta, minDistance).add(CONSTANT1F);
+        FloatVector resultsRight = dequantize(quantizedResultsRightRaw, delta, minDistance).add(CONSTANT1F);
+
+        switch (vsf) {
+            case DOT_PRODUCT -> {
+                resultsLeft = resultsLeft.div(CONSTANT2F);
+                resultsRight = resultsRight.div(CONSTANT2F);
+                resultsLeft.intoArray(results.get(), 0);
+                resultsRight.intoArray(results.get(), 16);
+            }
+            case EUCLIDEAN -> {
+                resultsLeft = CONSTANT1F.div(resultsLeft);
+                resultsRight = CONSTANT1F.div(resultsRight);
+                resultsLeft.intoArray(results.get(), 0);
+                resultsRight.intoArray(results.get(), 16);
+            }
+        }
+    }
+
+    public static void bulkShuffleQuantizedSimilarityCosine(ArrayByteSequence shuffles,
+            int codebookCount,
+            short[] quantizedPartialSumsShorts, float sumDelta, float minDistance,
+            short[] quantizedPartialSquaredMagnitudesShorts,float magnitudeDelta,
+            float minMagnitude, float queryMagnitudeSquared, ArrayVectorFloat results) {
+        VectorSpecies<Short> shortSpecies512 = ShortVector.SPECIES_512;
+        VectorSpecies<Byte> byteVectorSpecies256 = ByteVector.SPECIES_256;
+        var sum = ShortVector.zero(shortSpecies512);
+        var magnitude = ShortVector.zero(shortSpecies512);
+
+        // Lookup table implementation
+        for (int i = 0; i < codebookCount; i++) {
+            ShortVector shuffle512 = (ShortVector) ByteVector.fromArray(byteVectorSpecies256, shuffles.get(),
+                            i * byteVectorSpecies256.length())
+                    .convertShape(VectorOperators.ZERO_EXTEND_B2S, shortSpecies512, 0);
+            var partialsVec = lookUpPartialSums(shuffle512, /*quantizedPartialSums,*/quantizedPartialSumsShorts, i);
+            sum = sum.lanewise(VectorOperators.SUADD, partialsVec);
+
+            var partialsMag = lookUpPartialSums(shuffle512, quantizedPartialSquaredMagnitudesShorts, i);
+            magnitude = magnitude.lanewise(VectorOperators.SUADD, partialsMag);
+        }
+
+        ShortVector quantizedResultsLeftRaw = (ShortVector) sum.reinterpretShape(ShortVector.SPECIES_256, 0);
+        ShortVector quantizedResultsRightRaw = (ShortVector) sum.reinterpretShape(ShortVector.SPECIES_256, 1);
+        FloatVector resultsSumLeft = dequantize(quantizedResultsLeftRaw, sumDelta, minDistance);
+        FloatVector resultsSumRight = dequantize(quantizedResultsRightRaw, sumDelta, minDistance);
+
+        quantizedResultsLeftRaw = (ShortVector) magnitude.reinterpretShape(ShortVector.SPECIES_256, 0);
+        quantizedResultsRightRaw = (ShortVector) magnitude.reinterpretShape(ShortVector.SPECIES_256, 1);
+        FloatVector resultsMagLeft = dequantize(quantizedResultsLeftRaw, magnitudeDelta, minMagnitude);
+        FloatVector resultsMagRight = dequantize(quantizedResultsRightRaw, magnitudeDelta, minMagnitude);
+
+        FloatVector queryMagnitudeSquaredVec = FloatVector.broadcast(FloatVector.SPECIES_512, queryMagnitudeSquared);
+        resultsMagLeft = resultsMagLeft.mul(queryMagnitudeSquaredVec).sqrt();
+        resultsMagRight = resultsMagRight.mul(queryMagnitudeSquaredVec).sqrt();
+
+        resultsSumLeft = resultsSumLeft.div(resultsMagLeft).add(CONSTANT1F).div(CONSTANT2F);
+        resultsSumRight = resultsSumRight.div(resultsMagRight).add(CONSTANT1F).div(CONSTANT2F);
+        resultsSumLeft.intoArray(results.get(), 0);
+        resultsSumRight.intoArray(results.get(), 16);
+    }
+
+    private static FloatVector dequantize(ShortVector quantizedVec, float delta, float base)
+    {
+        IntVector quantizedVecWidened = quantizedVec.convertShape(VectorOperators.ZERO_EXTEND_S2I, IntVector.SPECIES_512, 0).reinterpretAsInts();
+        //Use convert shape as reinterpretAsFloats does not perform numerical conversion, but interprets binary form as float.
+        FloatVector floatVec = quantizedVecWidened.convert(VectorOperators.I2F, 0).reinterpretAsFloats();
+        //Broadcast deltaVect and baseVec
+        FloatVector deltaVec = FloatVector.broadcast(FloatVector.SPECIES_512, delta);
+        FloatVector baseVec = FloatVector.broadcast(FloatVector.SPECIES_512, base);
+        //Compute FMA
+        return floatVec.fma(deltaVec, baseVec);
+    }
+
+    private static ShortVector lookUpPartialSums(ShortVector shuffle512, short[] quantizedPartialsShorts,/*ArrayByteSequence quantizedPartials*/ int i)
+    {
+        VectorSpecies<Short> shortVectorSpecies512 = ShortVector.SPECIES_512;
+        int baseOffset = (i * 256);
+        ShortVector partialsVecA = ShortVector.fromArray(shortVectorSpecies512, quantizedPartialsShorts, baseOffset);
+        ShortVector partialsVecB = ShortVector.fromArray(shortVectorSpecies512, quantizedPartialsShorts, baseOffset + 32);
+        ShortVector partialsVecC = ShortVector.fromArray(shortVectorSpecies512, quantizedPartialsShorts, baseOffset + 64);
+        ShortVector partialsVecD = ShortVector.fromArray(shortVectorSpecies512, quantizedPartialsShorts, baseOffset + 96);
+        ShortVector partialsVecE = ShortVector.fromArray(shortVectorSpecies512, quantizedPartialsShorts, baseOffset + 128);
+        ShortVector partialsVecF = ShortVector.fromArray(shortVectorSpecies512, quantizedPartialsShorts, baseOffset + 160);
+        ShortVector partialsVecG = ShortVector.fromArray(shortVectorSpecies512, quantizedPartialsShorts, baseOffset + 192);
+        ShortVector partialsVecH = ShortVector.fromArray(shortVectorSpecies512, quantizedPartialsShorts, baseOffset + 224);
+
+        ShortVector partialsVecAB = shuffle512.selectFrom(partialsVecA, partialsVecB);
+        ShortVector partialsVecCD = shuffle512.selectFrom(partialsVecC, partialsVecD);
+        ShortVector partialsVecEF = shuffle512.selectFrom(partialsVecE, partialsVecF);
+        ShortVector partialsVecGH = shuffle512.selectFrom(partialsVecG, partialsVecH);
+
+        ShortVector maskSevenBitVector = ShortVector.broadcast(ShortVector.SPECIES_512, 0x0040);
+        ShortVector maskEightBitVector = ShortVector.broadcast(ShortVector.SPECIES_512, 0x0080);
+        VectorMask<Short> maskSeven = shuffle512.and(maskSevenBitVector).compare(VectorOperators.NE, ShortVector.zero(ShortVector.SPECIES_512));
+        VectorMask<Short> maskEight = shuffle512.and(maskEightBitVector).compare(VectorOperators.NE, ShortVector.zero(ShortVector.SPECIES_512));
+
+        ShortVector partialsVecABCD = partialsVecAB.blend(partialsVecCD, maskSeven);
+        ShortVector partialsVecEFGH = partialsVecEF.blend(partialsVecGH, maskSeven);
+
+        return partialsVecABCD.blend(partialsVecEFGH, maskEight);
+    }
+
+    //-----------------------------------------------------------------------------------------
+    // edgeLoadingSimilarity quantized similarity implementation using Java Vector API end here
+    //-------------------------------------------------------------------------------- --------
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.install.skip>true</maven.install.skip>
         <revision>4.0.0-beta.6-SNAPSHOT</revision>
+        <maven.compiler.release>22</maven.compiler.release>
     </properties>
     <modules>
         <module>jvector-base</module>
@@ -121,7 +122,7 @@
                             <additionalJOptions>
                                 <additionalJOption>--add-modules=jdk.incubator.vector</additionalJOption>
                             </additionalJOptions>
-                            <release>22</release>
+                            <release>${maven.compiler.release}</release>
                         </configuration>
                     </execution>
                 </executions>
@@ -220,4 +221,41 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <profiles>
+        <profile>
+            <id>java24</id>
+            <activation>
+                <jdk>[24,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>24</maven.compiler.release>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs-java24</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>aggregate-jar</goal>
+                                </goals>
+                                <configuration>
+                                    <skippedModules>jvector-examples,jvector-tests</skippedModules>
+                                    <additionalJOptions>
+                                        <additionalJOption>--add-modules=jdk.incubator.vector</additionalJOption>
+                                    </additionalJOptions>
+                                    <sourcepath>${project.basedir}/src/main/java:${project.basedir}/src/main/versions/24</sourcepath>
+                                    <release>${maven.compiler.release}</release>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Fused ADC vectorized implementation with new selectFrom and saturated Addition Java Vector API for edgeLoadingSimilarityTo (QuickerADC lookup)
QPS benefit and Mean Latency reduction over scalar execution, with the ada002-100k dataset, using the new Java Vector APIs for FusedAdc execution is as below:

![FusedAdcBenefitClaim](https://github.com/user-attachments/assets/5e939c15-b8b7-49dd-9809-369f5ab200bc)

The results above are from executions on 1 socket of m7i.metal-48xl AWS instance.

**Solution details:**
The new Java Vector APIs selectFrom and saturated additions are part of Java 24+, so the PanamaVectorizationProvider and PanamaVectorUtilSupport are extended to PanamaVectorizationProviderJava24Plus and PanamaVectorUtilSupportJava24Plus.
This ensures no impact for previous versions compilation and execution.

**Choice of ByteSequence/short[] based on the execution flow for performance reasons**
The Java Vector API solution is performant with short[] and not with ByteSequences because of endianess mismatch. 
So for better performance gains by Java Vector API implementation, based on the runtime execution flow, io.github.jbellis.jvector.quantization.ProductQuantization#partialQuantizedSums and io.github.jbellis.jvector.quantization.ProductQuantization#partialQuantizedSquaredMagnitudes are ArrayByteSequence for Scalar, Java 20-23 executions and short[] for Java 24+ with PanamaVectorizationProvider executions.