### PR TITLE
add PQ training benchmark

### DIFF
--- a/benchmarks-jmh/README.md
+++ b/benchmarks-jmh/README.md
@@ -6,21 +6,23 @@ are mostly targeting scalability and latency aspects.
 
 1. You can build and then run
 ```shell
+VERSION="4.0.0-beta.6"
 mvn clean install -DskipTests=true
 java --enable-native-access=ALL-UNNAMED \
   --add-modules=jdk.incubator.vector \
   -XX:+HeapDumpOnOutOfMemoryError \
   -Xmx14G -Djvector.experimental.enable_native_vectorization=true \
-  -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar 
+  -jar benchmarks-jmh/target/benchmarks-jmh-${VERSION}-SNAPSHOT.jar 
 ```
 
 You can add additional optional JMH arguments dynamically from command line. For example, to run the benchmarks with 4 forks, 5 warmup iterations, 5 measurement iterations, 2 threads, and 10 seconds warmup time per iteration, use the following command:
 ```shell
+VERSION="4.0.0-beta.6"
 java --enable-native-access=ALL-UNNAMED \
   --add-modules=jdk.incubator.vector \
   -XX:+HeapDumpOnOutOfMemoryError \
   -Xmx14G -Djvector.experimental.enable_native_vectorization=true \
-  -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.2-SNAPSHOT.jar \
+  -jar benchmarks-jmh/target/benchmarks-jmh-${VERSION}-SNAPSHOT.jar \
   -f 4 -wi 5 -i 5 -t 2 -w 10s
 ```
 
@@ -39,19 +41,33 @@ Common JMH command line options you can use in the configuration or command line
 
 For example in the below command lines we are going to run only `IndexConstructionWithRandomSetBenchmark`
 ```shell
-mvn clean install -DskipTests=true
+VERSION="4.0.0-beta.6"
 BENCHMARK_NAME="IndexConstructionWithRandomSetBenchmark"
+mvn clean install -DskipTests=true
 java --enable-native-access=ALL-UNNAMED \
   --add-modules=jdk.incubator.vector \
   -XX:+HeapDumpOnOutOfMemoryError \
   -Xmx20G -Djvector.experimental.enable_native_vectorization=true \
-  -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.3-SNAPSHOT.jar $BENCHMARK_NAME
+  -jar benchmarks-jmh/target/benchmarks-jmh-${VERSION}-SNAPSHOT.jar $BENCHMARK_NAME
+```
+
+Same example for PQ training benchmark
+```shell
+VERSION="4.0.0-beta.6"
+BENCHMARK_NAME="PQTrainingWithRandomVectorsBenchmark"
+mvn clean install -DskipTests=true
+java --enable-native-access=ALL-UNNAMED \
+  --add-modules=jdk.incubator.vector \
+  -XX:+HeapDumpOnOutOfMemoryError \
+  -Xmx20G -Djvector.experimental.enable_native_vectorization=true \
+  -jar benchmarks-jmh/target/benchmarks-jmh-${VERSION}-SNAPSHOT.jar $BENCHMARK_NAME
 ```
 
 If you want to rerun a specific benchmark without testing the entire grid of scenarios defined in the benchmark.
 You can just do the following to set M and beamWidth:
 ```shell
-java -jar benchmarks-jmh/target/benchmarks-jmh-4.0.0-beta.3-SNAPSHOT.jar IndexConstructionWithStaticSetBenchmark -p M=32 -p beamWidth=100 
+VERSION="4.0.0-beta.6"
+java -jar benchmarks-jmh/target/benchmarks-jmh-${VERSION}-SNAPSHOT.jar IndexConstructionWithStaticSetBenchmark -p M=32 -p beamWidth=100 
 ```
 
 

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/PQTrainingWithSiftBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/PQTrainingWithSiftBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jbellis.jvector.bench;
+
+import io.github.jbellis.jvector.example.util.SiftLoader;
+import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.quantization.ProductQuantization;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@Threads(1)
+public class PQTrainingWithSiftBenchmark {
+    private static final Logger log = LoggerFactory.getLogger(PQTrainingWithSiftBenchmark.class);
+    private RandomAccessVectorValues ravv;
+    private List<VectorFloat<?>> baseVectors;
+    private List<VectorFloat<?>> queryVectors;
+    private List<List<Integer>> groundTruth;
+    @Param({"16", "32", "64"})
+    private int M; // Number of subspaces
+    int originalDimension;
+
+    @Setup
+    public void setup() throws IOException {
+        var siftPath = "siftsmall";
+        baseVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_base.fvecs", siftPath));
+        queryVectors = SiftLoader.readFvecs(String.format("%s/siftsmall_query.fvecs", siftPath));
+        groundTruth = SiftLoader.readIvecs(String.format("%s/siftsmall_groundtruth.ivecs", siftPath));
+        log.info("base vectors size: {}, query vectors size: {}, loaded, dimensions {}",
+                baseVectors.size(), queryVectors.size(), baseVectors.get(0).length());
+        originalDimension = baseVectors.get(0).length();
+        // wrap the raw vectors in a RandomAccessVectorValues
+        ravv = new ListRandomAccessVectorValues(baseVectors, originalDimension);
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+        baseVectors.clear();
+        queryVectors.clear();
+        groundTruth.clear();
+    }
+
+    @Benchmark
+    public void productQuantizationComputeBenchmark(Blackhole blackhole) throws IOException {
+        // Compress the original vectors using PQ. this represents a compression ratio of 128 * 4 / 16 = 32x
+        ProductQuantization pq = ProductQuantization.compute(ravv,
+                M, // number of subspaces
+                256, // number of centroids per subspace
+                true); // center the dataset
+
+        blackhole.consume(pq);
+    }
+}


### PR DESCRIPTION
# Overview
In order to gauge for variance in PQ performance over various architectures we need to have a baseline measurement within jVector that captures the relative cost of training.
We need to have the number of vectors as an adjustable parameter which is harder to do on a static dataset without creating skewness in data distribution.

# Changes
- Added a PQ training benchmark for random vectors with adjustable vector count

# Testing

```shell
Benchmark                                                                 (M)  (originalDimension)  (vectorCount)  Mode  Cnt     Score     Error  Units
PQTrainingWithRandomVectorsBenchmark.productQuantizationComputeBenchmark   16                  768         100000  avgt    5  2566.605 ± 150.461  ms/op
PQTrainingWithRandomVectorsBenchmark.productQuantizationComputeBenchmark   32                  768         100000  avgt    5  2964.321 ± 124.850  ms/op
PQTrainingWithRandomVectorsBenchmark.productQuantizationComputeBenchmark   64                  768         100000  avgt    5  4028.526 ± 101.389  ms/op
```

