### PR TITLE
Fix dataset naming when using default.yml

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/yaml/MultiConfig.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/yaml/MultiConfig.java
@@ -34,11 +34,16 @@ public class MultiConfig {
 
     public static MultiConfig getDefaultConfig(String datasetName) throws FileNotFoundException {
         File configFile = new File(defaultDirectory + datasetName + ".yml");
-        if (!configFile.exists()) {
+        boolean useDefault = !configFile.exists();
+        if (useDefault) {
             configFile = new File(defaultDirectory + "default.yml");
             System.out.println("Default YAML config file: " + configFile.getAbsolutePath());
         }
-        return getConfig(configFile);
+        var config = getConfig(configFile);
+        if (useDefault) {
+            config.dataset = datasetName;
+        }
+        return config;
     }
 
     public static MultiConfig getConfig(String datasetName) throws FileNotFoundException {

--- a/jvector-examples/yaml-configs/default.yml
+++ b/jvector-examples/yaml-configs/default.yml
@@ -1,6 +1,6 @@
 version: 5
 
-dataset: cohere-english-v3-100k
+dataset: default
 
 construction:
   outDegree: [32]


### PR DESCRIPTION
The config file default.yml had the wrong name. Fixing the piping code so that the correct name is applied.