### PR TITLE
Reconstruct heap graph from disk graph

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
@@ -351,7 +351,7 @@ public class ConcurrentNeighborMap {
         }
     }
 
-    private static class NeighborIterator implements NodesIterator {
+    public static class NeighborIterator implements NodesIterator {
         private final NodeArray neighbors;
         private int i;
 
@@ -373,6 +373,10 @@ public class ConcurrentNeighborMap {
         @Override
         public int nextInt() {
             return neighbors.getNode(i++);
+        }
+
+        public NodeArray merge(NodeArray other) {
+            return NodeArray.merge(neighbors, other);
         }
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -957,4 +957,58 @@ public class GraphIndexBuilder implements Closeable {
         graph.updateEntryNode(new NodeAtLevel(0, entryNode));
         graph.setDegrees(List.of(maxDegree));
     }
+
+    /**
+     * Convenience method to build a new graph from an existing one, with the addition of new nodes.
+     * This is useful when we want to merge a new set of vectors into an existing graph that is already on disk.
+     *
+     * @param onDiskGraphIndex the on-disk representation of the graph index to be processed and converted.
+     * @param perLevelNeighborsScoreCache the cache containing pre-computed neighbor scores,
+     * @param newVectors a super set RAVV containing the new vectors to be added to the graph as well as the old ones that are already in the graph
+     * @param buildScoreProvider the provider responsible for calculating build scores.
+     * @param startingNodeOffset the offset in the newVectors RAVV where the new vectors start
+     * @param graphToRavvOrdMap a mapping from the old graph's node ids to the newVectors RAVV node ids
+     * @param beamWidth the width of the beam used during the graph building process.
+     * @param overflowRatio the ratio of extra neighbors to allow temporarily when inserting a node.
+     * @param alpha the weight factor for balancing score computations.
+     * @param addHierarchy whether to add hierarchical structures while building the graph.
+     *
+     * @return the in-memory representation of the graph index.
+     * @throws IOException if an I/O error occurs during the graph loading or conversion process.
+     */
+    public static ImmutableGraphIndex buildAndMergeNewNodes(OnDiskGraphIndex onDiskGraphIndex,
+                                                         NeighborsScoreCache perLevelNeighborsScoreCache,
+                                                         RandomAccessVectorValues newVectors,
+                                                         BuildScoreProvider buildScoreProvider,
+                                                         int startingNodeOffset,
+                                                         int[] graphToRavvOrdMap,
+                                                         int beamWidth,
+                                                         float overflowRatio,
+                                                         float alpha,
+                                                         boolean addHierarchy) throws IOException {
+
+
+
+        try (GraphIndexBuilder builder = new GraphIndexBuilder(buildScoreProvider,
+                onDiskGraphIndex,
+                perLevelNeighborsScoreCache,
+                beamWidth,
+                overflowRatio,
+                alpha,
+                addHierarchy,
+                true,
+                PhysicalCoreExecutor.pool(),
+                ForkJoinPool.commonPool())) {
+
+            var vv = newVectors.threadLocalSupplier();
+
+            // parallel graph construction from the merge documents Ids
+            PhysicalCoreExecutor.pool().submit(() -> IntStream.range(startingNodeOffset, newVectors.size()).parallel().forEach(ord -> {
+                builder.addGraphNode(ord, vv.get().getVector(graphToRavvOrdMap[ord]));
+            })).join();
+
+            builder.cleanup();
+            return builder.getGraph();
+        }
+    }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ImmutableGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ImmutableGraphIndex.java
@@ -61,6 +61,9 @@ public interface ImmutableGraphIndex extends AutoCloseable, Accountable {
      */
     NodesIterator getNodes(int level);
 
+    /** Return the dimension of the vectors in the graph */
+    int getDimension();
+
     /**
      * Return a View with which to navigate the graph.  Views are not threadsafe -- that is,
      * only one search at a time should be run per View.

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -617,7 +617,7 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
      * Converts an OnDiskGraphIndex to an OnHeapGraphIndex by copying all nodes, their levels, and neighbors,
      * along with other configuration details, from disk-based storage to heap-based storage.
      *
-     * @param diskIndex the disk-based index to be converted
+     * @param immutableGraphIndex the disk-based index to be converted
      * @param perLevelNeighborsScoreCache the cache containing pre-computed neighbor scores,
      *                                    organized by levels and nodes.
      * @param bsp The build score provider to be used for
@@ -626,7 +626,7 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
      * @return an OnHeapGraphIndex that is equivalent to the provided OnDiskGraphIndex but operates in heap memory
      * @throws IOException if an I/O error occurs during the conversion process
      */
-    public static OnHeapGraphIndex convertToHeap(OnDiskGraphIndex diskIndex,
+    public static OnHeapGraphIndex convertToHeap(ImmutableGraphIndex immutableGraphIndex,
                                                  NeighborsScoreCache perLevelNeighborsScoreCache,
                                                  BuildScoreProvider bsp,
                                                  float overflowRatio,
@@ -634,8 +634,8 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
 
         // Create a new OnHeapGraphIndex with the appropriate configuration
         List<Integer> maxDegrees = new ArrayList<>();
-        for (int level = 0; level <= diskIndex.getMaxLevel(); level++) {
-            maxDegrees.add(diskIndex.getDegree(level));
+        for (int level = 0; level <= immutableGraphIndex.getMaxLevel(); level++) {
+            maxDegrees.add(immutableGraphIndex.getDegree(level));
         }
 
         OnHeapGraphIndex heapIndex = new OnHeapGraphIndex(
@@ -645,10 +645,10 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
         );
 
         // Copy all nodes and their connections from disk to heap
-        try (var view = diskIndex.getView()) {
+        try (var view = immutableGraphIndex.getView()) {
             // Copy nodes level by level
-            for (int level = 0; level <= diskIndex.getMaxLevel(); level++) {
-                final NodesIterator nodesIterator = diskIndex.getNodes(level);
+            for (int level = 0; level <= immutableGraphIndex.getMaxLevel(); level++) {
+                final NodesIterator nodesIterator = immutableGraphIndex.getNodes(level);
                 final Map<Integer, NodeArray> levelNeighborsScoreCache = perLevelNeighborsScoreCache.getNeighborsScoresInLevel(level);
                 if (levelNeighborsScoreCache == null) {
                     throw new IllegalStateException("No neighbors score cache found for level " + level);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -77,6 +77,7 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
     private final CompletionTracker completions;
     private final ThreadSafeGrowableBitSet deletedNodes = new ThreadSafeGrowableBitSet(0);
     private final AtomicInteger maxNodeId = new AtomicInteger(-1);
+    private final int dimension;
 
     // Maximum number of neighbors (edges) per node per layer
     final List<Integer> maxDegrees;
@@ -86,9 +87,10 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
 
     private volatile boolean allMutationsCompleted = false;
 
-    OnHeapGraphIndex(List<Integer> maxDegrees, double overflowRatio, DiversityProvider diversityProvider) {
+    OnHeapGraphIndex(int dimension, List<Integer> maxDegrees, double overflowRatio, DiversityProvider diversityProvider) {
         this.overflowRatio = overflowRatio;
         this.maxDegrees = new IntArrayList();
+        this.dimension = dimension;
         setDegrees(maxDegrees);
         entryPoint = new AtomicReference<>();
         this.completions = new CompletionTracker(1024);
@@ -233,6 +235,11 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
     public NodesIterator getNodes(int level) {
         return NodesIterator.fromPrimitiveIterator(nodeStream(level).iterator(),
                                                    layers.get(level).size());
+    }
+
+    @Override
+    public int getDimension() {
+        return dimension;
     }
 
     @Override
@@ -639,6 +646,7 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
         }
 
         OnHeapGraphIndex heapIndex = new OnHeapGraphIndex(
+                immutableGraphIndex.getDimension(),
                 maxDegrees,
                 overflowRatio, // overflow ratio
                 new VamanaDiversityProvider(bsp, alpha) // diversity provider - can be null for basic usage

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -303,6 +303,10 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
         }
     }
 
+    public FrozenView getFrozenView() {
+        return new FrozenView();
+    }
+
     public ThreadSafeGrowableBitSet getDeletedNodes() {
         return deletedNodes;
     }
@@ -661,7 +665,7 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
                     final NodeArray neighbors = levelNeighborsScoreCache.get(nodeId).copy();
 
                     // Add the node with its neighbors
-                    heapIndex.addNode(level, nodeId, neighbors);
+                    heapIndex.connectNode(level, nodeId, neighbors);
                     heapIndex.markComplete(new NodeAtLevel(level, nodeId));
                 }
             }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/NeighborsScoreCache.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/NeighborsScoreCache.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph.disk;
+
+import io.github.jbellis.jvector.disk.IndexWriter;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.graph.*;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Cache containing pre-computed neighbor scores, organized by levels and nodes.
+ * <p>
+ * This cache bridges the gap between {@link OnDiskGraphIndex} and {@link OnHeapGraphIndex}:
+ * <ul>
+ * <li>{@link OnDiskGraphIndex} stores only neighbor IDs (not scores) for space efficiency</li>
+ * <li>{@link OnHeapGraphIndex} requires neighbor scores for pruning operations</li>
+ * </ul>
+ * <p>
+ * When converting from disk to heap representation, this cache avoids expensive score 
+ * recomputation by providing pre-calculated neighbor scores for all graph levels.
+ *
+ * @see OnHeapGraphIndex#convertToHeap(OnDiskGraphIndex, NeighborsScoreCache, BuildScoreProvider, float, float)
+ *
+ * This is particularly useful when merging new nodes into an existing graph.
+ * @see GraphIndexBuilder#buildAndMergeNewNodes(OnDiskGraphIndex, NeighborsScoreCache, RandomAccessVectorValues, BuildScoreProvider, int, int[], int, float, float, boolean)
+ */
+public class NeighborsScoreCache {
+    private final Map<Integer, Map<Integer, NodeArray>> perLevelNeighborsScoreCache;
+
+    public NeighborsScoreCache(OnHeapGraphIndex graphIndex) throws IOException {
+        try (OnHeapGraphIndex.FrozenView view = graphIndex.getFrozenView()) {
+            final Map<Integer, Map<Integer, NodeArray>> perLevelNeighborsScoreCache = new HashMap<>(graphIndex.getMaxLevel() + 1);
+            for (int level = 0; level <= graphIndex.getMaxLevel(); level++) {
+                final Map<Integer, NodeArray> levelNeighborsScores = new HashMap<>(graphIndex.size(level) + 1);
+                final NodesIterator nodesIterator = graphIndex.getNodes(level);
+                while (nodesIterator.hasNext()) {
+                    final int nodeId = nodesIterator.nextInt();
+
+                    ConcurrentNeighborMap.NeighborIterator neighborIterator = (ConcurrentNeighborMap.NeighborIterator) view.getNeighborsIterator(level, nodeId);
+                    final NodeArray neighbours = neighborIterator.merge(new NodeArray(neighborIterator.size()));
+                    levelNeighborsScores.put(nodeId, neighbours);
+                }
+
+                perLevelNeighborsScoreCache.put(level, levelNeighborsScores);
+            }
+
+            this.perLevelNeighborsScoreCache = perLevelNeighborsScoreCache;
+        }
+    }
+
+    public NeighborsScoreCache(RandomAccessReader in) throws IOException {
+        final int numberOfLevels = in.readInt();
+        perLevelNeighborsScoreCache = new HashMap<>(numberOfLevels);
+        for (int i = 0; i < numberOfLevels; i++) {
+            final int level = in.readInt();
+            final int numberOfNodesInLevel = in.readInt();
+            final Map<Integer, NodeArray> levelNeighborsScores = new HashMap<>(numberOfNodesInLevel);
+            for (int j = 0; j < numberOfNodesInLevel; j++) {
+                final int nodeId = in.readInt();
+                final int numberOfNeighbors = in.readInt();
+                final NodeArray nodeArray = new NodeArray(numberOfNeighbors);
+                for (int k = 0; k < numberOfNeighbors; k++) {
+                    final int neighborNodeId = in.readInt();
+                    final float neighborScore = in.readFloat();
+                    nodeArray.insertSorted(neighborNodeId, neighborScore);
+                }
+                levelNeighborsScores.put(nodeId, nodeArray);
+            }
+            perLevelNeighborsScoreCache.put(level, levelNeighborsScores);
+        }
+    }
+
+    public void write(IndexWriter out) throws IOException {
+        out.writeInt(perLevelNeighborsScoreCache.size()); // write the number of levels
+        for (Map.Entry<Integer ,Map<Integer, NodeArray>> levelNeighborsScores : perLevelNeighborsScoreCache.entrySet()) {
+            final int level = levelNeighborsScores.getKey();
+            out.writeInt(level);
+            out.writeInt(levelNeighborsScores.getValue().size()); // write the number of nodes in the level
+            // Write the neighborhoods for each node in the level
+            for (Map.Entry<Integer, NodeArray> nodeArrayEntry : levelNeighborsScores.getValue().entrySet()) {
+                final int nodeId = nodeArrayEntry.getKey();
+                out.writeInt(nodeId);
+                final NodeArray nodeArray = nodeArrayEntry.getValue();
+                out.writeInt(nodeArray.size()); // write the number of neighbors for the node
+                // Write the nodeArray(neighbors)
+                for (int i = 0; i < nodeArray.size(); i++) {
+                    out.writeInt(nodeArray.getNode(i));
+                    out.writeFloat(nodeArray.getScore(i));
+                }
+            }
+        }
+    }
+
+    public Map<Integer, NodeArray> getNeighborsScoresInLevel(int level) {
+        return perLevelNeighborsScoreCache.get(level);
+    }
+
+
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -225,6 +225,7 @@ public class OnDiskGraphIndex implements ImmutableGraphIndex, AutoCloseable, Acc
         return features.keySet();
     }
 
+    @Override
     public int getDimension() {
         return dimension;
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
@@ -25,6 +25,8 @@ import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 
+import java.util.stream.IntStream;
+
 /**
  * Encapsulates comparing node distances for GraphIndexBuilder.
  */
@@ -83,8 +85,17 @@ public interface BuildScoreProvider {
 
     /**
      * Returns a BSP that performs exact score comparisons using the given RandomAccessVectorValues and VectorSimilarityFunction.
+     *
+     * Helper method for the special case that mapping between graph node IDs and ravv ordinals is the identity function.
      */
     static BuildScoreProvider randomAccessScoreProvider(RandomAccessVectorValues ravv, VectorSimilarityFunction similarityFunction) {
+        return randomAccessScoreProvider(ravv, IntStream.range(0, ravv.size()).toArray(), similarityFunction);
+    }
+
+    /**
+     * Returns a BSP that performs exact score comparisons using the given RandomAccessVectorValues and VectorSimilarityFunction.
+     */
+    static BuildScoreProvider randomAccessScoreProvider(RandomAccessVectorValues ravv, int[] graphToRavvOrdMap, VectorSimilarityFunction similarityFunction) {
         // We need two sources of vectors in order to perform diversity check comparisons without
         // colliding.  ThreadLocalSupplier makes this a no-op if the RAVV is actually un-shared.
         var vectors = ravv.threadLocalSupplier();
@@ -113,22 +124,22 @@ public interface BuildScoreProvider {
             @Override
             public SearchScoreProvider searchProviderFor(VectorFloat<?> vector) {
                 var vc = vectorsCopy.get();
-                return DefaultSearchScoreProvider.exact(vector, similarityFunction, vc);
+                return DefaultSearchScoreProvider.exact(vector, graphToRavvOrdMap, similarityFunction, vc);
             }
 
             @Override
             public SearchScoreProvider searchProviderFor(int node1) {
                 RandomAccessVectorValues randomAccessVectorValues = vectors.get();
-                var v = randomAccessVectorValues.getVector(node1);
+                var v = randomAccessVectorValues.getVector(graphToRavvOrdMap[node1]);
                 return searchProviderFor(v);
             }
 
             @Override
             public SearchScoreProvider diversityProviderFor(int node1) {
                 RandomAccessVectorValues randomAccessVectorValues = vectors.get();
-                var v = randomAccessVectorValues.getVector(node1);
+                var v = randomAccessVectorValues.getVector(graphToRavvOrdMap[node1]);
                 var vc = vectorsCopy.get();
-                return DefaultSearchScoreProvider.exact(v, similarityFunction, vc);
+                return DefaultSearchScoreProvider.exact(v, graphToRavvOrdMap, similarityFunction, vc);
             }
         };
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/DefaultSearchScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/DefaultSearchScoreProvider.java
@@ -78,4 +78,20 @@ public final class DefaultSearchScoreProvider implements SearchScoreProvider {
         };
         return new DefaultSearchScoreProvider(sf);
     }
+
+    /**
+     * A SearchScoreProvider for a single-pass search based on exact similarity.
+     * Generally only suitable when your RandomAccessVectorValues is entirely in-memory,
+     * e.g. during construction.
+     */
+    public static DefaultSearchScoreProvider exact(VectorFloat<?> v, int[] graphToRavvOrdMap ,VectorSimilarityFunction vsf, RandomAccessVectorValues ravv) {
+        // don't use ESF.reranker, we need thread safety here
+        var sf = new ScoreFunction.ExactScoreFunction() {
+            @Override
+            public float similarityTo(int node2) {
+                return vsf.compare(v, ravv.getVector(graphToRavvOrdMap[node2]));
+            }
+        };
+        return new DefaultSearchScoreProvider(sf);
+    }
 }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/TestUtil.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/TestUtil.java
@@ -281,6 +281,11 @@ public class TestUtil {
         }
 
         @Override
+        public int getDimension() {
+            throw new NotImplementedException();
+        }
+
+        @Override
         public View getView() {
             return new FullyConnectedGraphIndexView();
         }
@@ -397,6 +402,11 @@ public class TestUtil {
         public NodesIterator getNodes(int level) {
             int sz = layerInfo.get(level).size;
             return new NodesIterator.ArrayNodesIterator(IntStream.range(0, sz).toArray(), sz);
+        }
+
+        @Override
+        public int getDimension() {
+            throw new NotImplementedException();
         }
 
         @Override

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/OnHeapGraphIndexTest.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/OnHeapGraphIndexTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import io.github.jbellis.jvector.TestUtil;
+import io.github.jbellis.jvector.disk.SimpleMappedReader;
+import io.github.jbellis.jvector.disk.SimpleWriter;
+import io.github.jbellis.jvector.graph.disk.NeighborsScoreCache;
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
+import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class OnHeapGraphIndexTest extends RandomizedTest  {
+    private final static Logger log = org.apache.logging.log4j.LogManager.getLogger(OnHeapGraphIndexTest.class);
+    private static final VectorTypeSupport VECTOR_TYPE_SUPPORT = VectorizationProvider.getInstance().getVectorTypeSupport();
+    private static final int NUM_BASE_VECTORS = 100;
+    private static final int NUM_NEW_VECTORS = 100;
+    private static final int NUM_ALL_VECTORS = NUM_BASE_VECTORS + NUM_NEW_VECTORS;
+    private static final int DIMENSION = 16;
+    private static final int M = 8;
+    private static final int BEAM_WIDTH = 100;
+    private static final float ALPHA = 1.2f;
+    private static final float NEIGHBOR_OVERFLOW = 1.2f;
+    private static final boolean ADD_HIERARCHY = false;
+    private static final int TOP_K = 10;
+
+    private Path testDirectory;
+
+    private ArrayList<VectorFloat<?>> baseVectors;
+    private ArrayList<VectorFloat<?>> newVectors;
+    private ArrayList<VectorFloat<?>> allVectors;
+    private RandomAccessVectorValues baseVectorsRavv;
+    private RandomAccessVectorValues newVectorsRavv;
+    private RandomAccessVectorValues allVectorsRavv;
+    private VectorFloat<?> queryVector;
+    private int[] groundTruthBaseVectors;
+    private int[] groundTruthAllVectors;
+    private BuildScoreProvider baseBuildScoreProvider;
+    private BuildScoreProvider newBuildScoreProvider;
+    private BuildScoreProvider allBuildScoreProvider;
+    private OnHeapGraphIndex baseGraphIndex;
+    private OnHeapGraphIndex newGraphIndex;
+    private OnHeapGraphIndex allGraphIndex;
+
+    @Before
+    public void setup() throws IOException {
+        testDirectory = Files.createTempDirectory(this.getClass().getSimpleName());
+        baseVectors = new ArrayList<>(NUM_BASE_VECTORS);
+        newVectors = new ArrayList<>(NUM_NEW_VECTORS);
+        allVectors = new ArrayList<>(NUM_ALL_VECTORS);
+        for (int i = 0; i < NUM_BASE_VECTORS; i++) {
+            VectorFloat<?> vector = createRandomVector(DIMENSION);
+            baseVectors.add(vector);
+            allVectors.add(vector);
+        }
+        for (int i = 0; i < NUM_NEW_VECTORS; i++) {
+            VectorFloat<?> vector = createRandomVector(DIMENSION);
+            newVectors.add(vector);
+            allVectors.add(vector);
+        }
+
+        // wrap the raw vectors in a RandomAccessVectorValues
+        baseVectorsRavv = new ListRandomAccessVectorValues(baseVectors, DIMENSION);
+        newVectorsRavv = new ListRandomAccessVectorValues(newVectors, DIMENSION);
+        allVectorsRavv = new ListRandomAccessVectorValues(allVectors, DIMENSION);
+
+        queryVector = createRandomVector(DIMENSION);
+        groundTruthBaseVectors = getGroundTruth(baseVectorsRavv, queryVector, TOP_K, VectorSimilarityFunction.EUCLIDEAN);
+        groundTruthAllVectors = getGroundTruth(allVectorsRavv, queryVector, TOP_K, VectorSimilarityFunction.EUCLIDEAN);
+
+        // score provider using the raw, in-memory vectors
+        baseBuildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(baseVectorsRavv, VectorSimilarityFunction.EUCLIDEAN);
+        newBuildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(newVectorsRavv, VectorSimilarityFunction.EUCLIDEAN);
+        allBuildScoreProvider = BuildScoreProvider.randomAccessScoreProvider(allVectorsRavv, VectorSimilarityFunction.EUCLIDEAN);
+        var baseGraphIndexBuilder = new GraphIndexBuilder(baseBuildScoreProvider,
+                baseVectorsRavv.dimension(),
+                M, // graph degree
+                BEAM_WIDTH, // construction search depth
+                NEIGHBOR_OVERFLOW, // allow degree overflow during construction by this factor
+                ALPHA, // relax neighbor diversity requirement by this factor
+                ADD_HIERARCHY); // add the hierarchy
+        var allGraphIndexBuilder = new GraphIndexBuilder(allBuildScoreProvider,
+                allVectorsRavv.dimension(),
+                M, // graph degree
+                BEAM_WIDTH, // construction search depth
+                NEIGHBOR_OVERFLOW, // allow degree overflow during construction by this factor
+                ALPHA, // relax neighbor diversity requirement by this factor
+                ADD_HIERARCHY); // add the hierarchy
+
+        baseGraphIndex = baseGraphIndexBuilder.build(baseVectorsRavv);
+        allGraphIndex = allGraphIndexBuilder.build(allVectorsRavv);
+    }
+
+    @After
+    public void tearDown() {
+        TestUtil.deleteQuietly(testDirectory);
+    }
+
+
+    /**
+     * Create an {@link OnHeapGraphIndex} persist it as a {@link OnDiskGraphIndex} and reconstruct back to a mutable {@link OnHeapGraphIndex}
+     * Make sure that both graphs are equivalent
+     * @throws IOException
+     */
+    @Test
+    public void testReconstructionOfOnHeapGraphIndex() throws IOException {
+        var graphOutputPath = testDirectory.resolve("testReconstructionOfOnHeapGraphIndex_" + baseGraphIndex.getClass().getSimpleName());
+        var neighborsScoreCacheOutputPath = testDirectory.resolve("testReconstructionOfOnHeapGraphIndex_" + NeighborsScoreCache.class.getSimpleName());
+        log.info("Writing graph to {}", graphOutputPath);
+        TestUtil.writeGraph(baseGraphIndex, baseVectorsRavv, graphOutputPath);
+
+        log.info("Writing neighbors score cache to {}", neighborsScoreCacheOutputPath);
+        final NeighborsScoreCache neighborsScoreCache = new NeighborsScoreCache(baseGraphIndex);
+        try (SimpleWriter writer = new SimpleWriter(neighborsScoreCacheOutputPath.toAbsolutePath())) {
+            neighborsScoreCache.write(writer);
+        }
+
+        log.info("Reading neighbors score cache from {}", neighborsScoreCacheOutputPath);
+        final NeighborsScoreCache neighborsScoreCacheRead;
+        try (var readerSupplier = new SimpleMappedReader.Supplier(neighborsScoreCacheOutputPath.toAbsolutePath())) {
+            neighborsScoreCacheRead = new NeighborsScoreCache(readerSupplier.get());
+        }
+
+        try (var readerSupplier = new SimpleMappedReader.Supplier(graphOutputPath.toAbsolutePath());
+             var onDiskGraph = OnDiskGraphIndex.load(readerSupplier)) {
+            TestUtil.assertGraphEquals(baseGraphIndex, onDiskGraph);
+            try (var onDiskView = onDiskGraph.getView()) {
+                validateVectors(onDiskView, baseVectorsRavv);
+            }
+
+            OnHeapGraphIndex reconstructedOnHeapGraphIndex = OnHeapGraphIndex.convertToHeap(onDiskGraph, neighborsScoreCacheRead, baseBuildScoreProvider, NEIGHBOR_OVERFLOW, ALPHA);
+            TestUtil.assertGraphEquals(baseGraphIndex, reconstructedOnHeapGraphIndex);
+            TestUtil.assertGraphEquals(onDiskGraph, reconstructedOnHeapGraphIndex);
+
+        }
+    }
+
+    /**
+     * Create {@link OnDiskGraphIndex} then append to it via {@link GraphIndexBuilder#buildAndMergeNewNodes}
+     * Verify that the resulting OnHeapGraphIndex is equivalent to the graph that would have been alternatively generated by bulk index into a new {@link OnDiskGraphIndex}
+     */
+    @Test
+    public void testIncrementalInsertionFromOnDiskIndex() throws IOException {
+        var outputPath = testDirectory.resolve("testReconstructionOfOnHeapGraphIndex_" + baseGraphIndex.getClass().getSimpleName());
+        log.info("Writing graph to {}", outputPath);
+        final NeighborsScoreCache neighborsScoreCache = new NeighborsScoreCache(baseGraphIndex);
+        TestUtil.writeGraph(baseGraphIndex, baseVectorsRavv, outputPath);
+        try (var readerSupplier = new SimpleMappedReader.Supplier(outputPath.toAbsolutePath());
+             var onDiskGraph = OnDiskGraphIndex.load(readerSupplier)) {
+            TestUtil.assertGraphEquals(baseGraphIndex, onDiskGraph);
+            // We will create a trivial 1:1 mapping between the new graph and the ravv
+            final int[] graphToRavvOrdMap = IntStream.range(0, allVectorsRavv.size()).toArray();
+            OnHeapGraphIndex reconstructedAllNodeOnHeapGraphIndex = GraphIndexBuilder.buildAndMergeNewNodes(onDiskGraph, neighborsScoreCache, allVectorsRavv, allBuildScoreProvider, NUM_BASE_VECTORS, graphToRavvOrdMap, BEAM_WIDTH, NEIGHBOR_OVERFLOW, ALPHA, ADD_HIERARCHY);
+
+            // Verify that the recall is similar
+            float recallFromReconstructedAllNodeOnHeapGraphIndex = calculateRecall(reconstructedAllNodeOnHeapGraphIndex, allBuildScoreProvider, queryVector, groundTruthAllVectors, TOP_K);
+            float recallFromAllGraphIndex = calculateRecall(allGraphIndex, allBuildScoreProvider, queryVector, groundTruthAllVectors, TOP_K);
+            Assert.assertEquals(recallFromReconstructedAllNodeOnHeapGraphIndex, recallFromAllGraphIndex, 0.01f);
+        }
+    }
+
+    public static void validateVectors(OnDiskGraphIndex.View view, RandomAccessVectorValues ravv) {
+        for (int i = 0; i < view.size(); i++) {
+            assertEquals("Incorrect vector at " + i, ravv.getVector(i), view.getVector(i));
+        }
+    }
+
+    private VectorFloat<?> createRandomVector(int dimension) {
+        VectorFloat<?> vector = VECTOR_TYPE_SUPPORT.createFloatVector(dimension);
+        for (int i = 0; i < dimension; i++) {
+            vector.set(i, (float) Math.random());
+        }
+        return vector;
+    }
+
+    /**
+     * Get the ground truth for a query vector
+     * @param ravv the vectors to search
+     * @param queryVector the query vector
+     * @param topK the number of results to return
+     * @param similarityFunction the similarity function to use
+
+     * @return the ground truth
+     */
+    private static int[] getGroundTruth(RandomAccessVectorValues ravv, VectorFloat<?> queryVector, int topK, VectorSimilarityFunction similarityFunction) {
+        var exactResults = new ArrayList<SearchResult.NodeScore>();
+        for (int i = 0; i < ravv.size(); i++) {
+            float similarityScore = similarityFunction.compare(queryVector, ravv.getVector(i));
+            exactResults.add(new SearchResult.NodeScore(i, similarityScore));
+        }
+        exactResults.sort((a, b) -> Float.compare(b.score, a.score));
+        return exactResults.stream().limit(topK).mapToInt(nodeScore -> nodeScore.node).toArray();
+    }
+
+    private static float calculateRecall(OnHeapGraphIndex graphIndex, BuildScoreProvider buildScoreProvider, VectorFloat<?> queryVector, int[] groundTruth, int k) throws IOException {
+        try (GraphSearcher graphSearcher = new GraphSearcher(graphIndex)){
+            SearchScoreProvider ssp = buildScoreProvider.searchProviderFor(queryVector);
+            var searchResults = graphSearcher.search(ssp, k, Bits.ALL);
+            var predicted = Arrays.stream(searchResults.getNodes()).mapToInt(nodeScore -> nodeScore.node).boxed().collect(Collectors.toSet());
+            return calculateRecall(predicted, groundTruth, k);
+        }
+    }
+    /**
+     * Calculate the recall for a set of predicted results
+     * @param predicted the predicted results
+     * @param groundTruth the ground truth
+     * @param k the number of results to consider
+     * @return the recall
+     */
+    private static float calculateRecall(Set<Integer> predicted, int[] groundTruth, int k) {
+        int hits = 0;
+        int actualK = Math.min(k, Math.min(predicted.size(), groundTruth.length));
+
+        for (int i = 0; i < actualK; i++) {
+            for (int j = 0; j < actualK; j++) {
+                if (predicted.contains(groundTruth[j])) {
+                    hits++;
+                    break;
+                }
+            }
+        }
+
+        return ((float) hits) / (float) actualK;
+    }
+}

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProviderTest.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProviderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph.similarity;
+
+import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class BuildScoreProviderTest {
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    /**
+     * Test that the ordinal mapping is correctly applied when creating search and diversity score providers.
+     */
+    @Test
+    public void testOrdinalMapping() {
+        final VectorSimilarityFunction vsf = VectorSimilarityFunction.DOT_PRODUCT;
+
+        // Create test vectors
+        final List<VectorFloat<?>> vectors = new ArrayList<>();
+        vectors.add(vts.createFloatVector(new float[]{1.0f, 0.0f}));
+        vectors.add(vts.createFloatVector(new float[]{0.0f, 1.0f}));
+        vectors.add(vts.createFloatVector(new float[]{-1.0f, 0.0f}));
+        var ravv = new ListRandomAccessVectorValues(vectors, 2);
+
+        // Create non-identity mapping: graph node 0 -> ravv ordinal 2, graph node 1 -> ravv ordinal 0, graph node 2 -> ravv ordinal 1
+        int[] graphToRavvOrdMap = {2, 0, 1};
+        
+        var bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, graphToRavvOrdMap, vsf);
+        
+        // Test that searchProviderFor(graphNode) uses the correct RAVV ordinal
+        var ssp0 = bsp.searchProviderFor(0); // should use ravv ordinal 2 (vector [-1, 0])
+        var ssp1 = bsp.searchProviderFor(1); // should use ravv ordinal 0 (vector [1, 0])
+        var ssp2 = bsp.searchProviderFor(2); // should use ravv ordinal 1 (vector [0, 1])
+        
+        // Verify by computing similarity between graph nodes
+        // Graph node 0 (vector 2:[-1, 0]) vs graph node 1 (vector 0:[1, 0])
+        assertEquals(vsf.compare(vectors.get(2), vectors.get(0)), ssp0.exactScoreFunction().similarityTo(1), 1e-6f);
+        
+        // Graph node 1 (vector 0:[1, 0]) vs graph node 0 (vector 2:[-1, 0])
+        assertEquals(vsf.compare(vectors.get(0), vectors.get(2)), ssp1.exactScoreFunction().similarityTo(0), 1e-6f);
+        
+        // Graph node 2 (vector 1:[0, 1]) vs graph node 1 (vector 0:[1, 0])
+        assertEquals(vsf.compare(vectors.get(1), vectors.get(0)), ssp2.exactScoreFunction().similarityTo(1), 1e-6f);
+        
+        // Test diversityProviderFor uses same mapping, Graph node 0 (vector 2:[-1, 0]) vs graph node 1 (vector 0:[1, 0])
+        var dsp0 = bsp.diversityProviderFor(0);
+        assertEquals(vsf.compare(vectors.get(2), vectors.get(0)), dsp0.exactScoreFunction().similarityTo(1), 1e-6f);
+    }
+}


### PR DESCRIPTION
#### Description
Multiple database projects such as C* and OpenSearch/Solr/Lucene use LSM mechanism with frequent merges.
This in turn creates a high overhead that forces us to reconstruct the entire graph from scratch upon every merge.
A more economic approach would be to pick a leading graph that was previously persisted to disk and incrementally add small graph nodes to it.

This PR makes some of the required changes to support that behavior in upstream systems such as C* and OpenSearch.

#### Changes

1. **Serializable Neighbor Distance Cache** - Add a serializable cache that can store the node distances within the `OnDiskGraphIndex` for a faster re-creation of the `OnHeapGraphIndex` when read back from disk. The cache is separate and is optional, therefore we can choose whether to apply it or not, without any breaking changes to the current `OnDiskGraphIndex`. This can later be augmented to a format if we choose to.
2. **Help Methods And Constructors** - Add helper method and constructors to facilitate easier usage by other projects with graph merge use cases.

#### Testing

Added tests for graph overlap and recall for reconstructed graphs.