### PR TITLE
Revert "Release 4.0.0 rc.1"

### DIFF
--- a/jvector-multirelease/pom.xml
+++ b/jvector-multirelease/pom.xml
@@ -16,13 +16,9 @@
     </properties>
     <distributionManagement>
         <snapshotRepository>
-            <id>central</id>
-	    <url>https://central.sonatype.com/content/repositories/snapshots</url>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
-        <repository>
-            <id>central</id>
-            <url>https://central.sonatype.com/service/local/staging/deploy/maven2/</url>
-        </repository>
     </distributionManagement>
     <build>
         <plugins>
@@ -150,8 +146,8 @@
                         </execution>
                         </executions>
                         <configuration>
-                            <serverId>central</serverId>
-                            <nexusUrl>https://central.sonatype.com/</nexusUrl>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.install.skip>true</maven.install.skip>
-        <revision>4.0.0-rc.2-SNAPSHOT</revision>
+        <revision>4.0.0-rc.1</revision>
     </properties>
     <modules>
         <module>jvector-base</module>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.install.skip>true</maven.install.skip>
-        <revision>4.0.0-rc.1</revision>
+        <revision>4.0.0-beta.6-SNAPSHOT</revision>
     </properties>
     <modules>
         <module>jvector-base</module>


### PR DESCRIPTION
Reverts datastax/jvector#486

PR 486 introduced the changes needed to migrate from ossrh to sonatype central. However there was a plugin missed in the jvector-multirelease pom file so we need to revert and redo the release