### PR TITLE
Improvements to throughput benchmark

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -382,15 +382,17 @@ public class Grid {
                                           boolean addHierarchy) {
         int queryRuns = 2;
         System.out.format("Using %s:%n", cs.index);
-        // 1) Select benchmarks to run
+        // 1) Select benchmarks to run.  Use .createDefault or .createEmpty (for other options)
         List<QueryBenchmark> benchmarks = List.of(
-                ThroughputBenchmark.createDefault(2, 0.1),
+                ThroughputBenchmark.createEmpty(3, 3)
+                        .displayAvgQps(),
                 LatencyBenchmark.createDefault(),
                 CountBenchmark.createDefault(),
                 AccuracyBenchmark.createDefault()
         );
         QueryTester tester = new QueryTester(benchmarks);
 
+        // 2) Setup benchmark table for printing
         for (var topK : topKGrid.keySet()) {
             for (var usePruning : usePruningGrid) {
                 BenchmarkTablePrinter printer = new BenchmarkTablePrinter();

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/benchmarks/QueryExecutor.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/benchmarks/QueryExecutor.java
@@ -19,6 +19,7 @@ package io.github.jbellis.jvector.example.benchmarks;
 import io.github.jbellis.jvector.example.Grid.ConfiguredSystem;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
 
 public class QueryExecutor {
     /**
@@ -33,6 +34,15 @@ public class QueryExecutor {
      */
     public static SearchResult executeQuery(ConfiguredSystem cs, int topK, int rerankK, boolean usePruning, int i) {
         var queryVector = cs.getDataSet().queryVectors.get(i);
+        var searcher = cs.getSearcher();
+        searcher.usePruning(usePruning);
+        var sf = cs.scoreProviderFor(queryVector, searcher.getView());
+        return searcher.search(sf, topK, rerankK, 0.0f, 0.0f, Bits.ALL);
+    }
+
+    // Overload to allow single query injection (e.g., for warm-up with random vectors)
+    public static SearchResult executeQuery(ConfiguredSystem cs, int topK, int rerankK, boolean usePruning, VectorFloat<?> queryVector
+    ) {
         var searcher = cs.getSearcher();
         searcher.usePruning(usePruning);
         var sf = cs.scoreProviderFor(queryVector, searcher.getView());

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/benchmarks/ThroughputBenchmark.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/benchmarks/ThroughputBenchmark.java
@@ -16,12 +16,20 @@
 
 package io.github.jbellis.jvector.example.benchmarks;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 
 import io.github.jbellis.jvector.example.Grid.ConfiguredSystem;
 import io.github.jbellis.jvector.graph.SearchResult;
+import io.github.jbellis.jvector.vector.VectorUtil;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 
 /**
  * Measures throughput (queries/sec) with an optional warmup phase.
@@ -31,22 +39,69 @@ public class ThroughputBenchmark extends AbstractQueryBenchmark {
 
     private static volatile long SINK;
 
-    private final int warmupRuns;
-    private final double warmupRatio;
-    private String format;
+    private final int numWarmupRuns;
+    private final int numTestRuns;
+    private boolean computeAvgQps;
+    private boolean computeMedianQps;
+    private boolean computeMaxQps;
+    private String formatAvgQps;
+    private String formatMedianQps;
+    private String formatMaxQps;
 
-    public static ThroughputBenchmark createDefault(int warmupRuns, double warmupRatio) {
-        return new ThroughputBenchmark(warmupRuns, warmupRatio, DEFAULT_FORMAT);
+    VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    public static ThroughputBenchmark createDefault() {
+        return new ThroughputBenchmark(3, 3,
+                true, false, false,
+                DEFAULT_FORMAT, DEFAULT_FORMAT, DEFAULT_FORMAT);
     }
 
-    private ThroughputBenchmark(int warmupRuns, double warmupRatio, String format) {
-        this.warmupRuns = warmupRuns;
-        this.warmupRatio = warmupRatio;
-        this.format = format;
+    public static ThroughputBenchmark createEmpty(int numWarmupRuns, int numTestRuns) {
+        return new ThroughputBenchmark(numWarmupRuns, numTestRuns,
+                false, false, false,
+                DEFAULT_FORMAT, DEFAULT_FORMAT, DEFAULT_FORMAT);
     }
 
-    public ThroughputBenchmark setFormat(String format) {
-        this.format = format;
+    private ThroughputBenchmark(int numWarmupRuns, int numTestRuns,
+                                boolean computeAvgQps, boolean computeMedianQps, boolean computeMaxQps,
+                                String formatAvgQps, String formatMedianQps, String formatMaxQps) {
+        this.numWarmupRuns = numWarmupRuns;
+        this.numTestRuns = numTestRuns;
+        this.computeAvgQps = computeAvgQps;
+        this.computeMedianQps = computeMedianQps;
+        this.computeMaxQps = computeMaxQps;
+        this.formatAvgQps = formatAvgQps;
+        this.formatMedianQps = formatMedianQps;
+        this.formatMaxQps = formatMaxQps;
+    }
+
+    public ThroughputBenchmark displayAvgQps() {
+        return displayAvgQps(DEFAULT_FORMAT);
+    }
+
+    public ThroughputBenchmark displayAvgQps(String format) {
+        this.computeAvgQps = true;
+        this.formatAvgQps = format;
+        return this;
+    }
+
+    public ThroughputBenchmark displayMedianQps() {
+        return displayMedianQps(DEFAULT_FORMAT);
+    }
+
+    public ThroughputBenchmark displayMedianQps(String format) {
+        this.computeMedianQps = true;
+        this.formatMedianQps = format;
+        return this;
+    }
+
+    public ThroughputBenchmark displayMaxQps() {
+        return displayMaxQps(DEFAULT_FORMAT);
+    }
+
+    public ThroughputBenchmark displayMaxQps(String format) {
+        this.computeMaxQps = true;
+        this.formatMaxQps = format;
         return this;
     }
 
@@ -63,40 +118,75 @@ public class ThroughputBenchmark extends AbstractQueryBenchmark {
             boolean usePruning,
             int queryRuns) {
 
-        int totalQueries = cs.getDataSet().queryVectors.size();
-        int warmupCount   = (int) (totalQueries * warmupRatio);
-        int testCount     = totalQueries - warmupCount;
-
-        // Warmup Phase
-        if (warmupCount > 0) {
-            for (int run = 0; run < warmupRuns; run++) {
-                IntStream.range(0, warmupCount)
-                        .parallel()
-                        .forEach(i -> {
-                            SearchResult sr = QueryExecutor.executeQuery(
-                                    cs, topK, rerankK, usePruning, i);
-                            SINK += sr.getVisitedCount();
-                        });
-            }
+        if (!(computeAvgQps || computeMedianQps || computeMaxQps)) {
+            throw new RuntimeException("At least one metric must be displayed");
         }
 
-        // Test Phase
-        LongAdder visitedAdder = new LongAdder();
-        long startTime = System.nanoTime();
+        int totalQueries = cs.getDataSet().queryVectors.size();
+        int dim = cs.getDataSet().getDimension();
 
-        IntStream.range(0, testCount)
-                .parallel()
-                .forEach(i -> {
-                    int queryIndex = i + warmupCount;
-                    SearchResult sr = QueryExecutor.executeQuery(
-                            cs, topK, rerankK, usePruning, queryIndex);
-                    // “Use” the result to prevent optimization
-                    visitedAdder.add(sr.getVisitedCount());
-                });
+        // Warmup Phase: Use randomly-generated vectors
+        for (int warmupRun = 0; warmupRun < numWarmupRuns; warmupRun++) {
+            IntStream.range(0, totalQueries)
+                    .parallel()
+                    .forEach(k -> {
+                        // Generate a random vector
+                        VectorFloat<?> randQ = vts.createFloatVector(dim);
+                        for (int j = 0; j < dim; j++) {
+                            randQ.set(j, ThreadLocalRandom.current().nextFloat());
+                        }
+                        VectorUtil.l2normalize(randQ);
+                        SearchResult sr = QueryExecutor.executeQuery(
+                                cs, topK, rerankK, usePruning, randQ);
+                        SINK += sr.getVisitedCount();
+                    });
+        }
 
-        double elapsedSec = (System.nanoTime() - startTime) / 1e9;
-        double qps = testCount / elapsedSec;
+        double maxQps    = 0;
+        double[] qpsSamples = new double[numTestRuns];
+        for (int testRun = 0; testRun < numTestRuns; testRun++) {
 
-        return List.of(Metric.of("QPS", format, qps));
+            // Clear Eden and let GC complete....
+            System.gc();
+            System.runFinalization();
+            try {
+                Thread.sleep(500);   // 100 ms is usually plenty
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+
+            // Test Phase: Execute the query set or more times
+            LongAdder visitedAdder = new LongAdder();
+            long startTime = System.nanoTime();
+            IntStream.range(0, totalQueries)
+                    .parallel()
+                    .forEach(i -> {
+                        SearchResult sr = QueryExecutor.executeQuery(
+                                cs, topK, rerankK, usePruning, i);
+                        // “Use” the result to prevent optimization
+                        visitedAdder.add(sr.getVisitedCount());
+                    });
+            double elapsedSec = (System.nanoTime() - startTime) / 1e9;
+            double runQps = totalQueries / elapsedSec;
+            maxQps       = Math.max(maxQps, runQps);
+            qpsSamples[testRun] = runQps;
+
+        }
+
+        Arrays.sort(qpsSamples);
+        double medianQps = qpsSamples[numTestRuns/2];  // middle element (for odd)
+        double avgQps   = DoubleStream.of(qpsSamples).average().getAsDouble();
+
+        var list = new ArrayList<Metric>();
+        if (computeAvgQps) {
+            list.add(Metric.of("Avg QPS (of " + numTestRuns + ")", formatAvgQps, avgQps));
+        }
+        if (computeMedianQps) {
+            list.add(Metric.of("Median QPS (of " + numTestRuns + ")", formatMedianQps, medianQps));
+        }
+        if (computeMaxQps) {
+            list.add(Metric.of("Max QPS (of " + numTestRuns + ")", formatMaxQps, maxQps));
+        }
+        return list;
     }
 }


### PR DESCRIPTION
- Warmup now uses random vectors instead of a split of the test vectors
- In addition to Avg QPS, can report Median QPS and Max QPS
- Number of warmup and test passes is configurable
- Overloaded QueryExecutor to accept random vector queries