### PR TITLE
Prefer footer constants in AbstractGraphIndexWriter

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -52,7 +52,9 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.github.jbellis.jvector.graph.disk.OnDiskSequentialGraphIndexWriter.*;
+import static io.github.jbellis.jvector.graph.disk.AbstractGraphIndexWriter.FOOTER_MAGIC;
+import static io.github.jbellis.jvector.graph.disk.AbstractGraphIndexWriter.FOOTER_MAGIC_SIZE;
+import static io.github.jbellis.jvector.graph.disk.AbstractGraphIndexWriter.FOOTER_OFFSET_SIZE;
 
 /**
  * A class representing a graph index stored on disk. The base graph contains only graph structure.

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskSequentialGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskSequentialGraphIndexWriter.java
@@ -57,10 +57,6 @@ import java.util.stream.Collectors;
  * </ul>
  */
 public class OnDiskSequentialGraphIndexWriter extends AbstractGraphIndexWriter<IndexWriter> {
-    public static final int FOOTER_MAGIC = 0x4a564244; // "EOF magic"
-    public static final int FOOTER_OFFSET_SIZE = Long.BYTES; // The size of the offset in the footer
-    public static final int FOOTER_MAGIC_SIZE = Integer.BYTES; // The size of the magic number in the footer
-    public static final int FOOTER_SIZE = FOOTER_MAGIC_SIZE + FOOTER_OFFSET_SIZE; // The total size of the footer
 
     OnDiskSequentialGraphIndexWriter(IndexWriter out,
                                              int version,


### PR DESCRIPTION
While working on the upgrade to jvector file format 5, I ran into some file validation errors regarding footer magic. I discovered that with https://github.com/datastax/jvector/pull/475, we have the same `FOOTER_MAGIC` defined in two places with the same hard coded value `0x4a564244`. Notably, we wrote to disk using one variable and then validated using the other, which seems error prone.

I propose that we remove the unnecessary duplication. This is technically a breaking change because we are removing public variables, but a quick search of OSS projects indicates no one is using these variables yet https://grep.app/search?q=OnDiskSequentialGraphIndexWriter.

The alternative is to define the `OnDiskSequentialGraphIndexWriter` constants with references to the `AbstractGraphIndexWriter` constants.