### PR TITLE
Remove extraneous character from datasets.yml

### DIFF
--- a/jvector-examples/yaml-configs/datasets.yml
+++ b/jvector-examples/yaml-configs/datasets.yml
@@ -18,6 +18,6 @@ ann-benchmarks:
   - glove-100-angular.hdf5
   - glove-200-angular.hdf5
   - nytimes-256-angular.hdf5
-  - sift-128-euclidean.hdf5"
+  - sift-128-euclidean.hdf5
   # - deep-image-96-angular.hdf5 # large files not yet supported
   # - gist-960-euclidean.hdf5 # large files not yet supported


### PR DESCRIPTION
There is an extraneous `"` following the filename of the sift dataset that is preventing it from being downloaded when the benchmarks are run through Maven.

When removed, the sift-128-euclidean dataset downloads fine and the bench runs successfully.