### PR TITLE
Add specific BuildScoreProvider for diversity to avoid extra encoding…

### DIFF
--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithRandomSetBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithRandomSetBenchmark.java
@@ -43,7 +43,7 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 @State(Scope.Thread)
 @Fork(1)
 @Warmup(iterations = 2)
-@Measurement(iterations = 5)
+@Measurement(iterations = 3)
 @Threads(1)
 public class IndexConstructionWithRandomSetBenchmark {
     private static final Logger log = LoggerFactory.getLogger(IndexConstructionWithRandomSetBenchmark.class);
@@ -52,11 +52,11 @@ public class IndexConstructionWithRandomSetBenchmark {
     private BuildScoreProvider buildScoreProvider;
     private int M = 32; // graph degree
     private int beamWidth = 100;
-    @Param({"768", "1536"})
+    @Param({"384"})
     private int originalDimension;
-    @Param({/*"10000",*/ "100000"/*, "1000000"*/})
+    @Param({"10000", "100000"/*, "1000000"*/})
     int numBaseVectors;
-    @Param({"0", "16"})
+    @Param({"48"})
     private int numberOfPQSubspaces;
 
     @Setup(Level.Invocation)

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
@@ -155,9 +155,7 @@ public interface BuildScoreProvider {
                 // like searchProviderFor, this skips reranking; unlike sPF, it uses pqv.scoreFunctionFor
                 // instead of precomputedScoreFunctionFor; since we only perform a few dozen comparisons
                 // during diversity computation, this is cheaper than precomputing a lookup table
-                VectorFloat<?> v1 = reusableVector.get();
-                pqv.getCompressor().decode(pqv.get(node1), v1);
-                var asf = pqv.scoreFunctionFor(v1, vsf); // not precomputed!
+                var asf = pqv.diversityFunctionFor(node1, vsf); // not precomputed!
                 return new DefaultSearchScoreProvider(asf);
             }
 
@@ -196,7 +194,7 @@ public interface BuildScoreProvider {
 
             @Override
             public SearchScoreProvider searchProviderFor(VectorFloat<?> vector) {
-                return new DefaultSearchScoreProvider(bqv.scoreFunctionFor(vector, null));
+                return new DefaultSearchScoreProvider(bqv.precomputedScoreFunctionFor(vector, null));
             }
 
             @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/BQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/BQVectors.java
@@ -96,6 +96,15 @@ public abstract class BQVectors implements CompressedVectors {
      * is a useful approximation for cosine distance and not really anything else.
      */
     @Override
+    public ScoreFunction.ApproximateScoreFunction diversityFunctionFor(int node1, VectorSimilarityFunction similarityFunction) {
+        var qBQ = compressedVectors[node1];
+        return node2 -> {
+            var vBQ = compressedVectors[node2];
+            return similarityBetween(qBQ, vBQ);
+        };
+    }
+
+    @Override
     public ScoreFunction.ApproximateScoreFunction scoreFunctionFor(VectorFloat<?> q, VectorSimilarityFunction similarityFunction) {
         var qBQ = bq.encode(q);
         return node2 -> {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/CompressedVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/CompressedVectors.java
@@ -53,7 +53,11 @@ public interface CompressedVectors extends Accountable {
     ScoreFunction.ApproximateScoreFunction precomputedScoreFunctionFor(VectorFloat<?> q, VectorSimilarityFunction similarityFunction);
 
     /** no precomputation; suitable when just a handful of score computations are performed */
+    ScoreFunction.ApproximateScoreFunction diversityFunctionFor(int nodeId, VectorSimilarityFunction similarityFunction);
+
+    /** no precomputation; suitable when just a handful of score computations are performed */
     ScoreFunction.ApproximateScoreFunction scoreFunctionFor(VectorFloat<?> q, VectorSimilarityFunction similarityFunction);
+
 
     @Deprecated
     default ScoreFunction.ApproximateScoreFunction approximateScoreFunctionFor(VectorFloat<?> q, VectorSimilarityFunction similarityFunction) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/NVQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/NVQVectors.java
@@ -108,6 +108,11 @@ public class NVQVectors implements CompressedVectors {
         return node2 -> function.similarityTo(compressedVectors[node2]);
     }
 
+    @Override
+    public ScoreFunction.ApproximateScoreFunction diversityFunctionFor(int node1, VectorSimilarityFunction similarityFunction) {
+        throw new UnsupportedOperationException();
+    }
+
     public NVQuantization.QuantizedVector get(int ordinal) {
         return compressedVectors[ordinal];
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/PQVectors.java
@@ -223,7 +223,6 @@ public abstract class PQVectors implements CompressedVectors {
         }
     }
 
-    @Override
     public ScoreFunction.ApproximateScoreFunction scoreFunctionFor(VectorFloat<?> q, VectorSimilarityFunction similarityFunction) {
         VectorFloat<?> centeredQuery = pq.globalCentroid == null ? q : VectorUtil.sub(q, pq.globalCentroid);
         switch (similarityFunction) {
@@ -273,6 +272,75 @@ public abstract class PQVectors implements CompressedVectors {
                         int centroidLength = pq.subvectorSizesAndOffsets[m][0];
                         int centroidOffset = pq.subvectorSizesAndOffsets[m][1];
                         sum += VectorUtil.squareL2Distance(pq.codebooks[m], centroidIndex * centroidLength, centeredQuery, centroidOffset, centroidLength);
+                    }
+                    // scale to [0, 1]
+                    return 1 / (1 + sum);
+                };
+            default:
+                throw new IllegalArgumentException("Unsupported similarity function " + similarityFunction);
+        }
+    }
+
+    @Override
+    public ScoreFunction.ApproximateScoreFunction diversityFunctionFor(int node1, VectorSimilarityFunction similarityFunction) {
+        final int subspaceCount = pq.getSubspaceCount();
+        var node1Chunk = getChunk(node1);
+        var node1Offset = getOffsetInChunk(node1);
+
+        switch (similarityFunction) {
+            case DOT_PRODUCT:
+                return (node2) -> {
+                    var node2Chunk = getChunk(node2);
+                    var node2Offset = getOffsetInChunk(node2);
+                    // compute the euclidean distance between the query and the codebook centroids corresponding to the encoded points
+                    float dp = 0;
+                    for (int m = 0; m < subspaceCount; m++) {
+                        int centroidIndex1 = Byte.toUnsignedInt(node1Chunk.get(m + node1Offset));
+                        int centroidIndex2 = Byte.toUnsignedInt(node2Chunk.get(m + node2Offset));
+                        int centroidLength = pq.subvectorSizesAndOffsets[m][0];
+                        dp += VectorUtil.dotProduct(pq.codebooks[m], centroidIndex1 * centroidLength, pq.codebooks[m], centroidIndex2 * centroidLength, centroidLength);
+                    }
+                    // scale to [0, 1]
+                    return (1 + dp) / 2;
+                };
+            case COSINE:
+                float norm1 = 0.0f;
+                for (int m1 = 0; m1 < subspaceCount; m1++) {
+                    int centroidIndex = Byte.toUnsignedInt(node1Chunk.get(m1 + node1Offset));
+                    int centroidLength = pq.subvectorSizesAndOffsets[m1][0];
+                    var codebookOffset = centroidIndex * centroidLength;
+                    norm1 += VectorUtil.dotProduct(pq.codebooks[m1], codebookOffset, pq.codebooks[m1], codebookOffset, centroidLength);
+                }
+                final float norm1final = norm1;
+                return (node2) -> {
+                    var node2Chunk = getChunk(node2);
+                    var node2Offset = getOffsetInChunk(node2);
+                    // compute the dot product of the query and the codebook centroids corresponding to the encoded points
+                    float sum = 0;
+                    float norm2 = 0;
+                    for (int m = 0; m < subspaceCount; m++) {
+                        int centroidIndex1 = Byte.toUnsignedInt(node1Chunk.get(m + node1Offset));
+                        int centroidIndex2 = Byte.toUnsignedInt(node2Chunk.get(m + node2Offset));
+                        int centroidLength = pq.subvectorSizesAndOffsets[m][0];
+                        int codebookOffset = centroidIndex2 * centroidLength;
+                        sum += VectorUtil.dotProduct(pq.codebooks[m], codebookOffset, pq.codebooks[m], centroidIndex1 * centroidLength, centroidLength);
+                        norm2 += VectorUtil.dotProduct(pq.codebooks[m], codebookOffset, pq.codebooks[m], codebookOffset, centroidLength);
+                    }
+                    float cosine = sum / (float) Math.sqrt(norm1final * norm2);
+                    // scale to [0, 1]
+                    return (1 + cosine) / 2;
+                };
+            case EUCLIDEAN:
+                return (node2) -> {
+                    var node2Chunk = getChunk(node2);
+                    var node2Offset = getOffsetInChunk(node2);
+                    // compute the euclidean distance between the query and the codebook centroids corresponding to the encoded points
+                    float sum = 0;
+                    for (int m = 0; m < subspaceCount; m++) {
+                        int centroidIndex1 = Byte.toUnsignedInt(node1Chunk.get(m + node1Offset));
+                        int centroidIndex2 = Byte.toUnsignedInt(node2Chunk.get(m + node2Offset));
+                        int centroidLength = pq.subvectorSizesAndOffsets[m][0];
+                        sum += VectorUtil.squareL2Distance(pq.codebooks[m], centroidIndex1 * centroidLength, pq.codebooks[m], centroidIndex2 * centroidLength, centroidLength);
                     }
                     // scale to [0, 1]
                     return 1 / (1 + sum);


### PR DESCRIPTION
… and decoding of nodes

For a JMH just benchmarking the diversity calculation this is a huge win

Before:
```
PQDistanceCalculationBenchmark.distanceCalculation          0         1536           100          10000  avgt    5   418.095 ±  4.628  ms/op
PQDistanceCalculationBenchmark.distanceCalculation         16         1536           100          10000  avgt    5   940.306 ±  2.556  ms/op
PQDistanceCalculationBenchmark.distanceCalculation         64         1536           100          10000  avgt    5  1214.263 ± 70.999  ms/op
PQDistanceCalculationBenchmark.distanceCalculation        192         1536           100          10000  avgt    5  2019.785 ± 67.312  ms/op
```

```
Benchmark                                           (M)  (dimension)  (queryCount)  (vectorCount)  Mode  Cnt    Score   Error  Units
PQDistanceCalculationBenchmark.distanceCalculation    0         1536           100          10000  avgt    5  417.770 ± 3.297  ms/op
PQDistanceCalculationBenchmark.distanceCalculation   16         1536           100          10000  avgt    5  261.959 ± 3.048  ms/op
PQDistanceCalculationBenchmark.distanceCalculation   64         1536           100          10000  avgt    5  376.058 ± 3.726  ms/op
PQDistanceCalculationBenchmark.distanceCalculation  192         1536           100          10000  avgt    5  666.985 ± 8.505  ms/op

```


For actual Graph Build using PQ diversity this is more like 25% boost

Before
```
Benchmark                                                    (numBaseVectors)  (numberOfPQSubspaces)  (originalDimension)  Mode  Cnt      Score      Error  Units
IndexConstructionWithRandomSetBenchmark.buildIndexBenchmark             10000                     48                  384  avgt    3   2998.352 ±  292.077  ms/op
IndexConstructionWithRandomSetBenchmark.buildIndexBenchmark            100000                     48                  384  avgt    3  30923.062 ± 1689.046  ms/op
```

After
```
Benchmark                                                    (numBaseVectors)  (numberOfPQSubspaces)  (originalDimension)  Mode  Cnt      Score      Error  Units
IndexConstructionWithRandomSetBenchmark.buildIndexBenchmark             10000                     48                  384  avgt    3   2370.760 ±  230.455  ms/op
IndexConstructionWithRandomSetBenchmark.buildIndexBenchmark            100000                     48                  384  avgt    3  25302.423 ± 2256.221  ms/op

```
