### PR TITLE
New MutableGraphIndex and ImmutableGraphIndex interfaces

### DIFF
--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/RecallWithRandomVectorsBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/RecallWithRandomVectorsBenchmark.java
@@ -52,7 +52,7 @@ public class RecallWithRandomVectorsBenchmark {
     private ArrayList<VectorFloat<?>> baseVectors;
     private ArrayList<VectorFloat<?>> queryVectors;
     private GraphIndexBuilder graphIndexBuilder;
-    private GraphIndex graphIndex;
+    private ImmutableGraphIndex graphIndex;
     private PQVectors pqVectors;
 
     // Add ground truth storage

--- a/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/StaticSetVectorsBenchmark.java
+++ b/benchmarks-jmh/src/main/java/io/github/jbellis/jvector/bench/StaticSetVectorsBenchmark.java
@@ -45,7 +45,7 @@ public class StaticSetVectorsBenchmark {
     private List<VectorFloat<?>> queryVectors;
     private List<List<Integer>> groundTruth;
     private GraphIndexBuilder graphIndexBuilder;
-    private GraphIndex graphIndex;
+    private ImmutableGraphIndex graphIndex;
     int originalDimension;
 
     @Setup

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -18,7 +18,7 @@ package io.github.jbellis.jvector.graph;
 
 import io.github.jbellis.jvector.annotations.VisibleForTesting;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
-import io.github.jbellis.jvector.graph.GraphIndex.NodeAtLevel;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex.NodeAtLevel;
 import io.github.jbellis.jvector.graph.SearchResult.NodeScore;
 import io.github.jbellis.jvector.graph.diversity.VamanaDiversityProvider;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
@@ -30,7 +30,6 @@ import io.github.jbellis.jvector.util.ExplicitThreadLocal;
 import io.github.jbellis.jvector.util.PhysicalCoreExecutor;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
-import org.agrona.collections.IntArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +48,7 @@ import static io.github.jbellis.jvector.util.DocIdSetIterator.NO_MORE_DOCS;
 import static java.lang.Math.*;
 
 /**
- * Builder for Concurrent GraphIndex. See {@link GraphIndex} for a high level overview, and the
+ * Builder for Concurrent GraphIndex. See {@link ImmutableGraphIndex} for a high level overview, and the
  * comments to `addGraphNode` for details on the concurrent building approach.
  * <p>
  * GIB allocates scratch space and copies of the RandomAccessVectorValues for each thread
@@ -71,7 +70,7 @@ public class GraphIndexBuilder implements Closeable {
     private final boolean refineFinalGraph;
 
     @VisibleForTesting
-    final OnHeapGraphIndex graph;
+    final MutableGraphIndex graph;
 
     private final ConcurrentSkipListSet<NodeAtLevel> insertionsInProgress = new ConcurrentSkipListSet<>();
 
@@ -343,7 +342,7 @@ public class GraphIndexBuilder implements Closeable {
     public static GraphIndexBuilder rescore(GraphIndexBuilder other, BuildScoreProvider newProvider) {
         var newBuilder = new GraphIndexBuilder(newProvider,
                 other.dimension,
-                other.graph.maxDegrees,
+                other.graph.maxDegrees(),
                 other.beamWidth,
                 other.neighborOverflow,
                 other.alpha,
@@ -352,17 +351,13 @@ public class GraphIndexBuilder implements Closeable {
                 other.simdExecutor,
                 other.parallelExecutor);
 
+        var otherView = other.graph.getView();
+
         // Copy each node and its neighbors from the old graph to the new one
         other.parallelExecutor.submit(() -> {
             IntStream.range(0, other.graph.getIdUpperBound()).parallel().forEach(i -> {
                 // Find the highest layer this node exists in
-                int maxLayer = -1;
-                for (int lvl = 0; lvl < other.graph.layers.size(); lvl++) {
-                    if (other.graph.getNeighbors(lvl, i) == null) {
-                        break;
-                    }
-                    maxLayer = lvl;
-                }
+                int maxLayer = other.graph.getMaxLevelForNode(i);
                 if (maxLayer < 0) {
                     return;
                 }
@@ -370,7 +365,7 @@ public class GraphIndexBuilder implements Closeable {
                 // Loop over 0..maxLayer, re-score neighbors for each layer
                 var sf = newProvider.searchProviderFor(i).scoreFunction();
                 for (int lvl = 0; lvl <= maxLayer; lvl++) {
-                    var oldNeighborsIt = other.graph.getNeighborsIterator(lvl, i);
+                    var oldNeighborsIt = otherView.getNeighborsIterator(lvl, i);
                     // Copy edges, compute new scores
                     var newNeighbors = new NodeArray(oldNeighborsIt.size());
                     while (oldNeighborsIt.hasNext()) {
@@ -378,18 +373,18 @@ public class GraphIndexBuilder implements Closeable {
                         // since we're using a different score provider, use insertSorted instead of addInOrder
                         newNeighbors.insertSorted(neighbor, sf.similarityTo(neighbor));
                     }
-                    newBuilder.graph.addNode(lvl, i, newNeighbors);
+                    newBuilder.graph.connectNode(lvl, i, newNeighbors);
                 }
             });
         }).join();
 
         // Set the entry node
-        newBuilder.graph.updateEntryNode(other.graph.entry());
+        newBuilder.graph.updateEntryNode(otherView.entryNode());
 
         return newBuilder;
     }
 
-    public OnHeapGraphIndex build(RandomAccessVectorValues ravv) {
+    public ImmutableGraphIndex build(RandomAccessVectorValues ravv) {
         var vv = ravv.threadLocalSupplier();
         int size = ravv.size();
 
@@ -401,6 +396,19 @@ public class GraphIndexBuilder implements Closeable {
 
         cleanup();
         return graph;
+    }
+
+    /**
+     * Validates that the current entry node has been completely added.
+     */
+    void validateEntryNode() {
+        if (graph.size(0) == 0) {
+            return;
+        }
+        NodeAtLevel entry = graph.entryNode();
+        if (entry == null || !graph.getView().contains(entry.level, entry.node)) {
+            throw new IllegalStateException("Entry node was incompletely added! " + entry);
+        }
     }
 
     /**
@@ -417,7 +425,7 @@ public class GraphIndexBuilder implements Closeable {
         if (graph.size(0) == 0) {
             return;
         }
-        graph.validateEntryNode(); // sanity check before we start
+        validateEntryNode(); // sanity check before we start
 
         // purge deleted nodes.
         // backlinks can cause neighbors to soft-overflow, so do this before neighbors cleanup
@@ -442,8 +450,8 @@ public class GraphIndexBuilder implements Closeable {
         // clean up overflowed neighbor lists
         parallelExecutor.submit(() -> {
             IntStream.range(0, graph.getIdUpperBound()).parallel().forEach(id -> {
-                for (int layer = 0; layer < graph.layers.size(); layer++) {
-                    graph.layers.get(layer).enforceDegree(id);
+                for (int layer = 0; layer <= graph.getMaxLevel(); layer++) {
+                    graph.enforceDegree(id);
                 }
             });
         }).join();
@@ -453,23 +461,22 @@ public class GraphIndexBuilder implements Closeable {
         var ssp = scoreProvider.searchProviderFor(node);
         var bits = new ExcludingBits(node);
         try (var gs = searchers.get()) {
-            gs.initializeInternal(ssp, graph.entry(), bits);
+            gs.initializeInternal(ssp, graph.entryNode(), bits);
             var acceptedBits = Bits.intersectionOf(bits, gs.getView().liveNodes());
 
             // Move downward from entry.level to 0
-            for (int lvl = graph.entry().level; lvl >= 0; lvl--) {
+            for (int lvl = graph.entryNode().level; lvl >= 0; lvl--) {
                 // This additional call seems redundant given that we have already initialized an ssp above.
                 // However, there is a subtle interplay between the ssp of the search and the ssp used in insertDiverse.
                 // Do not remove this line.
                 ssp = scoreProvider.searchProviderFor(node);
 
-                if (graph.layers.get(lvl).get(node) != null) {
+                if (graph.getNeighborsIterator(lvl, node).size() > 0) {
                     gs.searchOneLayer(ssp, beamWidth, 0.0f, lvl, acceptedBits);
 
                     var candidates = new NodeArray(gs.approximateResults.size());
                     gs.approximateResults.foreach(candidates::insertSorted);
-                    var newNeighbors = graph.layers.get(lvl).insertDiverse(node, candidates);
-                    graph.layers.get(lvl).backlink(newNeighbors, node, neighborOverflow);
+                    graph.addEdges(lvl, node, candidates, neighborOverflow);
                 } else {
                     gs.searchOneLayer(ssp, 1, 0.0f, lvl, acceptedBits);
                 }
@@ -480,7 +487,7 @@ public class GraphIndexBuilder implements Closeable {
         }
     }
 
-    public OnHeapGraphIndex getGraph() {
+    public ImmutableGraphIndex getGraph() {
         return graph;
     }
 
@@ -554,12 +561,13 @@ public class GraphIndexBuilder implements Closeable {
         insertionsInProgress.add(nodeLevel);
         var inProgressBefore = insertionsInProgress.clone();
         try (var gs = searchers.get()) {
-            gs.setView(graph.getView()); // new snapshot
+            var view = graph.getConcurrentView();
+            gs.setView(view); // new snapshot
             var naturalScratchPooled = naturalScratch.get();
             var concurrentScratchPooled = concurrentScratch.get();
 
             var bits = new ExcludingBits(nodeLevel.node);
-            var entry = graph.entry();
+            var entry = view.entryNode();
             SearchResult result;
             if (entry == null) {
                 result = new SearchResult(new NodeScore[] {}, 0, 0, 0, 0, 0);
@@ -636,7 +644,7 @@ public class GraphIndexBuilder implements Closeable {
             return 0;
         }
 
-        for (int currentLevel = 0; currentLevel < graph.layers.size(); currentLevel++) {
+        for (int currentLevel = 0; currentLevel <= graph.getMaxLevel(); currentLevel++) {
             final int level = currentLevel;  // Create effectively final copy for lambda
             // Compute new edges to insert.  If node j is deleted, we add edges (i, k)
             // whenever (i, j) and (j, k) are directed edges in the current graph.  This
@@ -687,10 +695,10 @@ public class GraphIndexBuilder implements Closeable {
                         // doing actual sampling-without-replacement is expensive so we'll loop a fixed number of times instead
                         for (int i = 0; i < 2 * graph.getDegree(level); i++) {
                             int randomNode = R.nextInt(graph.getIdUpperBound());
-                            while(toDelete.get(randomNode)) {
+                            while (toDelete.get(randomNode)) {
                                 randomNode = R.nextInt(graph.getIdUpperBound());
                             }
-                            if (randomNode != node && !candidates.contains(randomNode) && graph.layers.get(level).contains(randomNode)) {
+                            if (randomNode != node && !candidates.contains(randomNode) && graph.contains(level, randomNode)) {
                                 float score = sf.similarityTo(randomNode);
                                 candidates.insertSorted(randomNode, score);
                             }
@@ -701,14 +709,14 @@ public class GraphIndexBuilder implements Closeable {
                     }
 
                     // remove edges to deleted nodes and add the new connections, maintaining diversity
-                    graph.layers.get(level).replaceDeletedNeighbors(node, toDelete, candidates);
+                    graph.replaceDeletedNeighbors(level, node, toDelete, candidates);
                 });
             }).join();
         }
 
         // Generally we want to keep entryPoint update and node removal distinct, because both can be expensive,
         // but if the entry point was deleted then we have no choice
-        if (toDelete.get(graph.entry().node)) {
+        if (toDelete.get(graph.entryNode().node)) {
             // pick a random node at the top layer
             int newLevel = graph.getMaxLevel();
             int newEntry = -1;
@@ -751,8 +759,7 @@ public class GraphIndexBuilder implements Closeable {
             toMerge = NodeArray.merge(natural, concurrent);
         }
         // toMerge may be approximate-scored, but insertDiverse will compute exact scores for the diverse ones
-        var neighbors = graph.layers.get(layer).insertDiverse(nodeId, toMerge);
-        graph.layers.get(layer).backlink(neighbors, nodeId, neighborOverflow);
+        graph.addEdges(layer, nodeId, toMerge, neighborOverflow);
     }
 
     private static NodeArray toScratchCandidates(NodeScore[] candidates, NodeArray scratch) {
@@ -801,6 +808,7 @@ public class GraphIndexBuilder implements Closeable {
         }
     }
 
+    @Deprecated
     public void load(RandomAccessReader in) throws IOException {
         if (graph.size(0) != 0) {
             throw new IllegalStateException("Cannot load into a non-empty graph");
@@ -819,6 +827,7 @@ public class GraphIndexBuilder implements Closeable {
         }
     }
 
+    @Deprecated
     private void loadV4(RandomAccessReader in) throws IOException {
         if (graph.size(0) != 0) {
             throw new IllegalStateException("Cannot load into a non-empty graph");
@@ -851,7 +860,7 @@ public class GraphIndexBuilder implements Closeable {
                     int neighbor = in.readInt();
                     ca.addInOrder(neighbor, sf.similarityTo(neighbor));
                 }
-                graph.addNode(level, nodeId, ca);
+                graph.connectNode(level, nodeId, ca);
                 nodeLevelMap.put(nodeId, level);
             }
         }
@@ -865,7 +874,7 @@ public class GraphIndexBuilder implements Closeable {
         graph.updateEntryNode(new NodeAtLevel(graph.getMaxLevel(), entryNode));
     }
 
-
+    @Deprecated
     private void loadV3(RandomAccessReader in, int size) throws IOException {
         if (graph.size() != 0) {
             throw new IllegalStateException("Cannot load into a non-empty graph");
@@ -891,7 +900,7 @@ public class GraphIndexBuilder implements Closeable {
                 int neighbor = in.readInt();
                 ca.addInOrder(neighbor, sf.similarityTo(neighbor));
             }
-            graph.addNode(0, nodeId, ca);
+            graph.connectNode(0, nodeId, ca);
             graph.markComplete(new NodeAtLevel(0, nodeId));
         }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -455,6 +455,8 @@ public class GraphIndexBuilder implements Closeable {
                 }
             });
         }).join();
+
+        graph.allMutationsCompleted();
     }
 
     private void improveConnections(int node) {
@@ -561,7 +563,7 @@ public class GraphIndexBuilder implements Closeable {
         insertionsInProgress.add(nodeLevel);
         var inProgressBefore = insertionsInProgress.clone();
         try (var gs = searchers.get()) {
-            var view = graph.getConcurrentView();
+            var view = graph.getView();
             gs.setView(view); // new snapshot
             var naturalScratchPooled = naturalScratch.get();
             var concurrentScratchPooled = concurrentScratch.get();

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
@@ -25,7 +25,7 @@
 package io.github.jbellis.jvector.graph;
 
 import io.github.jbellis.jvector.annotations.Experimental;
-import io.github.jbellis.jvector.graph.GraphIndex.NodeAtLevel;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex.NodeAtLevel;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
@@ -43,10 +43,10 @@ import java.io.IOException;
 
 /**
  * Searches a graph to find nearest neighbors to a query vector. For more background on the
- * search algorithm, see {@link GraphIndex}.
+ * search algorithm, see {@link ImmutableGraphIndex}.
  */
 public class GraphSearcher implements Closeable {
-    private GraphIndex.View view;
+    private ImmutableGraphIndex.View view;
 
     // Scratch data structures that are used in each {@link #searchInternal} call. These can be expensive
     // to allocate, so they're cleared and reused across calls.
@@ -71,14 +71,14 @@ public class GraphSearcher implements Closeable {
     /**
      * Creates a new graph searcher from the given GraphIndex
      */
-    public GraphSearcher(GraphIndex graph) {
+    public GraphSearcher(ImmutableGraphIndex graph) {
         this(graph.getView());
     }
 
     /**
      * Creates a new graph searcher from the given GraphIndex.View
      */
-    protected GraphSearcher(GraphIndex.View view) {
+    protected GraphSearcher(ImmutableGraphIndex.View view) {
         this.view = view;
         this.candidates = new NodeQueue(new GrowableLongHeap(100), NodeQueue.Order.MAX_HEAP);
         this.evictedResults = new NodesUnsorted(100);
@@ -112,7 +112,7 @@ public class GraphSearcher implements Closeable {
         cachingReranker = new CachingReranker(scoreProvider);
     }
 
-    public GraphIndex.View getView() {
+    public ImmutableGraphIndex.View getView() {
         return view;
     }
 
@@ -129,7 +129,7 @@ public class GraphSearcher implements Closeable {
      * Convenience function for simple one-off searches.  It is caller's responsibility to make sure that it
      * is the unique owner of the vectors instance passed in here.
      */
-    public static SearchResult search(VectorFloat<?> queryVector, int topK, RandomAccessVectorValues vectors, VectorSimilarityFunction similarityFunction, GraphIndex graph, Bits acceptOrds) {
+    public static SearchResult search(VectorFloat<?> queryVector, int topK, RandomAccessVectorValues vectors, VectorSimilarityFunction similarityFunction, ImmutableGraphIndex graph, Bits acceptOrds) {
         try (var searcher = new GraphSearcher(graph)) {
             var ssp = DefaultSearchScoreProvider.exact(queryVector, similarityFunction, vectors);
             return searcher.search(ssp, topK, acceptOrds);
@@ -142,7 +142,7 @@ public class GraphSearcher implements Closeable {
      * Convenience function for simple one-off searches.  It is caller's responsibility to make sure that it
      * is the unique owner of the vectors instance passed in here.
      */
-    public static SearchResult search(VectorFloat<?> queryVector, int topK, int rerankK, RandomAccessVectorValues vectors, VectorSimilarityFunction similarityFunction, GraphIndex graph, Bits acceptOrds) {
+    public static SearchResult search(VectorFloat<?> queryVector, int topK, int rerankK, RandomAccessVectorValues vectors, VectorSimilarityFunction similarityFunction, ImmutableGraphIndex graph, Bits acceptOrds) {
         try (var searcher = new GraphSearcher(graph)) {
             var ssp = DefaultSearchScoreProvider.exact(queryVector, similarityFunction, vectors);
             return searcher.search(ssp, topK, rerankK, 0.f, 0.f, acceptOrds);
@@ -160,7 +160,7 @@ public class GraphSearcher implements Closeable {
      *
      * @param view the new view
      */
-    public void setView(GraphIndex.View view) {
+    public void setView(ImmutableGraphIndex.View view) {
         this.view = view;
     }
 
@@ -169,9 +169,9 @@ public class GraphSearcher implements Closeable {
      */
     @Deprecated
     public static class Builder {
-        private final GraphIndex.View view;
+        private final ImmutableGraphIndex.View view;
 
-        public Builder(GraphIndex.View view) {
+        public Builder(ImmutableGraphIndex.View view) {
             this.view = view;
         }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ImmutableGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ImmutableGraphIndex.java
@@ -29,6 +29,8 @@ import io.github.jbellis.jvector.util.Accountable;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
+
+import java.util.List;
 import java.util.Objects;
 
 import java.io.Closeable;
@@ -44,7 +46,7 @@ import java.io.IOException;
  * All methods are threadsafe.  Operations that require persistent state are wrapped
  * in a View that should be created per accessing thread.
  */
-public interface GraphIndex extends AutoCloseable, Accountable {
+public interface ImmutableGraphIndex extends AutoCloseable, Accountable {
     /** Returns the number of nodes in the graph */
     @Deprecated
     default int size() {
@@ -76,6 +78,8 @@ public interface GraphIndex extends AutoCloseable, Accountable {
      */
     int maxDegree();
 
+    List<Integer> maxDegrees();
+
     /**
      * @return the first ordinal greater than all node ids in the graph.  Equal to size() in simple cases;
      * May be different from size() if nodes are being added concurrently, or if nodes have been
@@ -106,6 +110,14 @@ public interface GraphIndex extends AutoCloseable, Accountable {
      * @return the maximum out-degree of the given level
      */
     int getDegree(int level);
+
+    /**
+     * Returns the average degree computed over nodes in the specified layer.
+     *
+     * @param level the level of interest.
+     * @return the average degree or NaN if no nodes are present.
+     */
+    double getAverageDegree(int level);
 
     /**
      * Return the number of vectors/nodes in the given level.
@@ -150,6 +162,11 @@ public interface GraphIndex extends AutoCloseable, Accountable {
         default int getIdUpperBound() {
             return size();
         }
+
+        /**
+         * Whether the given node is present in the given layer of the graph.
+         */
+        boolean contains(int level, int node);
     }
 
     /**
@@ -161,7 +178,7 @@ public interface GraphIndex extends AutoCloseable, Accountable {
         ScoreFunction.ApproximateScoreFunction approximateScoreFunctionFor(VectorFloat<?> queryVector, VectorSimilarityFunction vsf);
     }
 
-    static String prettyPrint(GraphIndex graph) {
+    static String prettyPrint(ImmutableGraphIndex graph) {
         StringBuilder sb = new StringBuilder();
         sb.append(graph);
         sb.append("\n");

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/MutableGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/MutableGraphIndex.java
@@ -1,0 +1,170 @@
+/*
+ * All changes to the original code are Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+/*
+ * Original license:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph;
+
+import io.github.jbellis.jvector.util.BitSet;
+import io.github.jbellis.jvector.util.ThreadSafeGrowableBitSet;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+
+/**
+ * An {@link ImmutableGraphIndex} that offers concurrent access; for typical graphs you will get significant
+ * speedups in construction and searching as you add threads.
+ *
+ * <p>The base layer (layer 0) contains all nodes, while higher layers are stored in sparse maps.
+ * For searching, use a view obtained from {@link #getView()} which supports level–aware operations.
+ */
+interface MutableGraphIndex extends ImmutableGraphIndex {
+    /**
+     * Add the given node ordinal with an empty set of neighbors.
+     *
+     * <p>Nodes can be inserted out of order, but it requires that the nodes preceded by the node
+     * inserted out of order are eventually added.
+     *
+     * <p>Actually populating the neighbors, and establishing bidirectional links, is the
+     * responsibility of the caller.
+     *
+     * <p>It is also the responsibility of the caller to ensure that each node is only added once.
+     */
+    void addNode(NodeAtLevel nodeLevel);
+
+    /**
+     * Add the given node ordinal with an empty set of neighbors.
+     *
+     * <p>Nodes can be inserted out of order, but it requires that the nodes preceded by the node
+     * inserted out of order are eventually added.
+     *
+     * <p>Actually populating the neighbors, and establishing bidirectional links, is the
+     * responsibility of the caller.
+     *
+     * <p>It is also the responsibility of the caller to ensure that each node is only added once.
+     */
+    void addNode(int level, int node);
+
+    /**
+     * Whether the given node is present in the graph.
+     */
+    boolean contains(NodeAtLevel nodeLevel);
+
+    /**
+     * Whether the given node is present in the given layer of the graph.
+     */
+    boolean contains(int level, int node);
+
+    /**
+     * Add the given node ordinal with an empty set of neighbors.
+     *
+     * <p>Nodes can be inserted out of order, but it requires that the nodes preceded by the node
+     * inserted out of order are eventually added.
+     *
+     * <p>Actually populating the neighbors, and establishing bidirectional links, is the
+     * responsibility of the caller.
+     *
+     * <p>It is also the responsibility of the caller to ensure that each node is only added once.
+     */
+    void connectNode(int level, int node, NodeArray nodes);
+
+    /**
+     * Use with extreme caution. Used by Builder to load a saved graph and for rescoring.
+     */
+    void connectNode(NodeAtLevel nodeLevel, NodeArray nodes);
+
+    /**
+     * Mark the given node deleted.  Does NOT remove the node from the graph.
+     */
+    void markDeleted(int node);
+
+    /** must be called after addNode once neighbors are linked in all levels. */
+    void markComplete(NodeAtLevel nodeLevel);
+
+    void updateEntryNode(NodeAtLevel newEntry);
+
+    /**
+     * Returns an upper bound on the amount of memory used by a single node, in bytes.
+     */
+    long ramBytesUsedOneNode(int layer);
+
+    ThreadSafeGrowableBitSet getDeletedNodes();
+
+    void setDegrees(List<Integer> layerDegrees);
+
+    /**
+     * Enforce the degree of the given node in all layers.
+     */
+    void enforceDegree(int node);
+
+    /**
+     * Returns an iterator over the neighbors for the given node at the specified level, which can be empty if the node does not belong to that layer.
+     */
+    NodesIterator getNeighborsIterator(NodeAtLevel nodeLevel);
+
+    /**
+     * Returns an iterator over the neighbors for the given node at the specified level, which can be empty if the node does not belong to that layer.
+     */
+    NodesIterator getNeighborsIterator(int level, int node);
+
+    /**
+     * Removes the given node from all layers.
+     *
+     * @param node the node id to remove
+     * @return the number of layers from which it was removed
+     */
+    int removeNode(int node);
+
+    /**
+     * this does call get() internally to filter level 0, so if you're going to use it in a pipeline
+     * that also calls get(), consider using your own raw IntStream.range instead
+     */
+    IntStream nodeStream(int level);
+
+    /**
+     * @return the maximum (coarser) level that contains a vector in the graph.
+     */
+    int getMaxLevelForNode(int node);
+
+    /**
+     * @return the node of the graph to start searches at
+     */
+    NodeAtLevel entryNode();
+
+    /**
+     * Add the given neighbors to the given node at the specified level, maintaining diversity
+     * It also adds backlinks from the neighbors to the given node.
+     * The edges will only be added if the out-degree of the node is less than overflowRatio times the max degree.
+     */
+    void addEdges(int level, int node, NodeArray candidates, float overflowRatio);
+
+    /**
+     * Remove edges to deleted nodes and add the new connections, maintaining diversity
+     */
+    void replaceDeletedNeighbors(int level, int node, BitSet toDelete, NodeArray candidates);
+
+    /**
+     * A View that assumes no concurrent modifications are made
+     */
+    View getConcurrentView();
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/MutableGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/MutableGraphIndex.java
@@ -136,13 +136,12 @@ interface MutableGraphIndex extends ImmutableGraphIndex {
     int removeNode(int node);
 
     /**
-     * this does call get() internally to filter level 0, so if you're going to use it in a pipeline
-     * that also calls get(), consider using your own raw IntStream.range instead
+     * Returns an Integer stream with the nodes contained in the specified level.
      */
     IntStream nodeStream(int level);
 
     /**
-     * @return the maximum (coarser) level that contains a vector in the graph.
+     * Returns the maximum (coarser) level that contains a vector in the graph or -1 if the node is not in the graph.
      */
     int getMaxLevelForNode(int node);
 
@@ -164,7 +163,8 @@ interface MutableGraphIndex extends ImmutableGraphIndex {
     void replaceDeletedNeighbors(int level, int node, BitSet toDelete, NodeArray candidates);
 
     /**
-     * A View compatible with concurrent modifications
+     * Signals that all mutations have been completed and the graph will not be mutated any further.
+     * Should be called by the builder after all mutations are completed (during cleanup).
      */
-    View getConcurrentView();
+    void allMutationsCompleted();
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/MutableGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/MutableGraphIndex.java
@@ -164,7 +164,7 @@ interface MutableGraphIndex extends ImmutableGraphIndex {
     void replaceDeletedNeighbors(int level, int node, BitSet toDelete, NodeArray candidates);
 
     /**
-     * A View that assumes no concurrent modifications are made
+     * A View compatible with concurrent modifications
      */
     View getConcurrentView();
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -237,25 +237,25 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
         return graphBytesUsed + completions.ramBytesUsed();
     }
 
-    private long ramBytesUsedOneLayer(int layer) {
+    private long ramBytesUsedOneLayer(int level) {
         int OH_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
         var REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
         var AH_BYTES = RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
 
-        long neighborSize = ramBytesUsedOneNode(layer) * layers.get(layer).size();
+        long neighborSize = ramBytesUsedOneNode(level) * layers.get(level).size();
         return OH_BYTES + REF_BYTES * 2L + AH_BYTES + neighborSize;
     }
 
-    public long ramBytesUsedOneNode(int layer) {
+    public long ramBytesUsedOneNode(int level) {
         // we include the REF_BYTES for the CNS reference here to make it self-contained for addGraphNode()
         int REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-        return REF_BYTES + Neighbors.ramBytesUsed(layers.get(layer).nodeArrayLength());
+        return REF_BYTES + Neighbors.ramBytesUsed(layers.get(level).nodeArrayLength());
     }
 
     @Override
     public void enforceDegree(int node) {
-        for (int layer = 0; layer <= getMaxLevel(); layer++) {
-            layers.get(layer).enforceDegree(node);
+        for (int level = 0; level <= getMaxLevel(); level++) {
+            layers.get(level).enforceDegree(node);
         }
     }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -26,14 +26,13 @@ package io.github.jbellis.jvector.graph;
 
 import io.github.jbellis.jvector.graph.ConcurrentNeighborMap.Neighbors;
 import io.github.jbellis.jvector.graph.diversity.DiversityProvider;
-import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
 import io.github.jbellis.jvector.util.Accountable;
+import io.github.jbellis.jvector.util.BitSet;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.util.DenseIntMap;
 import io.github.jbellis.jvector.util.RamUsageEstimator;
 import io.github.jbellis.jvector.util.SparseIntMap;
 import io.github.jbellis.jvector.util.ThreadSafeGrowableBitSet;
-import io.github.jbellis.jvector.vector.types.VectorFloat;
 import org.agrona.collections.IntArrayList;
 
 import java.io.DataOutput;
@@ -42,8 +41,6 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicReference;
@@ -51,13 +48,13 @@ import java.util.concurrent.locks.StampedLock;
 import java.util.stream.IntStream;
 
 /**
- * An {@link GraphIndex} that offers concurrent access; for typical graphs you will get significant
+ * An {@link ImmutableGraphIndex} that offers concurrent access; for typical graphs you will get significant
  * speedups in construction and searching as you add threads.
  *
  * <p>The base layer (layer 0) contains all nodes, while higher layers are stored in sparse maps.
  * For searching, use a view obtained from {@link #getView()} which supports level–aware operations.
  */
-public class OnHeapGraphIndex implements GraphIndex {
+public class OnHeapGraphIndex implements MutableGraphIndex {
     // Used for saving and loading OnHeapGraphIndex
     public static final int MAGIC = 0x75EC4012; // JVECTOR, with some imagination
 
@@ -72,7 +69,7 @@ public class OnHeapGraphIndex implements GraphIndex {
     private final AtomicInteger maxNodeId = new AtomicInteger(-1);
 
     // Maximum number of neighbors (edges) per node per layer
-    final IntArrayList maxDegrees;
+    final List<Integer> maxDegrees;
     // The ratio by which we can overflow the neighborhood of a node during construction. Since it is a multiplicative
     // ratio, i.e., the maximum allowable degree if maxDegree * overflowRatio, it should be higher than 1.
     private final double overflowRatio;
@@ -106,14 +103,13 @@ public class OnHeapGraphIndex implements GraphIndex {
         return layers.get(level).get(node);
     }
 
-    /**
-     * Returns an iterator over the neighbors for the given node at the specified level.
-     *
-     * @param level the layer
-     * @param node  the node id
-     * @return a NodesIterator, which can be empty
-     */
-    NodesIterator getNeighborsIterator(int level, int node) {
+    @Override
+    public NodesIterator getNeighborsIterator(NodeAtLevel nodeAtLevel) {
+        return getNeighborsIterator(nodeAtLevel.level, nodeAtLevel.node);
+    }
+
+    @Override
+    public NodesIterator getNeighborsIterator(int level, int node) {
         if (level >= layers.size()) {
             return NodesIterator.EMPTY_NODE_ITERATOR;
         }
@@ -126,29 +122,44 @@ public class OnHeapGraphIndex implements GraphIndex {
     }
 
     @Override
+    public int getMaxLevelForNode(int node) {
+        int maxLayer = -1;
+        for (int lvl = 0; lvl < layers.size(); lvl++) {
+            if (getNeighbors(lvl, node) == null) {
+                break;
+            }
+            maxLayer = lvl;
+        }
+        return maxLayer;
+    }
+
+    @Override
     public int size(int level) {
         return layers.get(level).size();
     }
 
-    /**
-     * Add the given node ordinal with an empty set of neighbors.
-     *
-     * <p>Nodes can be inserted out of order, but it requires that the nodes preceded by the node
-     * inserted out of order are eventually added.
-     *
-     * <p>Actually populating the neighbors, and establishing bidirectional links, is the
-     * responsibility of the caller.
-     *
-     * <p>It is also the responsibility of the caller to ensure that each node is only added once.
-     */
     public void addNode(NodeAtLevel nodeLevel) {
-        ensureLayersExist(nodeLevel.level);
+        addNode(nodeLevel.level, nodeLevel.node);
+    }
+
+    public void addNode(int level, int node) {
+        ensureLayersExist(level);
 
         // add the node to each layer
-        for (int i = 0; i <= nodeLevel.level; i++) {
-            layers.get(i).addNode(nodeLevel.node);
+        for (int i = 0; i <= level; i++) {
+            layers.get(i).addNode(node);
         }
-        maxNodeId.accumulateAndGet(nodeLevel.node, Math::max);
+        maxNodeId.accumulateAndGet(node, Math::max);
+    }
+
+    @Override
+    public boolean contains(NodeAtLevel nodeLevel) {
+        return contains(nodeLevel.level, nodeLevel.node);
+    }
+
+    @Override
+    public boolean contains(int level, int node) {
+        return layers.get(level).contains(node);
     }
 
     private void ensureLayersExist(int level) {
@@ -166,14 +177,15 @@ public class OnHeapGraphIndex implements GraphIndex {
         }
     }
 
-    /**
-     * Only for use by Builder loading a saved graph
-     */
-    void addNode(int level, int nodeId, NodeArray nodes) {
+    public void connectNode(NodeAtLevel nodeLevel, NodeArray nodes) {
+        connectNode(nodeLevel.level, nodeLevel.node, nodes);
+    }
+
+    public void connectNode(int level, int node, NodeArray nodes) {
         assert nodes != null;
         ensureLayersExist(level);
-        this.layers.get(level).addNode(nodeId, nodes);
-        maxNodeId.accumulateAndGet(nodeId, Math::max);
+        this.layers.get(level).addNode(node, nodes);
+        maxNodeId.accumulateAndGet(node, Math::max);
     }
 
     /**
@@ -183,8 +195,7 @@ public class OnHeapGraphIndex implements GraphIndex {
         deletedNodes.set(node);
     }
 
-    /** must be called after addNode once neighbors are linked in all levels. */
-    void markComplete(NodeAtLevel nodeLevel) {
+    public void markComplete(NodeAtLevel nodeLevel) {
         entryPoint.accumulateAndGet(
                 nodeLevel,
                 (oldEntry, newEntry) -> {
@@ -197,11 +208,12 @@ public class OnHeapGraphIndex implements GraphIndex {
         completions.markComplete(nodeLevel.node);
     }
 
-    void updateEntryNode(NodeAtLevel newEntry) {
+    public void updateEntryNode(NodeAtLevel newEntry) {
         entryPoint.set(newEntry);
     }
 
-    NodeAtLevel entry() {
+    @Override
+    public NodeAtLevel entryNode() {
         return entryPoint.get();
     }
 
@@ -211,11 +223,8 @@ public class OnHeapGraphIndex implements GraphIndex {
                                                    layers.get(level).size());
     }
 
-    /**
-     * this does call get() internally to filter level 0, so if you're going to use it in a pipeline
-     * that also calls get(), consider using your own raw IntStream.range instead
-     */
-    IntStream nodeStream(int level) {
+    @Override
+    public IntStream nodeStream(int level) {
         var layer = layers.get(level);
         return level == 0
                 ? IntStream.range(0, getIdUpperBound()).filter(i -> layer.get(i) != null)
@@ -228,7 +237,7 @@ public class OnHeapGraphIndex implements GraphIndex {
         return graphBytesUsed + completions.ramBytesUsed();
     }
 
-    public long ramBytesUsedOneLayer(int layer) {
+    private long ramBytesUsedOneLayer(int layer) {
         int OH_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
         var REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
         var AH_BYTES = RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
@@ -241,6 +250,24 @@ public class OnHeapGraphIndex implements GraphIndex {
         // we include the REF_BYTES for the CNS reference here to make it self-contained for addGraphNode()
         int REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
         return REF_BYTES + Neighbors.ramBytesUsed(layers.get(layer).nodeArrayLength());
+    }
+
+    @Override
+    public void enforceDegree(int node) {
+        for (int layer = 0; layer <= getMaxLevel(); layer++) {
+            layers.get(layer).enforceDegree(node);
+        }
+    }
+
+    @Override
+    public void addEdges(int level, int node, NodeArray candidates, float overflowRatio) {
+        var newNeighbors = layers.get(level).insertDiverse(node, candidates);
+        layers.get(level).backlink(newNeighbors, node, overflowRatio);
+    }
+
+    @Override
+    public void replaceDeletedNeighbors(int level, int node, BitSet toDelete, NodeArray candidates) {
+        layers.get(level).replaceDeletedNeighbors(node, toDelete, candidates);
     }
 
     @Override
@@ -260,41 +287,21 @@ public class OnHeapGraphIndex implements GraphIndex {
      * <p>Multiple Views may be searched concurrently.
      */
     @Override
-    public ConcurrentGraphIndexView getView() {
-        return new ConcurrentGraphIndexView();
-    }
-
-    /**
-     * A View that assumes no concurrent modifications are made
-     */
-    public GraphIndex.View getFrozenView() {
+    public View getView() {
         return new FrozenView();
     }
 
-    /**
-     * Validates that the current entry node has been completely added.
-     */
-    void validateEntryNode() {
-        if (size(0) == 0) {
-            return;
-        }
-        NodeAtLevel entry = getView().entryNode();
-        if (entry == null || getNeighbors(entry.level, entry.node) == null) {
-            throw new IllegalStateException("Entry node was incompletely added! " + entry);
-        }
+    @Override
+    public View getConcurrentView() {
+        return new ConcurrentGraphIndexView();
     }
 
     public ThreadSafeGrowableBitSet getDeletedNodes() {
         return deletedNodes;
     }
 
-    /**
-     * Removes the given node from all layers.
-     *
-     * @param node the node id to remove
-     * @return the number of layers from which it was removed
-     */
-    int removeNode(int node) {
+    @Override
+    public int removeNode(int node) {
         int found = 0;
         for (var layer : layers) {
             if (layer.remove(node) != null) {
@@ -351,8 +358,9 @@ public class OnHeapGraphIndex implements GraphIndex {
         return maxDegrees.stream().mapToInt(i -> i).max().orElseThrow();
     }
 
-    public int getLayerSize(int level) {
-        return layers.get(level).size();
+    @Override
+    public List<Integer> maxDegrees() {
+        return maxDegrees;
     }
 
     public void setDegrees(List<Integer> layerDegrees) {
@@ -448,6 +456,11 @@ public class OnHeapGraphIndex implements GraphIndex {
         @Override
         public int getIdUpperBound() {
             return OnHeapGraphIndex.this.getIdUpperBound();
+        }
+
+        @Override
+        public boolean contains(int level, int node) {
+            return OnHeapGraphIndex.this.contains(level, node);
         }
 
         @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -284,6 +284,8 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
 
     @Override
     public View getView() {
+        // Before all completions are completed, we need a View that is thread-safe and allows concurrent mutations in the graph.
+        // Once all completions are completed, we can freeze the graph and just need  a View that is thread-safe.
         if (allMutationsCompleted) {
             return new FrozenView();
         } else {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -74,7 +74,7 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
     // ratio, i.e., the maximum allowable degree if maxDegree * overflowRatio, it should be higher than 1.
     private final double overflowRatio;
 
-    private boolean allMutationsCompleted = false;
+    private volatile boolean allMutationsCompleted = false;
 
     OnHeapGraphIndex(List<Integer> maxDegrees, double overflowRatio, DiversityProvider diversityProvider) {
         this.overflowRatio = overflowRatio;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/AbstractGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/AbstractGraphIndexWriter.java
@@ -17,9 +17,7 @@
 package io.github.jbellis.jvector.graph.disk;
 
 import io.github.jbellis.jvector.disk.IndexWriter;
-import io.github.jbellis.jvector.disk.RandomAccessWriter;
-import io.github.jbellis.jvector.graph.GraphIndex;
-import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.disk.feature.*;
 import org.agrona.collections.Int2IntHashMap;
 
@@ -37,8 +35,8 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
     public static final int FOOTER_MAGIC_SIZE = Integer.BYTES; // The size of the magic number in the footer
     public static final int FOOTER_SIZE = FOOTER_MAGIC_SIZE + FOOTER_OFFSET_SIZE; // The total size of the footer
     final int version;
-    final GraphIndex graph;
-    final GraphIndex.View view;
+    final ImmutableGraphIndex graph;
+    final ImmutableGraphIndex.View view;
     final OrdinalMapper ordinalMapper;
     final int dimension;
     // we don't use Map features but EnumMap is the best way to make sure we don't
@@ -51,7 +49,7 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
 
     AbstractGraphIndexWriter(T out,
                                      int version,
-                                     GraphIndex graph,
+                                     ImmutableGraphIndex graph,
                                      OrdinalMapper oldToNewOrdinals,
                                      int dimension,
                                      EnumMap<FeatureId, Feature> features)
@@ -61,7 +59,7 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
         }
         this.version = version;
         this.graph = graph;
-        this.view = graph instanceof OnHeapGraphIndex ? ((OnHeapGraphIndex) graph).getFrozenView() : graph.getView();
+        this.view = graph.getView();
         this.ordinalMapper = oldToNewOrdinals;
         this.dimension = dimension;
         this.featureMap = features;
@@ -105,7 +103,7 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
      * if i &lt; j in `graph` then map[i] &lt; map[j] in the returned map.  "Holes" left by
      * deleted nodes are filled in by shifting down the new ordinals.
      */
-    public static Map<Integer, Integer> sequentialRenumbering(GraphIndex graph) {
+    public static Map<Integer, Integer> sequentialRenumbering(ImmutableGraphIndex graph) {
         try (var view = graph.getView()) {
             Int2IntHashMap oldToNewMap = new Int2IntHashMap(-1);
             int nextOrdinal = 0;
@@ -237,13 +235,13 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
      * T - the type of the output stream
      */
     public abstract static class Builder<K extends AbstractGraphIndexWriter<T>, T extends IndexWriter> {
-        final GraphIndex graphIndex;
+        final ImmutableGraphIndex graphIndex;
         final EnumMap<FeatureId, Feature> features;
         final T out;
         OrdinalMapper ordinalMapper;
         int version;
 
-        public Builder(GraphIndex graphIndex, T out) {
+        public Builder(ImmutableGraphIndex graphIndex, T out) {
             this.graphIndex = graphIndex;
             this.out = out;
             this.features = new EnumMap<>(FeatureId.class);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/AbstractGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/AbstractGraphIndexWriter.java
@@ -36,7 +36,6 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
     public static final int FOOTER_SIZE = FOOTER_MAGIC_SIZE + FOOTER_OFFSET_SIZE; // The total size of the footer
     final int version;
     final ImmutableGraphIndex graph;
-    final ImmutableGraphIndex.View view;
     final OrdinalMapper ordinalMapper;
     final int dimension;
     // we don't use Map features but EnumMap is the best way to make sure we don't
@@ -59,7 +58,6 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
         }
         this.version = version;
         this.graph = graph;
-        this.view = graph.getView();
         this.ordinalMapper = oldToNewOrdinals;
         this.dimension = dimension;
         this.featureMap = features;
@@ -131,7 +129,7 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
      * @param headerOffset the offset of the header in the slice
      * @throws IOException IOException
      */
-    void writeFooter(long headerOffset) throws IOException {
+    void writeFooter(ImmutableGraphIndex.View view, long headerOffset) throws IOException {
         var layerInfo = CommonHeader.LayerInfo.fromGraph(graph, ordinalMapper);
         var commonHeader = new CommonHeader(version,
                 dimension,
@@ -153,7 +151,7 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
      * Public so that you can write the index size (and thus usefully open an OnDiskGraphIndex against the index)
      * to read Features from it before writing the edges.
      */
-    public synchronized void writeHeader(long startOffset) throws IOException {
+    public synchronized void writeHeader(ImmutableGraphIndex.View view, long startOffset) throws IOException {
         // graph-level properties
         var layerInfo = CommonHeader.LayerInfo.fromGraph(graph, ordinalMapper);
         var commonHeader = new CommonHeader(version,
@@ -166,7 +164,7 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
         assert out.position() == startOffset + headerSize : String.format("%d != %d", out.position(), startOffset + headerSize);
     }
 
-    void writeSparseLevels() throws IOException {
+    void writeSparseLevels(ImmutableGraphIndex.View view) throws IOException {
         // write sparse levels
         for (int level = 1; level <= graph.getMaxLevel(); level++) {
             int layerSize = graph.size(level);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/CommonHeader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/CommonHeader.java
@@ -19,12 +19,10 @@ package io.github.jbellis.jvector.graph.disk;
 import io.github.jbellis.jvector.annotations.VisibleForTesting;
 import io.github.jbellis.jvector.disk.IndexWriter;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
-import io.github.jbellis.jvector.disk.RandomAccessWriter;
-import io.github.jbellis.jvector.graph.GraphIndex;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -174,7 +172,7 @@ public class CommonHeader {
             this.degree = degree;
         }
 
-        public static List<LayerInfo> fromGraph(GraphIndex graph, OrdinalMapper mapper) {
+        public static List<LayerInfo> fromGraph(ImmutableGraphIndex graph, OrdinalMapper mapper) {
             return IntStream.rangeClosed(0, graph.getMaxLevel())
                     .mapToObj(i -> new LayerInfo(graph.size(i), graph.getDegree(i)))
                     .collect(Collectors.toList());

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexWriter.java
@@ -18,15 +18,10 @@ package io.github.jbellis.jvector.graph.disk;
 
 import io.github.jbellis.jvector.disk.BufferedRandomAccessWriter;
 import io.github.jbellis.jvector.disk.RandomAccessWriter;
-import io.github.jbellis.jvector.graph.GraphIndex;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
-import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
-import io.github.jbellis.jvector.graph.disk.feature.NVQ;
-import io.github.jbellis.jvector.graph.disk.feature.SeparatedFeature;
-import io.github.jbellis.jvector.graph.disk.feature.SeparatedNVQ;
-import io.github.jbellis.jvector.graph.disk.feature.SeparatedVectors;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -75,7 +70,7 @@ public class OnDiskGraphIndexWriter extends AbstractGraphIndexWriter<RandomAcces
     OnDiskGraphIndexWriter(RandomAccessWriter randomAccessWriter,
                                    int version,
                                    long startOffset,
-                                   GraphIndex graph,
+                                   ImmutableGraphIndex graph,
                                    OrdinalMapper oldToNewOrdinals,
                                    int dimension,
                                    EnumMap<FeatureId, Feature> features)
@@ -258,11 +253,11 @@ public class OnDiskGraphIndexWriter extends AbstractGraphIndexWriter<RandomAcces
     public static class Builder extends AbstractGraphIndexWriter.Builder<OnDiskGraphIndexWriter, RandomAccessWriter> {
         private long startOffset = 0L;
 
-        public Builder(GraphIndex graphIndex, Path outPath) throws FileNotFoundException {
+        public Builder(ImmutableGraphIndex graphIndex, Path outPath) throws FileNotFoundException {
             this(graphIndex, new BufferedRandomAccessWriter(outPath));
         }
 
-        public Builder(GraphIndex graphIndex, RandomAccessWriter out) {
+        public Builder(ImmutableGraphIndex graphIndex, RandomAccessWriter out) {
             super(graphIndex, out);
         }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskSequentialGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskSequentialGraphIndexWriter.java
@@ -17,17 +17,14 @@
 package io.github.jbellis.jvector.graph.disk;
 
 import io.github.jbellis.jvector.disk.IndexWriter;
-import io.github.jbellis.jvector.graph.GraphIndex;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
 import io.github.jbellis.jvector.graph.disk.feature.*;
 
 import java.io.IOException;
 import java.util.EnumMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.IntFunction;
-import java.util.stream.Collectors;
 
 /**
  * Writes a graph index to disk in a format that can be loaded as an OnDiskGraphIndex.
@@ -64,7 +61,7 @@ public class OnDiskSequentialGraphIndexWriter extends AbstractGraphIndexWriter<I
 
     OnDiskSequentialGraphIndexWriter(IndexWriter out,
                                              int version,
-                                             GraphIndex graph,
+                                             ImmutableGraphIndex graph,
                                              OrdinalMapper oldToNewOrdinals,
                                              int dimension,
                                              EnumMap<FeatureId, Feature> features)
@@ -170,7 +167,7 @@ public class OnDiskSequentialGraphIndexWriter extends AbstractGraphIndexWriter<I
      * Builder for {@link OnDiskSequentialGraphIndexWriter}, with optional features.
      */
     public static class Builder extends AbstractGraphIndexWriter.Builder<OnDiskSequentialGraphIndexWriter, IndexWriter> {
-        public Builder(GraphIndex graphIndex, IndexWriter out) {
+        public Builder(ImmutableGraphIndex graphIndex, IndexWriter out) {
             super(graphIndex, out);
         }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FusedADC.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FusedADC.java
@@ -17,7 +17,7 @@
 package io.github.jbellis.jvector.graph.disk.feature;
 
 import io.github.jbellis.jvector.disk.RandomAccessReader;
-import io.github.jbellis.jvector.graph.GraphIndex;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.disk.CommonHeader;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
@@ -118,11 +118,11 @@ public class FusedADC implements Feature {
     }
 
     public static class State implements Feature.State {
-        public final GraphIndex.View view;
+        public final ImmutableGraphIndex.View view;
         public final PQVectors pqVectors;
         public final int nodeId;
 
-        public State(GraphIndex.View view, PQVectors pqVectors, int nodeId) {
+        public State(ImmutableGraphIndex.View view, PQVectors pqVectors, int nodeId) {
             this.view = view;
             this.pqVectors = pqVectors;
             this.nodeId = nodeId;

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/SiftSmall.java
@@ -21,11 +21,10 @@ import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.github.jbellis.jvector.disk.ReaderSupplierFactory;
 import io.github.jbellis.jvector.example.util.AccuracyMetrics;
 import io.github.jbellis.jvector.example.util.SiftLoader;
-import io.github.jbellis.jvector.graph.GraphIndex;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
-import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
@@ -90,7 +89,7 @@ public class SiftSmall {
                                                  true))
         {
             // build the index (in memory)
-            OnHeapGraphIndex index = builder.build(ravv);
+            ImmutableGraphIndex index = builder.build(ravv);
 
             // search for a random vector
             VectorFloat<?> q = randomVector(originalDimension);
@@ -113,7 +112,7 @@ public class SiftSmall {
 
         BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, VectorSimilarityFunction.EUCLIDEAN);
         try (GraphIndexBuilder builder = new GraphIndexBuilder(bsp, ravv.dimension(), 16, 100, 1.2f, 1.2f, false, true)) {
-            OnHeapGraphIndex index = builder.build(ravv);
+            ImmutableGraphIndex index = builder.build(ravv);
 
             // search for a random vector using a GraphSearcher and SearchScoreProvider
             VectorFloat<?> q = randomVector(originalDimension);
@@ -134,7 +133,7 @@ public class SiftSmall {
 
         BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, VectorSimilarityFunction.EUCLIDEAN);
         try (GraphIndexBuilder builder = new GraphIndexBuilder(bsp, ravv.dimension(), 16, 100, 1.2f, 1.2f, false, true)) {
-            OnHeapGraphIndex index = builder.build(ravv);
+            ImmutableGraphIndex index = builder.build(ravv);
             // measure our recall against the (exactly computed) ground truth
             Function<VectorFloat<?>, SearchScoreProvider> sspFactory = q -> DefaultSearchScoreProvider.exact(q, VectorSimilarityFunction.EUCLIDEAN, ravv);
             testRecall(index, queryVectors, groundTruth, sspFactory);
@@ -150,7 +149,7 @@ public class SiftSmall {
         Path indexPath = Files.createTempFile("siftsmall", ".inline");
         try (GraphIndexBuilder builder = new GraphIndexBuilder(bsp, ravv.dimension(), 16, 100, 1.2f, 1.2f, false, true)) {
             // build the index (in memory)
-            OnHeapGraphIndex index = builder.build(ravv);
+            ImmutableGraphIndex index = builder.build(ravv);
             // write the index to disk with default options
             OnDiskGraphIndex.write(index, ravv, indexPath);
         }
@@ -173,7 +172,7 @@ public class SiftSmall {
         BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, VectorSimilarityFunction.EUCLIDEAN);
         Path indexPath = Files.createTempFile("siftsmall", ".inline");
         try (GraphIndexBuilder builder = new GraphIndexBuilder(bsp, ravv.dimension(), 16, 100, 1.2f, 1.2f, false, true)) {
-            OnHeapGraphIndex index = builder.build(ravv);
+            ImmutableGraphIndex index = builder.build(ravv);
             OnDiskGraphIndex.write(index, ravv, indexPath);
         }
 
@@ -351,7 +350,7 @@ public class SiftSmall {
         return vec;
     }
 
-    private static void testRecall(GraphIndex graph,
+    private static void testRecall(ImmutableGraphIndex graph,
                                    List<VectorFloat<?>> queryVectors,
                                    List<List<Integer>> groundTruth,
                                    Function<VectorFloat<?>,

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/GraphIndexBuilderTest.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/GraphIndexBuilderTest.java
@@ -94,7 +94,9 @@ public class GraphIndexBuilderTest extends LuceneTestCase {
         builder.addGraphNode(0, ravv.getVector(0));
         builder.addGraphNode(1, ravv.getVector(1));
         builder.addGraphNode(2, ravv.getVector(2));
-        var neighbors = builder.graph.getNeighbors(0, 0);
+
+        var ohgi = (OnHeapGraphIndex) builder.graph;
+        var neighbors = ohgi.getNeighbors(0, 0);
         assertEquals(1, neighbors.getNode(0));
         assertEquals(2, neighbors.getNode(1));
         assertEquals(0.5f, neighbors.getScore(0), 1E-6);
@@ -111,7 +113,7 @@ public class GraphIndexBuilderTest extends LuceneTestCase {
         var rescored = GraphIndexBuilder.rescore(builder, bsp);
 
         // Verify edges still exist
-        var newGraph = rescored.getGraph();
+        var newGraph = (OnHeapGraphIndex) rescored.getGraph();
         assertTrue(newGraph.containsNode(0));
         assertTrue(newGraph.containsNode(1));
         assertTrue(newGraph.containsNode(2));
@@ -140,7 +142,7 @@ public class GraphIndexBuilderTest extends LuceneTestCase {
         var graph = TestUtil.buildSequentially(builder, ravv);
 
         try (var out = TestUtil.openDataOutputStream(indexDataPath)) {
-            graph.save(out);
+            ((OnHeapGraphIndex) graph).save(out);
         }
 
         builder = newBuilder.get();
@@ -148,7 +150,7 @@ public class GraphIndexBuilderTest extends LuceneTestCase {
             builder.load(readerSupplier.get());
         }
 
-        assertEquals(ravv.size(), builder.graph.size());
+        assertEquals(ravv.size(), builder.graph.size(0));
         for (int i = 0; i < ravv.size(); i++) {
             assertTrue(builder.graph.containsNode(i));
         }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
@@ -29,9 +29,6 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import io.github.jbellis.jvector.LuceneTestCase;
 import io.github.jbellis.jvector.TestUtil;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
-import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
-import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
-import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.util.BoundedLongHeap;
@@ -43,9 +40,9 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -280,30 +277,33 @@ public class TestVectorGraph extends LuceneTestCase {
         }
         // We expect to get approximately 100% recall;
         // the lowest docIds are closest to zero; sum(0,9) = 45
-        assertTrue("sum(result docs)=" + sum + " for " + GraphIndex.prettyPrint(builder.graph), sum < 75);
+        assertTrue("sum(result docs)=" + sum + " for " + ImmutableGraphIndex.prettyPrint(builder.graph), sum < 75);
     }
 
-    private static void validateIndex(OnHeapGraphIndex graph) {
+    private static void validateIndex(ImmutableGraphIndex graph) {
+        var view = graph.getView();
+
         for (int level = graph.getMaxLevel(); level > 0; level--) {
             for (var nodeIt = graph.getNodes(level); nodeIt.hasNext(); ) {
                 var nodeInLevel = nodeIt.nextInt();
 
                 // node's neighbors should also exist in the same level
-                var neighbors = graph.getNeighbors(level, nodeInLevel);
-                for (int neighbor : neighbors.copyDenseNodes()) {
-                    assertNotNull(graph.getNeighbors(level, neighbor));
+                var it = view.getNeighborsIterator(level, nodeInLevel);
+                while (it.hasNext()) {
+                    int neighbor = it.nextInt();
+                    assertTrue(view.contains(level, neighbor));
                 }
 
                 // node should exist at every layer below it
                 for (int lowerLevel = level - 1; lowerLevel >= 0; lowerLevel--) {
-                    assertNotNull(graph.getNeighbors(lowerLevel, nodeInLevel));
+                    assertTrue(view.contains(lowerLevel, nodeInLevel));
                 }
             }
         }
 
         // no holes in lowest level (not true for all graphs but true for the ones constructed here)
         for (int i = 0; i < graph.getIdUpperBound(); i++) {
-            assertNotNull(graph.getNeighbors(0, i));
+            assertTrue(view.getNeighborsIterator(0, i).size() >= 0);
         }
     }
 
@@ -343,7 +343,7 @@ public class TestVectorGraph extends LuceneTestCase {
         }
         // We expect to get approximately 100% recall;
         // the lowest docIds are closest to zero; sum(0,9) = 45
-        assertTrue("sum(result docs)=" + sum + " for " + GraphIndex.prettyPrint(builder.graph), sum < 75);
+        assertTrue("sum(result docs)=" + sum + " for " + ImmutableGraphIndex.prettyPrint(builder.graph), sum < 75);
     }
 
     @Test
@@ -378,7 +378,7 @@ public class TestVectorGraph extends LuceneTestCase {
         }
         // We expect to get approximately 100% recall;
         // the lowest docIds are closest to zero; sum(0,9) = 45
-        assertTrue("sum(result docs)=" + sum + " for " + GraphIndex.prettyPrint(builder.graph), sum < 75);
+        assertTrue("sum(result docs)=" + sum + " for " + ImmutableGraphIndex.prettyPrint(builder.graph), sum < 75);
     }
 
     @Test
@@ -414,13 +414,13 @@ public class TestVectorGraph extends LuceneTestCase {
         int[] nodes = Arrays.stream(nn).mapToInt(nodeScore -> nodeScore.node).toArray();
         for (int node : nodes) {
             assertTrue(String.format("the results include a deleted document: %d for %s",
-                    node, GraphIndex.prettyPrint(builder.graph)), acceptOrds.get(node));
+                    node, ImmutableGraphIndex.prettyPrint(builder.graph)), acceptOrds.get(node));
         }
         for (int i = 0; i < acceptOrds.length(); i++) {
             if (acceptOrds.get(i)) {
                 int finalI = i;
                 assertTrue(String.format("the results do not include an accepted document: %d for %s",
-                        i, GraphIndex.prettyPrint(builder.graph)), Arrays.stream(nodes).anyMatch(j -> j == finalI));
+                        i, ImmutableGraphIndex.prettyPrint(builder.graph)), Arrays.stream(nodes).anyMatch(j -> j == finalI));
             }
         }
     }
@@ -479,37 +479,41 @@ public class TestVectorGraph extends LuceneTestCase {
         builder.addGraphNode(0, vectors.getVector(0));
         builder.addGraphNode(1, vectors.getVector(1));
         builder.addGraphNode(2, vectors.getVector(2));
+
+        var view = builder.graph.getView();
+
         // now every node has tried to attach every other node as a neighbor, but
         // some were excluded based on diversity check.
-        assertNeighbors(builder.graph, 0, 1, 2);
-        assertNeighbors(builder.graph, 1, 0);
-        assertNeighbors(builder.graph, 2, 0);
+        assertNeighbors(view, 0, 1, 2);
+        assertNeighbors(view, 1, 0);
+        assertNeighbors(view, 2, 0);
 
         builder.addGraphNode(3, vectors.getVector(3));
-        assertNeighbors(builder.graph, 0, 1, 2);
+        assertNeighbors(view, 0, 1, 2);
         // we added 3 here
-        assertNeighbors(builder.graph, 1, 0, 3);
-        assertNeighbors(builder.graph, 2, 0);
-        assertNeighbors(builder.graph, 3, 1);
+        assertNeighbors(view, 1, 0, 3);
+        assertNeighbors(view, 2, 0);
+        assertNeighbors(view, 3, 1);
 
         // supplant an existing neighbor
         builder.addGraphNode(4, vectors.getVector(4));
+
         // 4 is the same distance from 0 that 2 is; we leave the existing node in place
-        assertNeighbors(builder.graph, 0, 1, 2);
-        assertNeighbors(builder.graph, 1, 0, 3, 4);
-        assertNeighbors(builder.graph, 2, 0);
+        assertNeighbors(view, 0, 1, 2);
+        assertNeighbors(view, 1, 0, 3, 4);
+        assertNeighbors(view, 2, 0);
         // 1 survives the diversity check
-        assertNeighbors(builder.graph, 3, 1, 4);
-        assertNeighbors(builder.graph, 4, 1, 3);
+        assertNeighbors(view, 3, 1, 4);
+        assertNeighbors(view, 4, 1, 3);
 
         builder.addGraphNode(5, vectors.getVector(5));
-        assertNeighbors(builder.graph, 0, 1, 2);
-        assertNeighbors(builder.graph, 1, 0, 3, 4, 5);
-        assertNeighbors(builder.graph, 2, 0);
+        assertNeighbors(view, 0, 1, 2);
+        assertNeighbors(view, 1, 0, 3, 4, 5);
+        assertNeighbors(view, 2, 0);
         // even though 5 is closer, 3 is not a neighbor of 5, so no update to *its* neighbors occurs
-        assertNeighbors(builder.graph, 3, 1, 4);
-        assertNeighbors(builder.graph, 4, 1, 3, 5);
-        assertNeighbors(builder.graph, 5, 1, 4);
+        assertNeighbors(view, 3, 1, 4);
+        assertNeighbors(view, 4, 1, 3, 5);
+        assertNeighbors(view, 5, 1, 4);
     }
 
     @Test
@@ -538,18 +542,21 @@ public class TestVectorGraph extends LuceneTestCase {
         builder.addGraphNode(0, vectors.getVector(0));
         builder.addGraphNode(1, vectors.getVector(1));
         builder.addGraphNode(2, vectors.getVector(2));
-        assertNeighbors(builder.graph, 0, 1, 2);
+
+        var view = builder.graph.getView();
+
+        assertNeighbors(view, 0, 1, 2);
         // 2 is closer to 0 than 1, so it is excluded as non-diverse
-        assertNeighbors(builder.graph, 1, 0);
+        assertNeighbors(view, 1, 0);
         // 1 is closer to 0 than 2, so it is excluded as non-diverse
-        assertNeighbors(builder.graph, 2, 0);
+        assertNeighbors(view, 2, 0);
 
         builder.addGraphNode(3, vectors.getVector(3));
         // this is one case we are testing; 2 has been displaced by 3
-        assertNeighbors(builder.graph, 0, 1, 3);
-        assertNeighbors(builder.graph, 1, 0);
-        assertNeighbors(builder.graph, 2, 0);
-        assertNeighbors(builder.graph, 3, 0);
+        assertNeighbors(view, 0, 1, 3);
+        assertNeighbors(view, 1, 0);
+        assertNeighbors(view, 2, 0);
+        assertNeighbors(view, 3, 0);
     }
 
     @Test
@@ -574,21 +581,24 @@ public class TestVectorGraph extends LuceneTestCase {
         builder.addGraphNode(0, vectors.getVector(0));
         builder.addGraphNode(1, vectors.getVector(1));
         builder.addGraphNode(2, vectors.getVector(2));
-        assertNeighbors(builder.graph, 0, 1, 2);
+
+        var view = builder.graph.getView();
+
+        assertNeighbors(view, 0, 1, 2);
         // 2 is closer to 0 than 1, so it is excluded as non-diverse
-        assertNeighbors(builder.graph, 1, 0);
+        assertNeighbors(view, 1, 0);
         // 1 is closer to 0 than 2, so it is excluded as non-diverse
-        assertNeighbors(builder.graph, 2, 0);
+        assertNeighbors(view, 2, 0);
 
         builder.addGraphNode(3, vectors.getVector(3));
         // this is one case we are testing; 1 has been displaced by 3
-        assertNeighbors(builder.graph, 0, 2, 3);
-        assertNeighbors(builder.graph, 1, 0, 3);
-        assertNeighbors(builder.graph, 2, 0);
-        assertNeighbors(builder.graph, 3, 0, 1);
+        assertNeighbors(view, 0, 2, 3);
+        assertNeighbors(view, 1, 0, 3);
+        assertNeighbors(view, 2, 0);
+        assertNeighbors(view, 3, 0, 1);
     }
 
-    private void assertNeighbors(OnHeapGraphIndex graph, int node, int... expected) {
+    private void assertNeighbors(ImmutableGraphIndex.View graph, int node, int... expected) {
         Arrays.sort(expected);
         NodesIterator it = graph.getNeighborsIterator(0, node);
         int[] actual = new int[it.size()];
@@ -677,8 +687,9 @@ public class TestVectorGraph extends LuceneTestCase {
         GraphIndexBuilder builder = new GraphIndexBuilder(vectors, similarityFunction, 2, 30, 1.0f, 1.4f, addHierarchy);
         var graph = builder.build(vectors);
         validateIndex(graph);
+        var view = graph.getView();
         for (int i = 0; i < vectors.size(); i++) {
-            assertTrue(graph.getNeighbors(0, i).size() <= 2); // TODO
+            assertTrue(view.getNeighborsIterator(0, i).size() <= 2); // TODO
         }
     }
 
@@ -699,6 +710,8 @@ public class TestVectorGraph extends LuceneTestCase {
             var results = GraphSearcher.search(qv, 1, vectors, VectorSimilarityFunction.COSINE, graph, Bits.ALL);
             assertEquals(1, results.getNodes().length);
             assertEquals(1, results.getNodes()[0].node);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
@@ -489,6 +489,9 @@ public class TestVectorGraph extends LuceneTestCase {
         assertNeighbors(view, 2, 0);
 
         builder.addGraphNode(3, vectors.getVector(3));
+
+        view = builder.graph.getView();
+
         assertNeighbors(view, 0, 1, 2);
         // we added 3 here
         assertNeighbors(view, 1, 0, 3);
@@ -497,6 +500,8 @@ public class TestVectorGraph extends LuceneTestCase {
 
         // supplant an existing neighbor
         builder.addGraphNode(4, vectors.getVector(4));
+
+        view = builder.graph.getView();
 
         // 4 is the same distance from 0 that 2 is; we leave the existing node in place
         assertNeighbors(view, 0, 1, 2);
@@ -507,6 +512,9 @@ public class TestVectorGraph extends LuceneTestCase {
         assertNeighbors(view, 4, 1, 3);
 
         builder.addGraphNode(5, vectors.getVector(5));
+
+        view = builder.graph.getView();
+
         assertNeighbors(view, 0, 1, 2);
         assertNeighbors(view, 1, 0, 3, 4, 5);
         assertNeighbors(view, 2, 0);
@@ -552,6 +560,9 @@ public class TestVectorGraph extends LuceneTestCase {
         assertNeighbors(view, 2, 0);
 
         builder.addGraphNode(3, vectors.getVector(3));
+
+        view = builder.graph.getView();
+
         // this is one case we are testing; 2 has been displaced by 3
         assertNeighbors(view, 0, 1, 3);
         assertNeighbors(view, 1, 0);
@@ -591,6 +602,9 @@ public class TestVectorGraph extends LuceneTestCase {
         assertNeighbors(view, 2, 0);
 
         builder.addGraphNode(3, vectors.getVector(3));
+
+        view = builder.graph.getView();
+
         // this is one case we are testing; 1 has been displaced by 3
         assertNeighbors(view, 0, 2, 3);
         assertNeighbors(view, 1, 0, 3);

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
@@ -78,7 +78,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
         for (var graph : List.of(fullyConnectedGraph, randomlyConnectedGraph))
         {
             var outputPath = testDirectory.resolve("test_graph_" + graph.getClass().getSimpleName());
-            var ravv = new TestVectorGraph.CircularFloatVectorValues(graph.size());
+            var ravv = new TestVectorGraph.CircularFloatVectorValues(graph.size(0));
             TestUtil.writeGraph(graph, ravv, outputPath);
             try (var readerSupplier = new SimpleMappedReader.Supplier(outputPath.toAbsolutePath());
                  var onDiskGraph = OnDiskGraphIndex.load(readerSupplier))
@@ -109,7 +109,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
         builder.setEntryPoint(0, builder.getGraph().getIdUpperBound() - 1); // TODO
 
         // check
-        assertEquals(2, original.size());
+        assertEquals(2, original.size(0));
         var originalView = original.getView();
         // 1 -> 2
         assertEquals(1, getNeighborNodes(originalView, 0, 1).size());
@@ -244,7 +244,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
     public void testSimpleGraphSeparated() throws Exception {
         for (var graph : List.of(fullyConnectedGraph, randomlyConnectedGraph)) {
             var outputPath = testDirectory.resolve("test_graph_separated_" + graph.getClass().getSimpleName());
-            var ravv = new TestVectorGraph.CircularFloatVectorValues(graph.size());
+            var ravv = new TestVectorGraph.CircularFloatVectorValues(graph.size(0));
 
             // Write graph with SEPARATED_VECTORS
             try (var writer = new OnDiskGraphIndexWriter.Builder(graph, outputPath)
@@ -315,7 +315,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
     {
         var graph = new TestUtil.RandomlyConnectedGraphIndex(1_000_000, 32, getRandom());
         var outputPath = testDirectory.resolve("large_graph");
-        var ravv = new TestVectorGraph.CircularFloatVectorValues(graph.size());
+        var ravv = new TestVectorGraph.CircularFloatVectorValues(graph.size(0));
         TestUtil.writeGraph(graph, ravv, outputPath);
 
         try (var readerSupplier = new SimpleMappedReader.Supplier(outputPath.toAbsolutePath());

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskSequentialGraphIndexWriter.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskSequentialGraphIndexWriter.java
@@ -20,7 +20,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import io.github.jbellis.jvector.LuceneTestCase;
 import io.github.jbellis.jvector.disk.SimpleMappedReader;
 import io.github.jbellis.jvector.disk.SimpleWriter;
-import io.github.jbellis.jvector.graph.GraphIndex;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.TestUtil;
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
@@ -84,7 +84,7 @@ public class TestOnDiskSequentialGraphIndexWriter extends LuceneTestCase {
         // Create random vectors and build a graph
         var ravv = new ListRandomAccessVectorValues(new ArrayList<>(TestUtil.createRandomVectors(size, dimension)), dimension);
         var builder = new GraphIndexBuilder(ravv, VectorSimilarityFunction.COSINE, maxConnections, beamWidth, neighborOverflow, alpha, addHierarchy);
-        GraphIndex graph = TestUtil.buildSequentially(builder, ravv);
+        ImmutableGraphIndex graph = TestUtil.buildSequentially(builder, ravv);
 
         // Create a sequential writer and write the graph
         Path indexPath = testDirectory.resolve("graph.index_with_hierarchy_" + addHierarchy);

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestADCGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/quantization/TestADCGraphIndex.java
@@ -73,7 +73,7 @@ public class TestADCGraphIndex extends RandomizedTest {
                     var reranker = cachedOnDiskView.rerankerFor(queryVector, similarityFunction);
                     for (int i = 0; i < 50; i++) {
                         var fusedScoreFunction = cachedOnDiskView.approximateScoreFunctionFor(queryVector, similarityFunction);
-                        var ordinal = getRandom().nextInt(graph.size());
+                        var ordinal = getRandom().nextInt(graph.size(0));
                         // first pass compares fused ADC's direct similarity to reranker's similarity, used for comparisons to a specific node
                         var neighbors = cachedOnDiskView.getNeighborsIterator(0, ordinal);
                         for (; neighbors.hasNext(); ) {


### PR DESCRIPTION
The main intent of this PR is to add an interface in front of the OnHeapGraphIndex. This is because it has become clear recently that we will need new implementations for mutable graphs (that are more conservative in the use of heap memory). This PR paves the way towards that path.

Importantly, MutableGraphIndex is protected inside its package, because modifications should only be done through the GraphIndexBuilder class and never directly.

These changes triggered a lot of minor changes everywhere.