### PR TITLE
Fix bad assert hit on CC cluster

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -131,7 +131,7 @@ public class OnDiskGraphIndex implements GraphIndex, AutoCloseable, Accountable
 
             for (int i = 0; i < info.size; i++) {
                 int nodeId = in.readInt();
-                assert nodeId >= 0 && nodeId < layerInfo.get(0).size :
+                assert nodeId >= 0 :
                         String.format("Node ID %d out of bounds for layer %d", nodeId, lvl);
                 int neighborCount = in.readInt();
                 assert neighborCount >= 0 && neighborCount <= info.degree


### PR DESCRIPTION
The assert in this PR was hit on a test Cassandra cluster.  Looking at it it doesn't make sense to me as the size of the layer will not correspond to the max nodeId in the layer.