### PR TITLE
Fix issue when calling cleanup while concurrently executing searches

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodesIterator.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodesIterator.java
@@ -96,4 +96,21 @@ public interface NodesIterator extends PrimitiveIterator.OfInt {
             return cur < size;
         }
     }
+
+    class EmptyNodeIterator implements NodesIterator {
+        @Override
+        public int size() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int nextInt() {
+            return Integer.MIN_VALUE;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+    }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -366,40 +366,60 @@ public class OnHeapGraphIndex implements GraphIndex {
 
         @Override
         public NodesIterator getNeighborsIterator(int level, int node) {
-            var it = getNeighbors(level, node).iterator();
-            return new NodesIterator() {
-                int nextNode = advance();
+            NodesIterator it;
+            try {
+                it = getNeighbors(level, node).iterator();
+                return new NodesIterator() {
+                    int nextNode = advance();
 
-                private int advance() {
-                    while (it.hasNext()) {
-                        int n = it.nextInt();
-                        if (completions.completedAt(n) < timestamp) {
-                            return n;
+                    private int advance() {
+                        while (it.hasNext()) {
+                            int n = it.nextInt();
+                            if (completions.completedAt(n) < timestamp) {
+                                return n;
+                            }
                         }
+                        return Integer.MIN_VALUE;
                     }
-                    return Integer.MIN_VALUE;
-                }
 
-                @Override
-                public int size() {
-                    throw new UnsupportedOperationException();
-                }
-
-                @Override
-                public int nextInt() {
-                    int current = nextNode;
-                    if (current == Integer.MIN_VALUE) {
-                        throw new IndexOutOfBoundsException();
+                    @Override
+                    public int size() {
+                        throw new UnsupportedOperationException();
                     }
-                    nextNode = advance();
-                    return current;
-                }
 
-                @Override
-                public boolean hasNext() {
-                    return nextNode != Integer.MIN_VALUE;
-                }
-            };
+                    @Override
+                    public int nextInt() {
+                        int current = nextNode;
+                        if (current == Integer.MIN_VALUE) {
+                            throw new IndexOutOfBoundsException();
+                        }
+                        nextNode = advance();
+                        return current;
+                    }
+
+                    @Override
+                    public boolean hasNext() {
+                        return nextNode != Integer.MIN_VALUE;
+                    }
+                };
+            } catch (NullPointerException e) {
+                return new NodesIterator() {
+                    @Override
+                    public int size() {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public int nextInt() {
+                        return -1;
+                    }
+
+                    @Override
+                    public boolean hasNext() {
+                        return false;
+                    }
+                };
+            }
         }
     }
 
@@ -407,6 +427,7 @@ public class OnHeapGraphIndex implements GraphIndex {
         @Override
         public NodesIterator getNeighborsIterator(int level, int node) {
             return getNeighbors(level, node).iterator();
+
         }
 
         @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -406,22 +406,7 @@ public class OnHeapGraphIndex implements GraphIndex {
                 // This case may be encountered when concurrently searching while GraphIndexBuilder.cleanup is running.
                 // In such a case, the neighborhoods may get temporarily broken and we just assume that the node has
                 // no neighbors.
-                return new NodesIterator() {
-                    @Override
-                    public int size() {
-                        throw new UnsupportedOperationException();
-                    }
-
-                    @Override
-                    public int nextInt() {
-                        return Integer.MIN_VALUE;
-                    }
-
-                    @Override
-                    public boolean hasNext() {
-                        return false;
-                    }
-                };
+                return new NodesIterator.EmptyNodeIterator();
             }
         }
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -411,7 +411,7 @@ public class OnHeapGraphIndex implements GraphIndex {
 
                     @Override
                     public int nextInt() {
-                        return -1;
+                        return Integer.MIN_VALUE;
                     }
 
                     @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -403,6 +403,9 @@ public class OnHeapGraphIndex implements GraphIndex {
                     }
                 };
             } catch (NullPointerException e) {
+                // This case may be encountered when concurrently searching while GraphIndexBuilder.cleanup is running.
+                // In such a case, the neighborhoods may get temporarily broken and we just assume that the node has
+                // no neighbors.
                 return new NodesIterator() {
                     @Override
                     public int size() {

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestConcurrentReadWriteDeletes.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestConcurrentReadWriteDeletes.java
@@ -1,0 +1,161 @@
+package io.github.jbellis.jvector.graph;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import io.github.jbellis.jvector.LuceneTestCase;
+import io.github.jbellis.jvector.TestUtil;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
+import io.github.jbellis.jvector.util.FixedBitSet;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import org.junit.Test;
+
+import static io.github.jbellis.jvector.TestUtil.createRandomVectors;
+import static io.github.jbellis.jvector.TestUtil.randomVector;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class TestConcurrentReadWriteDeletes extends LuceneTestCase {
+    private static final int nVectors = 200_000;
+    private static final int dimension = 16;
+
+    KeySet keysInserted = new KeySet();
+    List<Integer> keysRemoved = new CopyOnWriteArrayList();
+
+    List<VectorFloat<?>> vectors = createRandomVectors(nVectors, dimension);
+    RandomAccessVectorValues ravv = new ListRandomAccessVectorValues(vectors, dimension);
+
+    VectorSimilarityFunction similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
+
+    BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, similarityFunction);
+    GraphIndexBuilder builder = new GraphIndexBuilder(bsp, 2, 2, 10, 1.0f, 1.0f, true);
+
+    FixedBitSet liveNodes = new FixedBitSet(nVectors);
+
+    @Test
+    public void testConcurrentReadsWritesDeletes() {
+        try {
+            testConcurrentReadsWritesDeletes(false);
+//            testConcurrentReadsWritesDeletes(true);
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void testConcurrentReadsWritesDeletes(boolean addHierarchy) throws ExecutionException, InterruptedException {
+        var vv = ravv.threadLocalSupplier();
+
+        testConcurrentOps(addHierarchy, i -> {
+            var R = ThreadLocalRandom.current();
+            if (R.nextDouble() < 0.2 || keysInserted.isEmpty())
+            {
+                builder.addGraphNode(i, vv.get().getVector(i));
+                liveNodes.set(i);
+                keysInserted.add(i);
+            } else if (R.nextDouble() < 0.1) {
+                var key = keysInserted.getRandom();
+                liveNodes.flip(key);
+                keysRemoved.add(key);
+            } else {
+                var queryVector = randomVector(getRandom(), dimension);
+                SearchScoreProvider ssp = DefaultSearchScoreProvider.exact(queryVector, similarityFunction, ravv);
+
+                int topK = Math.min(1, keysInserted.size());
+                int rerankK = Math.min(50, keysInserted.size());
+
+                GraphSearcher searcher = new GraphSearcher(builder.getGraph());
+                searcher.search(ssp, topK, rerankK, 0.f, 0.f, liveNodes);
+            }
+        });
+    }
+
+    @FunctionalInterface
+    private interface Op
+    {
+        void run(int i) throws Throwable;
+    }
+
+    private void testConcurrentOps(boolean addHierarchy, Op op) throws ExecutionException, InterruptedException {
+        AtomicInteger counter = new AtomicInteger();
+        long start = System.currentTimeMillis();
+        var fjp = ForkJoinPool.commonPool();
+        var keys = IntStream.range(0, nVectors).boxed().collect(Collectors.toList());
+        Collections.shuffle(keys);
+        var task = fjp.submit(() -> keys.stream().parallel().forEach(i ->
+        {
+            wrappedOp(op, i);
+            if (counter.incrementAndGet() % 10_000 == 0)
+            {
+                var elapsed = System.currentTimeMillis() - start;
+                System.out.println(String.format("%d ops in %dms = %f ops/s", counter.get(), elapsed, counter.get() * 1000.0 / elapsed));
+            }
+            if (ThreadLocalRandom.current().nextDouble() < 0.001) {
+//                System.out.println("Cleanup");
+                for (Integer key : keysRemoved) {
+                    builder.markNodeDeleted(key);
+                }
+                keysRemoved.clear();
+                builder.cleanup();
+            }
+        }));
+        fjp.shutdown();
+        task.get(); // re-throw
+    }
+
+    private static void wrappedOp(Op op, Integer i) {
+        try
+        {
+            op.run(i);
+        }
+        catch (Throwable e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class KeySet
+    {
+        private final Map<Integer, Integer> keys = new ConcurrentHashMap<>();
+        private final AtomicInteger ordinal = new AtomicInteger();
+
+        public void add(Integer key)
+        {
+            var i = ordinal.getAndIncrement();
+            keys.put(i, key);
+        }
+
+        public int getRandom()
+        {
+            if (isEmpty())
+                throw new IllegalStateException();
+            var i = ThreadLocalRandom.current().nextInt(ordinal.get());
+            // in case there is race with add(key), retry another random
+            return keys.containsKey(i) ? keys.get(i) : getRandom();
+        }
+
+        public boolean isEmpty()
+        {
+            return keys.isEmpty();
+        }
+
+        public int size() {
+            return keys.size();
+        }
+    }
+}

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestConcurrentReadWriteDeletes.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestConcurrentReadWriteDeletes.java
@@ -106,7 +106,6 @@ public class TestConcurrentReadWriteDeletes extends LuceneTestCase {
                 System.out.println(String.format("%d ops in %dms = %f ops/s", counter.get(), elapsed, counter.get() * 1000.0 / elapsed));
             }
             if (ThreadLocalRandom.current().nextDouble() < 0.001) {
-//                System.out.println("Cleanup");
                 for (Integer key : keysRemoved) {
                     builder.markNodeDeleted(key);
                 }


### PR DESCRIPTION
A NullPointerException that was thrown when we were:
1. deleting nodes
2. running cleanup (that commits the deletions) while concurrently executing searches

This is because there is no good isolation between a FrozenView and the commit of the deletions. If a deleted node was encountered during a concurrent search, its neighborhood was empty and caused the NPE.

This PR fixes this problem by simply returning an empty neighborhood for those nodes.