### PR TITLE
Create partial sums for PQ codebook for use during diversity checks

### DIFF
--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithRandomSetBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithRandomSetBenchmark.java
@@ -52,7 +52,7 @@ public class IndexConstructionWithRandomSetBenchmark {
     private BuildScoreProvider buildScoreProvider;
     private int M = 32; // graph degree
     private int beamWidth = 100;
-    @Param({"1536"})
+    @Param({"768", "1536"})
     private int originalDimension;
     @Param({/*"10000",*/ "100000"/*, "1000000"*/})
     int numBaseVectors;

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithRandomSetBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/IndexConstructionWithRandomSetBenchmark.java
@@ -41,7 +41,7 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(1)
+@Fork(value = 1, jvmArgsAppend = {"--add-modules=jdk.incubator.vector", "--enable-preview", "-Djvector.experimental.enable_native_vectorization=false"})
 @Warmup(iterations = 2)
 @Measurement(iterations = 3)
 @Threads(1)
@@ -52,14 +52,14 @@ public class IndexConstructionWithRandomSetBenchmark {
     private BuildScoreProvider buildScoreProvider;
     private int M = 32; // graph degree
     private int beamWidth = 100;
-    @Param({"768", "1536"})
+    @Param({"1536"})
     private int originalDimension;
     @Param({/*"10000",*/ "100000"/*, "1000000"*/})
     int numBaseVectors;
     @Param({"0", "16"})
     private int numberOfPQSubspaces;
 
-    @Setup(Level.Invocation)
+    @Setup(Level.Trial)
     public void setup() throws IOException {
 
         final var baseVectors = new ArrayList<VectorFloat<?>>(numBaseVectors);

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/PQDistanceCalculationBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/PQDistanceCalculationBenchmark.java
@@ -68,7 +68,7 @@ public class PQDistanceCalculationBenchmark {
     @Param({"100"})
     private int queryCount;
     
-    @Param({"0", "16", "64", "192"})
+    @Param({ "0", "16", "64", "192"})
     private int M; // Number of subspaces for PQ
     
 

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/PQDistanceCalculationBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/PQDistanceCalculationBenchmark.java
@@ -68,7 +68,7 @@ public class PQDistanceCalculationBenchmark {
     @Param({"100"})
     private int queryCount;
     
-    @Param({ "0", "16", "64", "192"})
+    @Param({"0", "16", "64", "192"})
     private int M; // Number of subspaces for PQ
     
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
@@ -318,31 +318,24 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
           int vector2OrdinalOffset,
           int clusterCount
   ) {
-    float sum = 0f;
-    int blockSize = clusterCount * (clusterCount + 1) / 2;
-    int k = clusterCount;               // number of centroids per codebook
+      final int k          = clusterCount;
+      final int blockSize  = k * (k + 1) / 2;
+      float res = 0f;
 
-    for (int i = 0; i < subspaceCount; i++) {
-      int c1 = Byte.toUnsignedInt(vector1Ordinals.get(i + vector1OrdinalOffset));
-      int c2 = Byte.toUnsignedInt(vector2Ordinals.get(i + vector1OrdinalOffset));
-      int r  = Math.min(c1, c2);
-      int c  = Math.max(c1, c2);
+      for (int i = 0; i < subspaceCount; i++) {
+          int c1 = Byte.toUnsignedInt(vector1Ordinals.get(i + vector1OrdinalOffset));
+          int c2 = Byte.toUnsignedInt(vector2Ordinals.get(i + vector2OrdinalOffset));
+          int r  = Math.min(c1, c2);
+          int c  = Math.max(c1, c2);
 
-      // compute row offset in the flattened upper triangle
-      int offsetRow = r * k - (r * (r - 1) / 2);
-      int idxInBlock = offsetRow + (c - r);
+          int offsetRow  = r * k - (r * (r - 1) / 2);
+          int idxInBlock = offsetRow + (c - r);
+          int base       = i * blockSize;
 
-      if (idxInBlock < 0 || idxInBlock >= blockSize) {
-        throw new IllegalStateException(
-                "computed idxInBlock out of range: " + idxInBlock + " (blockSize=" + blockSize + ")");
+          res += codebookPartialSums.get(base + idxInBlock);
       }
 
-      // jump to the start of this subspace's block
-      int base = i * blockSize;
-      sum += codebookPartialSums.get(base + idxInBlock);
-    }
-
-    return sum;
+      return res;
   }
 
   @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -170,6 +170,10 @@ public final class VectorUtil {
     return impl.assembleAndSum(data, dataBase, dataOffsets, dataOffsetsOffset, dataOffsetsLength);
   }
 
+  public static float assembleAndSumPQ(VectorFloat<?> data, int subspaceCount, ByteSequence<?> dataOffsets1, int dataOffsetsOffset1, ByteSequence<?> dataOffsets2, int dataOffsetsOffset2, int clusterCount) {
+    return impl.assembleAndSumPQ(data, subspaceCount, dataOffsets1, dataOffsetsOffset1, dataOffsets2, dataOffsetsOffset2, clusterCount);
+  }
+
   public static void bulkShuffleQuantizedSimilarity(ByteSequence<?> shuffles, int codebookCount, ByteSequence<?> quantizedPartials, float delta, float minDistance, VectorFloat<?> results, VectorSimilarityFunction vsf) {
     impl.bulkShuffleQuantizedSimilarity(shuffles, codebookCount, quantizedPartials, delta, minDistance, vsf, results);
   }
@@ -250,5 +254,4 @@ public final class VectorUtil {
   public static float nvqUniformLoss(VectorFloat<?> vector, float minValue, float maxValue, int nBits) {
     return impl.nvqUniformLoss(vector, minValue, maxValue, nBits);
   }
-
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
@@ -115,7 +115,7 @@ public interface VectorUtilSupport {
   float assembleAndSum(VectorFloat<?> data, int baseIndex, ByteSequence<?> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength);
 
   /**
-   * Calculates the sum of 2 vectors quantized using ProductQuantization.
+   * Calculates the distance between 2 vectors, which were quantized using Product Quantization, using a precomputed table of partial results
    *
    * See {@link ProductQuantization#createCodebookPartialSums(VectorSimilarityFunction)}
    *

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
@@ -24,6 +24,7 @@
 
 package io.github.jbellis.jvector.vector;
 
+import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
@@ -112,6 +113,22 @@ public interface VectorUtilSupport {
    * @return the sum of the points
    */
   float assembleAndSum(VectorFloat<?> data, int baseIndex, ByteSequence<?> baseOffsets, int baseOffsetsOffset, int baseOffsetsLength);
+
+  /**
+   * Calculates the sum of 2 vectors quantized using ProductQuantization.
+   *
+   * See {@link ProductQuantization#createCodebookPartialSums(VectorSimilarityFunction)}
+   *
+   * @param codebookPartialSums the vector of all PQ
+   * @param subspaceCount the number of PQ subspaces
+   * @param vector1Ordinals Specifies which centroid vector is used for each of node1's subvectors
+   * @param vector1OrdinalOffset the offset into the vector1Ordinals ByteSequence for node1 (in case vector1Ordinals is a chunk of many nodes)
+   * @param node2Ordinals Specifies which centroid vector is used for each of node2's subvectors
+   * @param node2OrdinalOffset the offset into the vector1Ordinals ByteSequence for node2 (in case vector1Ordinals is a chunk of many nodes)
+   * @param clusterCount the number of PQ clusters per subvector in the codebook
+   * @return the sum of the vectors
+   */
+  float assembleAndSumPQ(VectorFloat<?> codebookPartialSums, int subspaceCount, ByteSequence<?> vector1Ordinals, int vector1OrdinalOffset, ByteSequence<?> node2Ordinals, int node2OrdinalOffset, int clusterCount);
 
   int hammingDistance(long[] v1, long[] v2);
 

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
@@ -81,6 +81,20 @@ final class NativeVectorUtilSupport extends PanamaVectorUtilSupport
 
 
     @Override
+    public float assembleAndSumPQ(
+            VectorFloat<?> codebookPartialSums,
+            int subspaceCount,                  // = M
+            ByteSequence<?> vector1Ordinals,
+            int vector1OrdinalOffset,
+            ByteSequence<?> vector2Ordinals,
+            int vector2OrdinalOffset,
+            int clusterCount                    // = k
+    ) {
+        //Use the non-panama solution for now
+        return assembleAndSumPQ_128(codebookPartialSums, subspaceCount, vector1Ordinals, vector1OrdinalOffset, vector2Ordinals, vector2OrdinalOffset, clusterCount);
+    }
+
+    @Override
     public void calculatePartialSums(VectorFloat<?> codebook, int codebookBase, int size, int clusterCount, VectorFloat<?> query, int queryOffset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums) {
         switch (vsf) {
             case DOT_PRODUCT -> NativeSimdOps.calculate_partial_sums_dot_f32_512(((MemorySegmentVectorFloat)codebook).get(), codebookBase, size, clusterCount, ((MemorySegmentVectorFloat)query).get(), queryOffset, ((MemorySegmentVectorFloat)partialSums).get());

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestProductQuantization.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestProductQuantization.java
@@ -34,6 +34,7 @@ import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -303,5 +304,33 @@ public class TestProductQuantization extends RandomizedTest {
         // Test invalid inputs
         assertThrows(IllegalArgumentException.class, () -> PQVectors.calculateChunkParameters(-1, 8));
         assertThrows(IllegalArgumentException.class, () -> PQVectors.calculateChunkParameters(100, -1));
+    }
+
+    @Test
+    public void testPQCodebookSums() {
+        // Generate a PQ for random 2D vectors
+        var vectors = createRandomVectors(10000, 384);
+        var pq = ProductQuantization.compute(new ListRandomAccessVectorValues(vectors, 384), 48, 256, false);
+
+        MutablePQVectors pqm = new MutablePQVectors(pq);
+
+        // build the index vector-at-a-time (on disk)
+        for (int ordinal = 0; ordinal < vectors.size(); ordinal++)
+        {
+            VectorFloat<?> v = vectors.get(ordinal);
+            // compress the new vector and add it to the PQVectors
+            pqm.encodeAndSet(ordinal, v);
+        }
+
+        for (VectorSimilarityFunction vsf : VectorSimilarityFunction.values()) {
+            var sf = pqm.diversityFunctionFor(10, vsf);
+
+            ImmutablePQVectors pqi = ImmutablePQVectors.encodeAndBuild(pq, vectors.size(), new ListRandomAccessVectorValues(vectors, 384), ForkJoinPool.commonPool());
+            var sf2 = pqi.diversityFunctionFor(10, vsf);
+
+            for (int i = 0; i < vectors.size(); i++) {
+                assertEquals(vsf.name(), sf.similarityTo(i), sf2.similarityTo(i), 1e-6);
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the Product Quantization (PQ) codebase, primarily focused on enhancing support for similarity computations between quantized vectors and optimizing codebook partial sum calculations. The changes include new methods for calculating similarity using codebook partial sums, updates to benchmarks, and expanded tests to ensure correctness across similarity functions.

### Product Quantization and Similarity Function Enhancements

* Added a new method `createCodebookPartialSums` to `ProductQuantization`, enabling efficient computation of partial sums for codebook centroids and supporting multiple similarity functions (dot product, cosine, euclidean).
* Implemented and exposed `assembleAndSumPQ` in `VectorUtilSupport` and its implementations, allowing for fast similarity calculations between quantized vectors using precomputed codebook partial sums. [[1]](diffhunk://#diff-2fed7e0bbdea9456a19d6bfd95adeb56ca953e1c204b03d2185742ae11c72279R117-R132) [[2]](diffhunk://#diff-5a49d06e4207df1d06e2234ad65f4ff96fd6c97bd818076962e94432f1b27dbaR311-R347) [[3]](diffhunk://#diff-971935391e98d0bf553a9a5311b982ae213606ee5236cb37854601be9690443eR83-R96) [[4]](diffhunk://#diff-691bc23e9d5c15a1504394194e6b5d13d96fbaad46066a6a30f3adf06afb8a3dR173-R176)

### ImmutablePQVectors Improvements

* Added a cache for codebook partial sums in `ImmutablePQVectors` and a new `diversityFunctionFor` method that supports DOT_PRODUCT, COSINE, and EUCLIDEAN similarity functions, leveraging the new PQ partial sum mechanism. [[1]](diffhunk://#diff-4e79d9c49d1086e32ff105d929723f0a219316a840d987a34b54d849859989edR19-R30) [[2]](diffhunk://#diff-4e79d9c49d1086e32ff105d929723f0a219316a840d987a34b54d849859989edR44) [[3]](diffhunk://#diff-4e79d9c49d1086e32ff105d929723f0a219316a840d987a34b54d849859989edR56-R105)

### Benchmark and Test Updates

* Added comprehensive tests for PQ codebook partial sum calculations across all supported similarity functions, ensuring correctness between mutable and immutable PQ vector implementations.

Benchmarks show a > 2x improvement in build time.

<img width="2120" height="1308" alt="image" src="https://github.com/user-attachments/assets/04838710-b2c5-401c-9317-263e7a1203ab" />

**Testing with opensearch-jvector the test time went from >10m to 4m!!**

These changes collectively improve the performance and flexibility of similarity computations in PQ-based vector search, while ensuring correctness and maintainability through targeted benchmarks and tests.


