### PR TITLE
Enable specifying the benchmarks in the yaml file

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/BenchYAML.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/BenchYAML.java
@@ -22,6 +22,7 @@ import io.github.jbellis.jvector.example.yaml.DatasetCollection;
 import io.github.jbellis.jvector.example.yaml.MultiConfig;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -46,6 +47,8 @@ public class BenchYAML {
         var datasetCollection = DatasetCollection.load();
         var datasetNames = datasetCollection.getAll().stream().filter(dn -> pattern.matcher(dn).find()).collect(Collectors.toList());
 
+        List<MultiConfig> allConfigs = new ArrayList<>();
+
         if (!datasetNames.isEmpty()) {
             System.out.println("Executing the following datasets: " + datasetNames);
 
@@ -56,11 +59,7 @@ public class BenchYAML {
                     datasetName = datasetName.substring(0, datasetName.length() - ".hdf5".length());
                 }
                 MultiConfig config = MultiConfig.getDefaultConfig(datasetName);
-
-                Grid.runAll(ds, config.construction.outDegree, config.construction.efConstruction,
-                        config.construction.neighborOverflow, config.construction.addHierarchy, config.construction.refineFinalGraph,
-                        config.construction.getFeatureSets(), config.construction.getCompressorParameters(),
-                        config.search.getCompressorParameters(), config.search.topKOverquery, config.search.useSearchPruning);
+                allConfigs.add(config);
             }
         }
 
@@ -69,16 +68,20 @@ public class BenchYAML {
 
         if (!configNames.isEmpty()) {
             for (var configName : configNames) {
-                MultiConfig config = MultiConfig.getConfig(configName);
-                String datasetName = config.dataset;
-
-                DataSet ds = DataSetLoader.loadDataSet(datasetName);
-
-                Grid.runAll(ds, config.construction.outDegree, config.construction.efConstruction,
-                        config.construction.neighborOverflow, config.construction.addHierarchy, config.construction.refineFinalGraph,
-                        config.construction.getFeatureSets(), config.construction.getCompressorParameters(),
-                        config.search.getCompressorParameters(), config.search.topKOverquery, config.search.useSearchPruning);
+                MultiConfig config = MultiConfig.getDefaultConfig(configName);
+                allConfigs.add(config);
             }
+        }
+
+        for (var config : allConfigs) {
+            String datasetName = config.dataset;
+
+            DataSet ds = DataSetLoader.loadDataSet(datasetName);
+
+            Grid.runAll(ds, config.construction.outDegree, config.construction.efConstruction,
+                    config.construction.neighborOverflow, config.construction.addHierarchy, config.construction.refineFinalGraph,
+                    config.construction.getFeatureSets(), config.construction.getCompressorParameters(),
+                    config.search.getCompressorParameters(), config.search.topKOverquery, config.search.useSearchPruning, config.search.benchmarks);
         }
     }
 }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/yaml/ConstructionParameters.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/yaml/ConstructionParameters.java
@@ -39,6 +39,10 @@ public class ConstructionParameters extends CommonParameters {
                     return EnumSet.of(FeatureId.INLINE_VECTORS);
                 case "NVQ":
                     return EnumSet.of(FeatureId.NVQ_VECTORS);
+                case "FUSED+FP":
+                    return EnumSet.of(FeatureId.INLINE_VECTORS, FeatureId.FUSED_ADC);
+                case "FUSED+NVQ":
+                    return EnumSet.of(FeatureId.NVQ_VECTORS, FeatureId.FUSED_ADC);
                 default:
                     throw new IllegalArgumentException("Only 'FP' and 'NVQ' are supported");
             }

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/yaml/MultiConfig.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/yaml/MultiConfig.java
@@ -33,7 +33,11 @@ public class MultiConfig {
     public SearchParameters search;
 
     public static MultiConfig getDefaultConfig(String datasetName) throws FileNotFoundException {
-        File configFile = new File(defaultDirectory + datasetName + ".yml");
+        var name = defaultDirectory + datasetName;
+        if (!name.endsWith(".yml")) {
+            name += ".yml";
+        }
+        File configFile = new File(name);
         boolean useDefault = !configFile.exists();
         if (useDefault) {
             configFile = new File(defaultDirectory + "default.yml");
@@ -46,8 +50,8 @@ public class MultiConfig {
         return config;
     }
 
-    public static MultiConfig getConfig(String datasetName) throws FileNotFoundException {
-        File configFile = new File(datasetName);
+    public static MultiConfig getConfig(String configName) throws FileNotFoundException {
+        File configFile = new File(configName);
         return getConfig(configFile);
     }
 

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/yaml/SearchParameters.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/yaml/SearchParameters.java
@@ -22,4 +22,5 @@ import java.util.Map;
 public class SearchParameters extends CommonParameters {
     public Map<Integer, List<Double>> topKOverquery;
     public List<Boolean> useSearchPruning;
+    public Map<String, List<String>> benchmarks;
 }

--- a/jvector-examples/yaml-configs/default.yml
+++ b/jvector-examples/yaml-configs/default.yml
@@ -32,3 +32,8 @@ search:
         # k: 256 # optional parameter. By default, k=256
         centerData: No
         anisotropicThreshold: -1.0 # optional parameter. By default, anisotropicThreshold=-1 (i.e., no anisotropy)
+  benchmarks: # full option set, if the whole "benchmarks" section is not specified, a default set will be used
+    throughput: [ AVG ] # additional options: [AVG, MEDIAN, MAX]
+    latency: [ AVG ] # additional options: [ AVG, STD, P999 ]
+    count: [ visited ] # additional options: [ visited, expanded, expanded base layer ]
+    accuracy: [ recall ] # additional options: [ recall, MAP ]


### PR DESCRIPTION
This PR enables specifying which benchmarks to run and display in BenchYAML from the yaml file. This facilitates quickly changing the tables without hacking the code in Grid.java.

There is a new section in the yaml file, inside the search section, that can be specified as:
```
benchmarks:
    throughput: [AVG, MEDIAN, MAX] # a subset can be included
    latency: [ AVG, STD, P999 ] # a subset can be included
    count: [ visited, expanded, expanded base layer ] # a subset can be included
    accuracy: [ recall, MAP ] # a subset can be included
```
If the whole section is missing, a default set of benchmarks will be ran and displayed.