### PR TITLE
Allow generate-changelog GHA write permission for branch push

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -1,5 +1,9 @@
 name: Generate Changelog
 
+permissions:
+  contents: write        # allow git push / branch creation
+  pull-requests: write   # allow creating/updating PRs
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
- Update permissions so bot can push branch.  Default permission is read.
- Tested on fork in repo mirroring our permissions.  Fixed the failure.