### PR TITLE
GraphIndexBuilder::addGraphNode must iterate all graph levels to estimate used bytes

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -597,7 +597,7 @@ public class GraphIndexBuilder implements Closeable {
             insertionsInProgress.remove(nodeLevel);
         }
 
-        return IntStream.range(0, nodeLevel.level).mapToLong(graph::ramBytesUsedOneNode).sum();
+        return IntStream.rangeClosed(0, nodeLevel.level).mapToLong(graph::ramBytesUsedOneNode).sum();
     }
 
     private void updateNeighborsOneLayer(int layer, int node, NodeScore[] neighbors, NodeArray naturalScratchPooled, ConcurrentSkipListSet<NodeAtLevel> inProgressBefore, NodeArray concurrentScratchPooled, SearchScoreProvider ssp) {

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/GraphIndexBuilderTest.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/GraphIndexBuilderTest.java
@@ -57,6 +57,22 @@ public class GraphIndexBuilderTest extends LuceneTestCase {
     }
 
     @Test
+    public void testEstimatedBytes() throws IOException {
+        // Create test vectors where each vector is [node_id, 0]
+        var vectors = new ArrayList<VectorFloat<?>>();
+        vectors.add(vts.createFloatVector(new float[] {0, 0}));
+        vectors.add(vts.createFloatVector(new float[] {0, 1}));
+        vectors.add(vts.createFloatVector(new float[] {2, 0}));
+        var ravv = new ListRandomAccessVectorValues(vectors, 2);
+        var bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, VectorSimilarityFunction.EUCLIDEAN);
+        try (var builder = new GraphIndexBuilder(bsp, 2, 2, 10, 1.0f, 1.0f, false)) {
+            var bytesUsed = builder.addGraphNode(0, ravv.getVector(0));
+            // The actual value is not critical, but this confirms we do not get unexpected changes (for this config)
+            assertEquals(92, bytesUsed);
+        }
+    }
+
+    @Test
     public void testRescore() {
         testRescore(false);
         testRescore(true);


### PR DESCRIPTION
The current implementation for `GraphIndexBuilder::addGraphNode` has a bug in the byte estimation logic. It calls `IntStream.range(0, nodeLevel.level)`, which in turn calls:

```java
    public static IntStream range(int startInclusive, int endExclusive) {
        if (startInclusive >= endExclusive) {
            return empty();
        } else {
            return StreamSupport.intStream(
                    new Streams.RangeIntSpliterator(startInclusive, endExclusive, false), false);
        }
    }
```

This is problematic because the `nodeLevel.level` is inclusive while the right bound of the range is exclusive.

The end result is an estimate that systematically misses the numerically highest level of the graph, thereby under counting bytes used. In reviewing the `IntStream` api, it seems most appropriate to use the `rangeClosed` method to achieve the desired semantics.