### PR TITLE
an experiment: javadoc fixups everywhere, less verbose

### DIFF
--- a/benchmarks-jmh/pom.xml
+++ b/benchmarks-jmh/pom.xml
@@ -94,6 +94,21 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalJOptions>
+                        <additionalJOption>--add-modules=jdk.incubator.vector</additionalJOption>
+                    </additionalJOptions>
+                    <release>22</release>
+                    <detectOfflineLinks>false</detectOfflineLinks>
+                    <includeDependencySources>true</includeDependencySources>
+                    <dependencySourceIncludes>
+                        <dependencySourceInclude>io.github.jbellis:*</dependencySourceInclude>
+                    </dependencySourceIncludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/BufferedRandomAccessWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/BufferedRandomAccessWriter.java
@@ -35,6 +35,11 @@ public class BufferedRandomAccessWriter implements RandomAccessWriter {
     private final RandomAccessFile raf;
     private final DataOutputStream stream;
 
+    /**
+     * Create a BufferedRandomAccessWriter for the specified path.
+     * @param path the path
+     * @throws FileNotFoundException if the file is not found
+     */
     public BufferedRandomAccessWriter(Path path) throws FileNotFoundException {
         raf = new RandomAccessFile(path.toFile(), "rw");
         stream = new DataOutputStream(new BufferedOutputStream(new RandomAccessOutputStream(raf)));
@@ -89,9 +94,8 @@ public class BufferedRandomAccessWriter implements RandomAccessWriter {
 
     /**
      * return the CRC32 checksum for the range [startOffset .. endOffset)
-     * <p>
+     *
      * the file pointer will be left at endOffset.
-     * <p>
      */
     @Override
     public long checksum(long startOffset, long endOffset) throws IOException {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/ByteBufferReader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/ByteBufferReader.java
@@ -23,8 +23,13 @@ import java.nio.ByteBuffer;
  * RandomAccessReader that reads from a ByteBuffer
  */
 public class ByteBufferReader implements RandomAccessReader {
+    /** The ByteBuffer to read from. */
     protected final ByteBuffer bb;
 
+    /**
+     * Create a ByteBufferReader for the specified ByteBuffer.
+     * @param sourceBB the ByteBuffer
+     */
     public ByteBufferReader(ByteBuffer sourceBB) {
         bb = sourceBB;
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexWriter.java
@@ -20,9 +20,15 @@ import java.io.Closeable;
 import java.io.DataOutput;
 import java.io.IOException;
 
+/**
+ * Interface for writing index data to an output stream with position tracking.
+ * Extends DataOutput to provide standard data writing methods and Closeable for resource management.
+ */
 public interface IndexWriter extends DataOutput, Closeable {
     /**
+     * Gets the current position in the output.
      * @return the current position in the output
+     * @throws IOException if an error occurs
      */
     long position() throws IOException;
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessReader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessReader.java
@@ -32,32 +32,99 @@ import java.nio.ByteBuffer;
  * uses the ReaderSupplier API to create a RandomAccessReader per thread, as needed.
  */
 public interface RandomAccessReader extends AutoCloseable {
+    /**
+     * Seek to an offset in the reader.
+     * @param offset the offset
+     * @throws IOException if an error occurs
+     */
     void seek(long offset) throws IOException;
 
+    /**
+     * Get the current position in the reader.
+     * @return the current position
+     * @throws IOException if an error occurs
+     */
     long getPosition() throws IOException;
 
+    /**
+     * Read an int.
+     * @return the int
+     * @throws IOException if an error occurs
+     */
     int readInt() throws IOException;
 
+    /**
+     * Read a float.
+     * @return the float
+     * @throws IOException if an error occurs
+     */
     float readFloat() throws IOException;
 
+    /**
+     * Read a long.
+     * @return the long
+     * @throws IOException if an error occurs
+     */
     long readLong() throws IOException;
 
+    /**
+     * Read fully into a byte array.
+     * @param bytes the byte array
+     * @throws IOException if an error occurs
+     */
     void readFully(byte[] bytes) throws IOException;
 
+    /**
+     * Read fully into a ByteBuffer.
+     * @param buffer the ByteBuffer
+     * @throws IOException if an error occurs
+     */
     void readFully(ByteBuffer buffer) throws IOException;
 
+    /**
+     * Read fully into a float array.
+     * @param floats the float array
+     * @throws IOException if an error occurs
+     */
     default void readFully(float[] floats) throws IOException {
         read(floats, 0, floats.length);
     }
 
+    /**
+     * Read fully into a long array.
+     * @param vector the long array
+     * @throws IOException if an error occurs
+     */
     void readFully(long[] vector) throws IOException;
 
+    /**
+     * Read into an int array.
+     * @param ints the int array
+     * @param offset the offset
+     * @param count the count
+     * @throws IOException if an error occurs
+     */
     void read(int[] ints, int offset, int count) throws IOException;
 
+    /**
+     * Read into a float array.
+     * @param floats the float array
+     * @param offset the offset
+     * @param count the count
+     * @throws IOException if an error occurs
+     */
     void read(float[] floats, int offset, int count) throws IOException;
 
+    /**
+     * Close the reader.
+     * @throws IOException if an error occurs
+     */
     void close() throws IOException;
 
-    // Length of the reader slice
+    /**
+     * Length of the reader slice.
+     * @return the length
+     * @throws IOException if an error occurs
+     */
     long length() throws IOException;
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/RandomAccessWriter.java
@@ -24,9 +24,25 @@ import java.io.IOException;
  * A DataOutput that adds methods for random access writes
  */
 public interface RandomAccessWriter extends IndexWriter {
+    /**
+     * Seek to a position in the writer.
+     * @param position the position
+     * @throws IOException if an error occurs
+     */
     void seek(long position) throws IOException;
 
+    /**
+     * Flush the writer.
+     * @throws IOException if an error occurs
+     */
     void flush() throws IOException;
 
+    /**
+     * Compute a checksum for the range [startOffset .. endOffset).
+     * @param startOffset the start offset
+     * @param endOffset the end offset
+     * @return the checksum
+     * @throws IOException if an error occurs
+     */
     long checksum(long startOffset, long endOffset) throws IOException;
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/ReaderSupplier.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/ReaderSupplier.java
@@ -19,12 +19,17 @@ package io.github.jbellis.jvector.disk;
 import java.io.IOException;
 
 /**
- * A supplier of RandomAccessReaders.
+ * A supplier of RandomAccessReaders that provides access to the underlying index file.
+ * Implementations are responsible for opening new readers but not for managing their lifecycle
+ * after creation.
  */
 public interface ReaderSupplier extends AutoCloseable {
     /**
-     * @return a new reader.  It is up to the caller to re-use these readers or close them,
-     * the ReaderSupplier is not responsible for caching them.
+     * Creates and returns a new RandomAccessReader for accessing the index file. Each call returns
+     * a distinct reader instance. Callers are responsible for managing the lifecycle of returned
+     * readers, including closing them when done or reusing them as needed.
+     * @return a new reader positioned at the beginning of the file
+     * @throws IOException if an I/O error occurs while opening the reader
      */
     RandomAccessReader get() throws IOException;
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/ReaderSupplierFactory.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/ReaderSupplierFactory.java
@@ -22,11 +22,26 @@ import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Factory for creating ReaderSupplier instances with fallback support across multiple implementations.
+ * Tries MemorySegmentReader first (JDK 20+), then MMapReader, and finally MappedChunkReader.
+ */
 public class ReaderSupplierFactory {
     private static final Logger LOG = Logger.getLogger(ReaderSupplierFactory.class.getName());
+
+    /** Private constructor to prevent instantiation of this utility class */
+    private ReaderSupplierFactory() {
+        throw new UnsupportedOperationException("Utility class");
+    }
     private static final String MEMORY_SEGMENT_READER_CLASSNAME = "io.github.jbellis.jvector.disk.MemorySegmentReader$Supplier";
     private static final String MMAP_READER_CLASSNAME = "io.github.jbellis.jvector.example.util.MMapReader$Supplier";
 
+    /**
+     * Opens a ReaderSupplier for the specified file, using the best available implementation.
+     * @param path the path to the file to read
+     * @return a ReaderSupplier for creating readers for the file
+     * @throws IOException if an I/O error occurs while opening the file
+     */
     public static ReaderSupplier open(Path path) throws IOException {
         try {
             // prefer MemorySegmentReader (available under JDK 20+)

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleMappedReader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleMappedReader.java
@@ -55,10 +55,20 @@ public class SimpleMappedReader extends ByteBufferReader {
         // Individual readers don't close anything
     }
 
+    /**
+     * Supplies SimpleMappedReader instances backed by a shared memory-mapped buffer.
+     */
     public static class Supplier implements ReaderSupplier {
+        /** The shared memory-mapped buffer that all readers will use */
         private final MappedByteBuffer buffer;
+        /** Unsafe instance for manual buffer cleanup when closing */
         private static final Unsafe unsafe = getUnsafe();
 
+        /**
+         * Creates a new Supplier that memory-maps the specified file.
+         * @param path the path to the file to memory-map
+         * @throws IOException if an I/O error occurs or the file is larger than 2GB
+         */
         public Supplier(Path path) throws IOException {
             try (var raf = new RandomAccessFile(path.toString(), "r")) {
                 if (raf.length() > Integer.MAX_VALUE) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleReader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleReader.java
@@ -26,9 +26,19 @@ import java.nio.file.Path;
 // TODO what are the low-hanging optimization options here?
 // The requirement that we need to read from a file that is potentially changing in length
 // limits our options.
+/**
+ * A simple RandomAccessFile-based implementation of RandomAccessReader.
+ * Primarily used for testing and scenarios with dynamic file lengths.
+ */
 public class SimpleReader implements RandomAccessReader {
+    /** The underlying random access file for reading */
     RandomAccessFile raf;
 
+    /**
+     * Creates a new SimpleReader for the specified file path.
+     * @param path the path to the file to read
+     * @throws FileNotFoundException if the file does not exist
+     */
     public SimpleReader(Path path) throws FileNotFoundException {
         raf = new RandomAccessFile(path.toFile(), "r");
     }
@@ -105,9 +115,17 @@ public class SimpleReader implements RandomAccessReader {
         return raf.length();
     }
 
+    /**
+     * Supplies SimpleReader instances for the same file path.
+     */
     public static class Supplier implements ReaderSupplier {
+        /** The file path to open readers for */
         private final Path path;
 
+        /**
+         * Creates a new Supplier for the specified file path.
+         * @param path the path to the file that readers will open
+         */
         public Supplier(Path path) {
             this.path = path;
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/SimpleWriter.java
@@ -27,9 +27,16 @@ import java.nio.file.Path;
  * Primarily, it is a basic sequential writer, unlike {@link BufferedRandomAccessWriter} which is mostly used in production.
  */
 public class SimpleWriter implements IndexWriter {
+    /** The underlying file output stream */
     private final FileOutputStream fos;
+    /** The data output stream wrapping the file stream for typed writes */
     private final DataOutputStream dos;
 
+    /**
+     * Creates a new SimpleWriter for the specified file path.
+     * @param path the path to the file to write
+     * @throws IOException if an I/O error occurs while opening the file
+     */
     public SimpleWriter(Path path) throws IOException {
         fos = new FileOutputStream(path.toFile());
         dos = new DataOutputStream(fos);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/exceptions/ThreadInterruptedException.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/exceptions/ThreadInterruptedException.java
@@ -24,7 +24,15 @@
 
 package io.github.jbellis.jvector.exceptions;
 
+/**
+ * Runtime exception wrapper for InterruptedException, used to propagate thread interruption
+ * through code that cannot throw checked exceptions.
+ */
 public final class ThreadInterruptedException extends RuntimeException {
+  /**
+   * Creates a new ThreadInterruptedException wrapping the given InterruptedException.
+   * @param ie the InterruptedException that caused this thread to be interrupted
+   */
   public ThreadInterruptedException(InterruptedException ie) {
     super(ie);
   }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ConcurrentNeighborMap.java
@@ -41,10 +41,24 @@ public class ConcurrentNeighborMap {
     /** the maximum number of neighbors a node can have temporarily during construction */
     public final int maxOverflowDegree;
 
+    /**
+     * Constructor.
+     * @param diversityProvider the diversityProvider
+     * @param maxDegree the maxDegree
+     * @param maxOverflowDegree the maxOverflowDegree
+     */
     public ConcurrentNeighborMap(DiversityProvider diversityProvider, int maxDegree, int maxOverflowDegree) {
         this(new DenseIntMap<>(1024), diversityProvider, maxDegree, maxOverflowDegree);
     }
 
+    /**
+     * Constructor.
+     * @param neighbors the neighbors
+     * @param diversityProvider the diversityProvider
+     * @param maxDegree the maxDegree
+     * @param maxOverflowDegree the maxOverflowDegree
+     * @param <T> the T type parameter
+     */
     public <T> ConcurrentNeighborMap(IntMap<Neighbors> neighbors, DiversityProvider diversityProvider, int maxDegree, int maxOverflowDegree) {
         assert maxDegree <= maxOverflowDegree : String.format("maxDegree %d exceeds maxOverflowDegree %d", maxDegree, maxOverflowDegree);
         this.neighbors = neighbors;
@@ -53,6 +67,13 @@ public class ConcurrentNeighborMap {
         this.maxOverflowDegree = maxOverflowDegree;
     }
 
+    /**
+     * Insert edge.
+     * @param fromId the fromId
+     * @param toId the toId
+     * @param score the score
+     * @param overflow the overflow
+     */
     public void insertEdge(int fromId, int toId, float score, float overflow) {
         while (true) {
             var old = neighbors.get(fromId);
@@ -63,6 +84,12 @@ public class ConcurrentNeighborMap {
         }
     }
 
+    /**
+     * Insert edge not diverse.
+     * @param fromId the fromId
+     * @param toId the toId
+     * @param score the score
+     */
     public void insertEdgeNotDiverse(int fromId, int toId, float score) {
         while (true) {
             var old = neighbors.get(fromId);
@@ -74,6 +101,8 @@ public class ConcurrentNeighborMap {
     }
 
     /**
+     * Enforce degree.
+     * @param nodeId the nodeId
      * @return the fraction of short edges, i.e., neighbors within alpha=1.0
      */
     public double enforceDegree(int nodeId) {
@@ -91,6 +120,12 @@ public class ConcurrentNeighborMap {
         }
     }
 
+    /**
+     * Replace deleted neighbors.
+     * @param nodeId the nodeId
+     * @param toDelete the toDelete
+     * @param candidates the candidates
+     */
     public void replaceDeletedNeighbors(int nodeId, BitSet toDelete, NodeArray candidates) {
         while (true) {
             var old = neighbors.get(nodeId);
@@ -101,6 +136,12 @@ public class ConcurrentNeighborMap {
         }
     }
 
+    /**
+     * Insert diverse.
+     * @param nodeId the nodeId
+     * @param candidates the candidates
+     * @return the return value
+     */
     public Neighbors insertDiverse(int nodeId, NodeArray candidates) {
         while (true) {
             var old = neighbors.get(nodeId);
@@ -112,10 +153,19 @@ public class ConcurrentNeighborMap {
         }
     }
 
+    /**
+     * Get neighbors.
+     * @param node the node
+     * @return the return value
+     */
     public Neighbors get(int node) {
         return neighbors.get(node);
     }
 
+    /**
+     * Get size.
+     * @return the return value
+     */
     public int size() {
         return neighbors.size();
     }
@@ -130,18 +180,36 @@ public class ConcurrentNeighborMap {
         }
     }
 
+    /**
+     * Add node.
+     * @param nodeId the nodeId
+     */
     public void addNode(int nodeId) {
         addNode(nodeId, new NodeArray(0));
     }
 
+    /**
+     * Remove node.
+     * @param node the node
+     * @return the return value
+     */
     public Neighbors remove(int node) {
         return neighbors.remove(node);
     }
 
+    /**
+     * Check if contains node.
+     * @param nodeId the nodeId
+     * @return the return value
+     */
     public boolean contains(int nodeId) {
         return neighbors.containsKey(nodeId);
     }
 
+    /**
+     * For each neighbor.
+     * @param consumer the consumer
+     */
     public void forEach(DenseIntMap.IntBiConsumer<Neighbors> consumer) {
         neighbors.forEach(consumer);
     }
@@ -154,6 +222,9 @@ public class ConcurrentNeighborMap {
     /**
      * Add a link from every node in the NodeArray to the target toId.
      * If overflow is > 1.0, allow the number of neighbors to exceed maxConnections temporarily.
+     * @param nodes the nodes
+     * @param toId the toId
+     * @param overflow the overflow
      */
     public void backlink(NodeArray nodes, int toId, float overflow) {
         for (int i = 0; i < nodes.size(); i++) {
@@ -192,6 +263,10 @@ public class ConcurrentNeighborMap {
             this.diverseBefore = size();
         }
 
+        /**
+         * Get iterator.
+         * @return the return value
+         */
         public NodesIterator iterator() {
             return new NeighborIterator(this);
         }
@@ -322,6 +397,11 @@ public class ConcurrentNeighborMap {
             return next;
         }
 
+        /**
+         * Calculate RAM bytes used.
+         * @param count the count
+         * @return the return value
+         */
         public static long ramBytesUsed(int count) {
             return NodeArray.ramBytesUsed(count) // includes our object header
                     + Integer.BYTES // nodeId

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/MapRandomAccessVectorValues.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/MapRandomAccessVectorValues.java
@@ -33,6 +33,11 @@ public class MapRandomAccessVectorValues implements RandomAccessVectorValues {
     private final Map<Integer, VectorFloat<?>> map;
     private final int dimension;
 
+    /**
+     * Constructs a MapRandomAccessVectorValues backed by the provided map.
+     * @param map the map storing node ID to vector mappings
+     * @param dimension the dimensionality of all vectors in the map
+     */
     public MapRandomAccessVectorValues(Map<Integer, VectorFloat<?>> map, int dimension) {
         this.map = map;
         this.dimension = dimension;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodeArray.java
@@ -41,18 +41,35 @@ import static java.lang.Math.min;
  * i.e. the most-similar nodes are first.
  */
 public class NodeArray {
+    /**
+     * A shared empty NodeArray instance for use when no nodes are present.
+     */
     public static final NodeArray EMPTY = new NodeArray(0);
 
     private int size;
+    /**
+     * Scores for each node, maintained in descending order (highest scores first).
+     */
     private float[] scores;
+    /**
+     * Node IDs corresponding to the scores at the same index.
+     */
     private int[] nodes;
 
+    /**
+     * Constructs a new NodeArray with the specified initial capacity.
+     * @param initialSize the initial capacity for storing nodes
+     */
     public NodeArray(int initialSize) {
         nodes = new int[initialSize];
         scores = new float[initialSize];
     }
 
-    // this idiosyncratic constructor exists for the benefit of subclass ConcurrentNeighborMap
+    /**
+     * Protected copy constructor that shares the internal arrays with another NodeArray.
+     * This idiosyncratic constructor exists for the benefit of subclass ConcurrentNeighborMap.
+     * @param nodeArray the NodeArray to share arrays with
+     */
     protected NodeArray(NodeArray nodeArray) {
         this.size = nodeArray.size();
         this.nodes = nodeArray.nodes;
@@ -145,6 +162,8 @@ public class NodeArray {
     /**
      * Add a new node to the NodeArray. The new node must be worse than all previously stored
      * nodes.
+     * @param newNode the newNode
+     * @param newScore the newScore
      */
     public void addInOrder(int newNode, float newScore) {
         if (size == nodes.length) {
@@ -175,7 +194,8 @@ public class NodeArray {
     /**
      * Add a new node to the NodeArray into a correct sort position according to its score.
      * Duplicate node + score pairs are ignored.
-     *
+     * @param newNode the newNode
+     * @param newScore the newScore
      * @return the insertion point of the new node, or -1 if it already existed
      */
     public int insertSorted(int newNode, float newScore) {
@@ -230,9 +250,7 @@ public class NodeArray {
     /**
      * Retains only the elements in the current NodeArray whose corresponding index
      * is set in the given BitSet.
-     * <p>
      * This modifies the array in place, preserving the relative order of the elements retained.
-     * <p>
      *
      * @param selected A BitSet where the bit at index i is set if the i-th element should be retained.
      *                 (Thus, the elements of selected represent positions in the NodeArray, NOT node ids.)
@@ -255,10 +273,19 @@ public class NodeArray {
         size = writeIdx;
     }
 
+    /**
+     * Copy node array.
+     * @return the return value
+     */
     public NodeArray copy() {
         return copy(size);
     }
 
+    /**
+     * Copy node array with new size.
+     * @param newSize the newSize
+     * @return the return value
+     */
     public NodeArray copy(int newSize) {
         if (size > newSize) {
             throw new IllegalArgumentException(String.format("Cannot copy %d nodes to a smaller size %d", size, newSize));
@@ -271,23 +298,41 @@ public class NodeArray {
         return copy;
     }
 
+    /**
+     * Grows the internal storage arrays when capacity is exhausted. The nodes array grows
+     * using the default growth strategy, and the scores array is resized to match.
+     */
     protected final void growArrays() {
         nodes = ArrayUtil.grow(nodes);
         scores = ArrayUtil.growExact(scores, nodes.length);
     }
 
+    /**
+     * Returns the number of nodes currently stored in this array.
+     * @return the count of nodes in the array
+     */
     public int size() {
         return size;
     }
 
+    /**
+     * Removes all nodes from the array, resetting the size to zero without releasing memory.
+     */
     public void clear() {
         size = 0;
     }
 
+    /**
+     * Removes the last node from the array by decrementing the size counter.
+     */
     public void removeLast() {
         size--;
     }
 
+    /**
+     * Removes the node at the specified index, shifting all subsequent nodes down by one position.
+     * @param idx the index of the node to remove
+     */
     public void removeIndex(int idx) {
         System.arraycopy(nodes, idx + 1, nodes, idx, size - idx - 1);
         System.arraycopy(scores, idx + 1, scores, idx, size - idx - 1);
@@ -305,6 +350,12 @@ public class NodeArray {
         return sb.toString();
     }
 
+    /**
+     * Performs a binary search to find the rightmost insertion point for a new score in the descending-sorted array.
+     * If multiple elements have the same score, this returns the position after all of them.
+     * @param newScore the score value to find the insertion point for
+     * @return the index where the new score should be inserted to maintain descending order
+     */
     protected final int descSortFindRightMostInsertionPoint(float newScore) {
         int start = 0;
         int end = size - 1;
@@ -316,6 +367,11 @@ public class NodeArray {
         return start;
     }
 
+    /**
+     * Calculates the memory footprint in bytes for a NodeArray of the given size.
+     * @param size the number of nodes in the array
+     * @return the estimated RAM usage in bytes
+     */
     public static long ramBytesUsed(int size) {
         int REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
         int AH_BYTES = RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
@@ -354,20 +410,37 @@ public class NodeArray {
     /**
      * Insert a new node, without growing the array.  If the array is full, drop the worst existing node to make room.
      * (Even if the worst existing one is better than newNode!)
+     * @param newNode the newNode
+     * @param newScore the newScore
+     * @return the return value
      */
     protected int insertOrReplaceWorst(int newNode, float newScore) {
         size = min(size, nodes.length - 1);
         return insertSorted(newNode, newScore);
     }
 
+    /**
+     * Returns the score of the node at the specified index position.
+     * @param i the index position (0 to size-1)
+     * @return the score at the given index
+     */
     public float getScore(int i) {
         return scores[i];
     }
 
+    /**
+     * Returns the node ID at the specified index position.
+     * @param i the index position (0 to size-1)
+     * @return the node ID at the given index
+     */
     public int getNode(int i) {
         return nodes[i];
     }
 
+    /**
+     * Returns the total allocated capacity of the internal arrays, which may be larger than the current size.
+     * @return the length of the internal storage arrays
+     */
     protected int getArrayLength() {
         return nodes.length;
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodesIterator.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodesIterator.java
@@ -34,10 +34,17 @@ import java.util.PrimitiveIterator;
  */
 public interface NodesIterator extends PrimitiveIterator.OfInt {
     /**
-     * The number of elements in this iterator *
+     * Returns the total number of elements that this iterator will produce.
+     * @return the count of elements in this iterator
      */
     int size();
 
+    /**
+     * Creates a NodesIterator from a standard primitive integer iterator with a known size.
+     * @param iterator the source iterator providing node IDs
+     * @param size the total number of elements the iterator will produce
+     * @return a NodesIterator wrapping the provided iterator
+     */
     static NodesIterator fromPrimitiveIterator(PrimitiveIterator.OfInt iterator, int size) {
         return new NodesIterator() {
             @Override
@@ -57,12 +64,19 @@ public interface NodesIterator extends PrimitiveIterator.OfInt {
         };
     }
 
+    /**
+     * Implementation of NodesIterator that iterates over a subset of an integer array.
+     */
     class ArrayNodesIterator implements NodesIterator {
         private final int[] nodes;
         private int cur = 0;
         private final int size;
 
-        /** Constructor for iterator based on integer array representing nodes */
+        /**
+         * Constructs an iterator over a portion of the given array.
+         * @param nodes the array containing node IDs
+         * @param size the number of elements to iterate over (must be &lt;= nodes.length)
+         */
         public ArrayNodesIterator(int[] nodes, int size) {
             assert nodes != null;
             assert size <= nodes.length;
@@ -75,6 +89,10 @@ public interface NodesIterator extends PrimitiveIterator.OfInt {
             return size;
         }
 
+        /**
+         * Constructs an iterator over the entire array.
+         * @param nodes the array containing node IDs to iterate over
+         */
         public ArrayNodesIterator(int[] nodes) {
             this(nodes, nodes.length);
         }
@@ -97,9 +115,23 @@ public interface NodesIterator extends PrimitiveIterator.OfInt {
         }
     }
 
+    /**
+     * Shared instance of an empty iterator that contains no elements.
+     */
     EmptyNodeIterator EMPTY_NODE_ITERATOR = new EmptyNodeIterator();
 
+    /**
+     * An iterator implementation that contains no elements. Always returns false for hasNext()
+     * and throws NoSuchElementException for nextInt().
+     */
     class EmptyNodeIterator implements NodesIterator {
+        /**
+         * Constructs an empty node iterator with no elements.
+         */
+        public EmptyNodeIterator() {
+        }
+
+
         @Override
         public int size() {
             return 0;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodesUnsorted.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/NodesUnsorted.java
@@ -31,18 +31,33 @@ import io.github.jbellis.jvector.util.ArrayUtil;
  * NodesUnsorted contains scored node ids in insertion order.
  */
 public class NodesUnsorted {
+    /**
+     * The current number of nodes stored in this collection.
+     */
     protected int size;
+    /**
+     * Array of scores corresponding to each node, stored in insertion order.
+     */
     float[] score;
+    /**
+     * Array of node IDs stored in insertion order.
+     */
     int[] node;
 
+    /**
+     * Constructs a new NodesUnsorted collection with the specified initial capacity.
+     * @param initialSize the initial capacity for storing nodes
+     */
     public NodesUnsorted(int initialSize) {
         node = new int[initialSize];
         score = new float[initialSize];
     }
 
     /**
-     * Add a new node to the NodeArray. The new node must be worse than all previously stored
-     * nodes.
+     * Adds a new node and its score to the collection in insertion order. Unlike NodeArray, this
+     * collection does not maintain any sorting.
+     * @param newNode the node ID to add
+     * @param newScore the score associated with this node
      */
     public void add(int newNode, float newScore) {
         if (size == node.length) {
@@ -53,19 +68,33 @@ public class NodesUnsorted {
         ++size;
     }
 
+    /**
+     * Grows the internal storage arrays when capacity is exhausted, using the default growth strategy.
+     */
     protected final void growArrays() {
         node = ArrayUtil.grow(node);
         score = ArrayUtil.growExact(score, node.length);
     }
 
+    /**
+     * Returns the number of nodes currently stored in this collection.
+     * @return the count of nodes
+     */
     public int size() {
         return size;
     }
 
+    /**
+     * Removes all nodes from the collection, resetting the size to zero without releasing memory.
+     */
     public void clear() {
         size = 0;
     }
 
+    /**
+     * Iterates over all node-score pairs in insertion order, calling the consumer for each pair.
+     * @param consumer the function to call for each node-score pair
+     */
     public void foreach(NodeConsumer consumer) {
         for (int i = 0; i < size; i++) {
             consumer.accept(node[i], score[i]);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -55,7 +55,9 @@ import java.util.stream.IntStream;
  * For searching, use a view obtained from {@link #getView()} which supports level–aware operations.
  */
 public class OnHeapGraphIndex implements MutableGraphIndex {
-    // Used for saving and loading OnHeapGraphIndex
+    /**
+     * Magic number identifying JVector graph index files in serialized format
+     */
     public static final int MAGIC = 0x75EC4012; // JVECTOR, with some imagination
 
     // The current entry node for searches
@@ -380,6 +382,11 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
      * if concurrent updates are in progress.)
      */
     public class ConcurrentGraphIndexView extends FrozenView {
+        /**
+         * Default constructor creating a view with snapshot isolation based on completion timestamps
+         */
+        public ConcurrentGraphIndexView() {
+        }
         // It is tempting, but incorrect, to try to provide "adequate" isolation by
         // (1) keeping a bitset of complete nodes and giving that to the searcher as nodes to
         // accept -- but we need to keep incomplete nodes out of the search path entirely,
@@ -489,6 +496,7 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
 
     /**
      * Saves the graph to the given DataOutput for reloading into memory later
+     * @param out the DataOutput to write the serialized graph to
      */
     @Deprecated
     public void save(DataOutput out) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ScoreTracker.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ScoreTracker.java
@@ -23,7 +23,14 @@ import org.apache.commons.math3.stat.StatUtils;
 import static io.github.jbellis.jvector.util.NumericUtils.floatToSortableInt;
 import static io.github.jbellis.jvector.util.NumericUtils.sortableIntToFloat;
 
+/**
+ * Interface for tracking and analyzing similarity scores during graph search to determine
+ * when search can be terminated early based on score patterns.
+ */
 public interface ScoreTracker {
+    /**
+     * Factory for creating ScoreTracker instances appropriate for different search configurations.
+     */
     class ScoreTrackerFactory {
         private TwoPhaseTracker twoPhaseTracker;
         private RelaxedMonotonicityTracker relaxedMonotonicityTracker;
@@ -35,6 +42,13 @@ public interface ScoreTracker {
             noOpTracker = null;
         }
 
+        /**
+         * Returns an appropriate ScoreTracker based on search parameters.
+         * @param pruneSearch whether to enable pruning based on relaxed monotonicity
+         * @param rerankK the number of top candidates to track for reranking purposes
+         * @param threshold the similarity threshold for two-phase search (0 if not applicable)
+         * @return a ScoreTracker configured for the given search parameters
+         */
         public ScoreTracker getScoreTracker(boolean pruneSearch, int rerankK, float threshold) {
             // track scores to predict when we are done with threshold queries
             final ScoreTracker scoreTracker;
@@ -65,13 +79,28 @@ public interface ScoreTracker {
         }
     }
 
+    /** A singleton no-op tracker that performs no tracking and never signals to stop */
     ScoreTracker NO_OP = new NoOpTracker();
 
+    /**
+     * Records a similarity score encountered during search for statistical analysis.
+     * @param score the similarity score to track
+     */
     void track(float score);
 
+    /**
+     * Determines whether the search should be terminated early based on tracked score patterns.
+     * @return true if search can stop, false if it should continue
+     */
     boolean shouldStop();
 
+    /**
+     * A no-op implementation that performs no tracking and never signals to stop search.
+     */
     class NoOpTracker implements ScoreTracker {
+        /** Package-private constructor */
+        NoOpTracker() {}
+
         @Override
         public void track(float score) { }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/SearchResult.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/SearchResult.java
@@ -30,6 +30,15 @@ public final class SearchResult {
     private final int rerankedCount;
     private final float worstApproximateScoreInTopK;
 
+    /**
+     * Creates a new SearchResult containing the results and metrics from an ANN search operation.
+     * @param nodes the top scoring neighbors discovered during the search, sorted best-first
+     * @param visitedCount the total number of graph nodes visited during the search
+     * @param expandedCount the total number of graph nodes expanded (had their neighbors examined)
+     * @param expandedCountL0 the number of nodes expanded in the base layer (layer 0)
+     * @param rerankedCount the number of nodes that were reranked with exact scores
+     * @param worstApproximateScoreInTopK the worst approximate score among the top K results
+     */
     public SearchResult(NodeScore[] nodes, int visitedCount, int expandedCount, int expandedCountL0, int rerankedCount, float worstApproximateScoreInTopK) {
         this.nodes = nodes;
         this.visitedCount = visitedCount;
@@ -40,6 +49,7 @@ public final class SearchResult {
     }
 
     /**
+     * Returns the closest neighbors discovered by the search.
      * @return the closest neighbors discovered by the search, sorted best-first
      */
     public NodeScore[] getNodes() {
@@ -47,6 +57,7 @@ public final class SearchResult {
     }
 
     /**
+     * Returns the total number of graph nodes visited during the search operation.
      * @return the total number of graph nodes visited while performing the search
      */
     public int getVisitedCount() {
@@ -54,6 +65,7 @@ public final class SearchResult {
     }
 
     /**
+     * Returns the total number of graph nodes that had their neighbors examined during search.
      * @return the total number of graph nodes expanded while performing the search
      */
     public int getExpandedCount() {
@@ -61,6 +73,7 @@ public final class SearchResult {
     }
 
     /**
+     * Returns the number of graph nodes expanded specifically in the base layer.
      * @return the number of graph nodes expanded while performing the search in the base layer
      */
     public int getExpandedCountBaseLayer() {
@@ -68,6 +81,7 @@ public final class SearchResult {
     }
 
     /**
+     * Returns the count of nodes that were reranked with exact similarity scores.
      * @return the number of nodes that were reranked during the search
      */
     public int getRerankedCount() {
@@ -75,6 +89,7 @@ public final class SearchResult {
     }
 
     /**
+     * Returns the worst approximate score among the top K results, useful for distributed search.
      * @return the worst approximate score of the top K nodes in the search result.  Useful
      * for passing to rerankFloor during search across multiple indexes.  Will be
      * Float.POSITIVE_INFINITY if no reranking was performed or no results were found.
@@ -83,10 +98,20 @@ public final class SearchResult {
         return worstApproximateScoreInTopK;
     }
 
+    /**
+     * Represents a graph node and its similarity score, used to store search results.
+     */
     public static final class NodeScore implements Comparable<NodeScore> {
+        /** The ordinal ID of the graph node */
         public final int node;
+        /** The similarity score for this node */
         public final float score;
 
+        /**
+         * Creates a new NodeScore pairing a node with its similarity score.
+         * @param node the ordinal ID of the graph node
+         * @param score the similarity score for this node
+         */
         public NodeScore(int node, float score) {
             this.node = node;
             this.score = score;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/CommonHeader.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/CommonHeader.java
@@ -61,10 +61,15 @@ public class CommonHeader {
 
     private static final int V4_MAX_LAYERS = 32;
 
+    /** The on-disk format version number used for serialization compatibility */
     public final int version;
+    /** The dimensionality of vectors stored in the graph index */
     public final int dimension;
+    /** The node ID to use as the entry point for graph traversal */
     public final int entryNode;
+    /** Information about each layer in the graph, including size and degree constraints */
     public final List<LayerInfo> layerInfo;
+    /** The upper bound of node IDs in the graph (maximum node ID + 1) */
     public final int idUpperBound;
 
     CommonHeader(int version, int dimension, int entryNode, List<LayerInfo> layerInfo, int idUpperBound) {
@@ -162,16 +167,32 @@ public class CommonHeader {
         return size * Integer.BYTES;
     }
 
+    /**
+     * Information about a single layer in a hierarchical graph structure.
+     */
     @VisibleForTesting
     public static class LayerInfo {
+        /** The number of nodes present in this layer */
         public final int size;
+        /** The maximum number of neighbors (edges) allowed per node in this layer */
         public final int degree;
 
+        /**
+         * Creates layer information with the specified size and degree.
+         * @param size the number of nodes in this layer
+         * @param degree the maximum degree for nodes in this layer
+         */
         public LayerInfo(int size, int degree) {
             this.size = size;
             this.degree = degree;
         }
 
+        /**
+         * Extracts layer information from a graph index.
+         * @param graph the graph index to extract layer information from
+         * @param mapper the ordinal mapper (currently unused but retained for API compatibility)
+         * @return a list of LayerInfo objects, one for each layer in the graph
+         */
         public static List<LayerInfo> fromGraph(ImmutableGraphIndex graph, OrdinalMapper mapper) {
             return IntStream.rangeClosed(0, graph.getMaxLevel())
                     .mapToObj(i -> new LayerInfo(graph.size(i), graph.getDegree(i)))

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/GraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/GraphIndexWriter.java
@@ -36,6 +36,7 @@ public interface GraphIndexWriter extends Closeable {
      * Each supplier takes a node ordinal and returns a FeatureState suitable for Feature.writeInline.
      *
      * @param featureStateSuppliers a map of FeatureId to a function that returns a Feature.State
+     * @throws IOException if an I/O error occurs
      */
     void write(Map<FeatureId, IntFunction<Feature.State>> featureStateSuppliers) throws IOException;
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskSequentialGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskSequentialGraphIndexWriter.java
@@ -167,6 +167,11 @@ public class OnDiskSequentialGraphIndexWriter extends AbstractGraphIndexWriter<I
      * Builder for {@link OnDiskSequentialGraphIndexWriter}, with optional features.
      */
     public static class Builder extends AbstractGraphIndexWriter.Builder<OnDiskSequentialGraphIndexWriter, IndexWriter> {
+        /**
+         * Creates a builder for sequential graph index writing
+         * @param graphIndex the graph structure to serialize
+         * @param out the IndexWriter for sequential output
+         */
         public Builder(ImmutableGraphIndex graphIndex, IndexWriter out) {
             super(graphIndex, out);
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/Feature.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/Feature.java
@@ -25,28 +25,65 @@ import java.util.function.IntFunction;
  * A feature of an on-disk graph index. Information to use a feature is stored in the header on-disk.
  */
 public interface Feature {
+    /**
+     * Get feature ID.
+     * @return the return value
+     */
     FeatureId id();
 
+    /**
+     * Get header size.
+     * @return the return value
+     */
     int headerSize();
 
+    /**
+     * Get feature size.
+     * @return the return value
+     */
     int featureSize();
 
+    /**
+     * Write header.
+     * @param out the out
+     * @throws IOException if an error occurs
+     */
     void writeHeader(DataOutput out) throws IOException;
 
+    /**
+     * Write inline.
+     * @param out the out
+     * @param state the state
+     * @throws IOException if an error occurs
+     */
     default void writeInline(DataOutput out, State state) throws IOException {
         // default no-op
     }
 
-    // Feature implementations should implement a State as well for use with writeInline/writeSeparately
+    /**
+     * Feature implementations should implement a State as well for use with writeInline/writeSeparately
+     */
     interface State {
     }
 
+    /**
+     * Create single state factory.
+     * @param id the id
+     * @param stateFactory the stateFactory
+     * @return the return value
+     */
     static EnumMap<FeatureId, IntFunction<State>> singleStateFactory(FeatureId id, IntFunction<State> stateFactory) {
         EnumMap<FeatureId, IntFunction<State>> map = new EnumMap<>(FeatureId.class);
         map.put(id, stateFactory);
         return map;
     }
 
+    /**
+     * Create single state.
+     * @param id the id
+     * @param state the state
+     * @return the return value
+     */
     static EnumMap<FeatureId, State> singleState(FeatureId id, State state) {
         EnumMap<FeatureId, State> map = new EnumMap<>(FeatureId.class);
         map.put(id, state);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FeatureId.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FeatureId.java
@@ -31,12 +31,18 @@ import java.util.function.BiFunction;
  * These are typically mapped to a Feature.
  */
 public enum FeatureId {
+    /** INLINE_VECTORS feature */
     INLINE_VECTORS(InlineVectors::load),
+    /** FUSED_ADC feature */
     FUSED_ADC(FusedADC::load),
+    /** NVQ_VECTORS feature */
     NVQ_VECTORS(NVQ::load),
+    /** SEPARATED_VECTORS feature */
     SEPARATED_VECTORS(SeparatedVectors::load),
+    /** SEPARATED_NVQ feature */
     SEPARATED_NVQ(SeparatedNVQ::load);
 
+    /** ALL features */
     public static final Set<FeatureId> ALL = Collections.unmodifiableSet(EnumSet.allOf(FeatureId.class));
 
     private final BiFunction<CommonHeader, RandomAccessReader, Feature> loader;
@@ -45,10 +51,21 @@ public enum FeatureId {
         this.loader = loader;
     }
 
+    /**
+     * Load feature.
+     * @param header the header
+     * @param reader the reader
+     * @return the return value
+     */
     public Feature load(CommonHeader header, RandomAccessReader reader) {
         return loader.apply(header, reader);
     }
 
+    /**
+     * Deserialize feature IDs.
+     * @param bitflags the bitflags
+     * @return the return value
+     */
     public static EnumSet<FeatureId> deserialize(int bitflags) {
         EnumSet<FeatureId> set = EnumSet.noneOf(FeatureId.class);
         for (int n = 0; n < values().length; n++) {
@@ -58,6 +75,11 @@ public enum FeatureId {
         return set;
     }
 
+    /**
+     * Serialize feature IDs.
+     * @param flags the flags
+     * @return the return value
+     */
     public static int serialize(EnumSet<FeatureId> flags) {
         int i = 0;
         for (FeatureId flag : flags)

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FeatureSource.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FeatureSource.java
@@ -21,6 +21,16 @@ import io.github.jbellis.jvector.disk.RandomAccessReader;
 import java.io.Closeable;
 import java.io.IOException;
 
+/**
+ * A source of features for graph nodes.
+ */
 public interface FeatureSource extends Closeable {
+    /**
+     * Get feature reader for node.
+     * @param node the node
+     * @param featureId the featureId
+     * @return the return value
+     * @throws IOException if an error occurs
+     */
     RandomAccessReader featureReaderForNode(int node, FeatureId featureId) throws IOException;
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/InlineVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/InlineVectors.java
@@ -32,6 +32,10 @@ public class InlineVectors implements Feature {
     private static final VectorTypeSupport vectorTypeSupport = VectorizationProvider.getInstance().getVectorTypeSupport();
     private final int dimension;
 
+    /**
+     * Constructs an InlineVectors feature for storing vectors of the specified dimension.
+     * @param dimension the dimensionality of the vectors to be stored
+     */
     public InlineVectors(int dimension) {
         this.dimension = dimension;
     }
@@ -46,14 +50,28 @@ public class InlineVectors implements Feature {
         return 0;
     }
 
+    /**
+     * Returns the number of bytes required to store one inline vector.
+     * @return the byte size per vector (dimension * 4 bytes per float)
+     */
     public int featureSize() {
         return dimension * Float.BYTES;
     }
 
+    /**
+     * Returns the dimensionality of the inline vectors.
+     * @return the number of dimensions in each vector
+     */
     public int dimension() {
         return dimension;
     }
 
+    /**
+     * Loads an InlineVectors feature from disk using the provided header and reader.
+     * @param header the common header containing dimension information
+     * @param reader the reader to load data from (not used as dimension comes from header)
+     * @return a new InlineVectors instance
+     */
     static InlineVectors load(CommonHeader header, RandomAccessReader reader) {
         return new InlineVectors(header.dimension);
     }
@@ -68,9 +86,19 @@ public class InlineVectors implements Feature {
         vectorTypeSupport.writeFloatVector(out, ((InlineVectors.State) state).vector);
     }
 
+    /**
+     * State object holding a single vector to be written as part of the inline vectors feature.
+     */
     public static class State implements Feature.State {
+        /**
+         * The full-resolution vector to be stored inline.
+         */
         public final VectorFloat<?> vector;
 
+        /**
+         * Constructs a state holding the vector to be written.
+         * @param vector the vector to store
+         */
         public State(VectorFloat<?> vector) {
             this.vector = vector;
         }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/NVQ.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/NVQ.java
@@ -38,6 +38,10 @@ public class NVQ implements Feature {
     private final NVQScorer scorer;
     private final ThreadLocal<QuantizedVector> reusableQuantizedVector;
 
+    /**
+     * Creates an NVQ feature for storing quantized vectors in the graph index
+     * @param nvq the NVQuantization compressor defining quantization parameters
+     */
     public NVQ(NVQuantization nvq) {
         this.nvq = nvq;
         scorer = new NVQScorer(this.nvq);
@@ -57,6 +61,10 @@ public class NVQ implements Feature {
     @Override
     public int featureSize() { return nvq.compressedVectorSize();}
 
+    /**
+     * Returns the dimensionality of the original unquantized vectors
+     * @return the number of dimensions in the full-resolution vectors
+     */
     public int dimension() {
         return nvq.globalMean.length();
     }
@@ -80,14 +88,31 @@ public class NVQ implements Feature {
         state.vector.write(out);
     }
 
+    /**
+     * State object holding a single quantized vector for serialization
+     */
     public static class State implements Feature.State {
+        /**
+         * The quantized vector to be written to the graph index
+         */
         public final QuantizedVector vector;
 
+        /**
+         * Creates a state holding the specified quantized vector
+         * @param vector the quantized vector data
+         */
         public State(QuantizedVector vector) {
             this.vector = vector;
         }
     }
 
+    /**
+     * Creates a reranking function that scores graph nodes using NVQ-quantized vectors
+     * @param queryVector the unquantized query vector
+     * @param vsf the vector similarity function to use for scoring
+     * @param source provider for accessing feature data from disk
+     * @return an exact score function that reads and scores NVQ vectors
+     */
     public ScoreFunction.ExactScoreFunction rerankerFor(VectorFloat<?> queryVector,
                                                         VectorSimilarityFunction vsf,
                                                         FeatureSource source) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/SeparatedFeature.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/SeparatedFeature.java
@@ -19,9 +19,28 @@ package io.github.jbellis.jvector.graph.disk.feature;
 import java.io.DataOutput;
 import java.io.IOException;
 
+/**
+ * A feature that is written separately from the main graph structure, with an offset
+ * reference stored in the header to locate its data in a separate section of the file.
+ */
 public interface SeparatedFeature extends Feature {
+    /**
+     * Sets the file offset where this feature's data begins in the separated section.
+     * @param offset the byte offset in the file
+     */
     void setOffset(long offset);
+
+    /**
+     * Returns the file offset where this feature's data is stored.
+     * @return the byte offset in the file
+     */
     long getOffset();
 
+    /**
+     * Writes this feature's data to the separated section of the file.
+     * @param out the output stream to write to
+     * @param state the feature state containing the data to write
+     * @throws IOException if an I/O error occurs
+     */
     void writeSeparately(DataOutput out, State state) throws IOException;
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/SeparatedNVQ.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/SeparatedNVQ.java
@@ -29,12 +29,25 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+/**
+ * A feature implementation for storing NVQ (Neighborhood Vector Quantization) compressed vectors
+ * in a separated section of the index file.
+ */
 public class SeparatedNVQ implements SeparatedFeature {
+    /** The NVQ quantization configuration and codebooks */
     private final NVQuantization nvq;
+    /** Scorer for computing similarities using quantized vectors */
     private final NVQScorer scorer;
+    /** Thread-local storage for reusable quantized vector instances to avoid allocations */
     private final ThreadLocal<NVQuantization.QuantizedVector> reusableQuantizedVector;
+    /** The file offset where quantized vector data begins in the separated section */
     private long offset;
 
+    /**
+     * Creates a new SeparatedNVQ feature.
+     * @param nvq the NVQ quantization configuration including codebooks
+     * @param offset the file offset where the separated quantized vector data begins
+     */
     public SeparatedNVQ(NVQuantization nvq, long offset) {
         this.nvq = nvq;
         this.offset = offset;
@@ -96,6 +109,10 @@ public class SeparatedNVQ implements SeparatedFeature {
         }
     }
 
+    /**
+     * Returns the dimensionality of the vectors before quantization.
+     * @return the number of dimensions in the original unquantized vectors
+     */
     public int dimension() {
         return nvq.globalMean.length();
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/SeparatedVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/SeparatedVectors.java
@@ -25,11 +25,22 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+/**
+ * A feature implementation for storing uncompressed vectors in a separated section of the index file.
+ */
 public class SeparatedVectors implements SeparatedFeature {
+    /** Provides access to vector operations and SIMD implementations */
     private static final VectorTypeSupport vectorTypeSupport = VectorizationProvider.getInstance().getVectorTypeSupport();
+    /** The dimensionality of the vectors */
     private final int dimension;
+    /** The file offset where vector data begins in the separated section */
     private long offset;
 
+    /**
+     * Creates a new SeparatedVectors feature.
+     * @param dimension the number of dimensions in each vector
+     * @param offset the file offset where the separated vector data begins
+     */
     public SeparatedVectors(int dimension, long offset) {
         this.dimension = dimension;
         this.offset = offset;
@@ -89,6 +100,10 @@ public class SeparatedVectors implements SeparatedFeature {
         }
     }
 
+    /**
+     * Returns the dimensionality of the vectors stored in this feature.
+     * @return the number of dimensions in each vector
+     */
     public int dimension() {
         return dimension;
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/DiversityProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/DiversityProvider.java
@@ -24,9 +24,16 @@ import io.github.jbellis.jvector.util.DocIdSetIterator;
 
 import static java.lang.Math.min;
 
+/**
+ * Provides diversity filtering for neighbors.
+ */
 public interface DiversityProvider {
     /**
      * update `selected` with the diverse members of `neighbors`.  `neighbors` is not modified
+     * @param neighbors the neighbors
+     * @param maxDegree the maxDegree
+     * @param diverseBefore the diverseBefore
+     * @param selected the selected
      * @return the fraction of short edges (neighbors within alpha=1.0)
      */
     double retainDiverse(NodeArray neighbors, int maxDegree, int diverseBefore, BitSet selected);

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/diversity/VamanaDiversityProvider.java
@@ -24,14 +24,21 @@ import io.github.jbellis.jvector.util.DocIdSetIterator;
 
 import static java.lang.Math.min;
 
+/**
+ * Implements the Vamana diversity pruning strategy for building high-quality graph indexes.
+ */
 public class VamanaDiversityProvider implements DiversityProvider {
-    /** the diversity threshold; 1.0 is equivalent to HNSW; Vamana uses 1.2 or more */
+    /** The diversity threshold; 1.0 is equivalent to HNSW; Vamana uses 1.2 or more */
     public final float alpha;
 
-    /** used to compute diversity */
+    /** The score provider used to compute similarity between nodes for diversity calculation */
     public final BuildScoreProvider scoreProvider;
 
-    /** Create a new diversity provider */
+    /**
+     * Creates a new diversity provider with the specified parameters.
+     * @param scoreProvider the score provider for computing node similarities during diversity pruning
+     * @param alpha the diversity threshold (1.0 = HNSW behavior, higher values = more diversity)
+     */
     public VamanaDiversityProvider(BuildScoreProvider scoreProvider, float alpha) {
         this.scoreProvider = scoreProvider;
         this.alpha = alpha;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/DefaultSearchScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/DefaultSearchScoreProvider.java
@@ -26,22 +26,20 @@ public final class DefaultSearchScoreProvider implements SearchScoreProvider {
     private final ScoreFunction.ExactScoreFunction reranker;
 
     /**
-     * @param scoreFunction the primary, fast scoring function
-     * <p>
      * No reranking is performed.
+     * @param scoreFunction the primary, fast scoring function
      */
     public DefaultSearchScoreProvider(ScoreFunction scoreFunction) {
         this(scoreFunction, null);
     }
 
     /**
-     * @param scoreFunction the primary, fast scoring function
-     * @param reranker optional reranking function
      * Generally, reranker will be null iff scoreFunction is an ExactScoreFunction.  However,
      * it is allowed, and sometimes useful, to only perform approximate scoring without reranking.
-     * <p>
      * Most often it will be convenient to get the reranker either using `RandomAccessVectorValues.rerankerFor`
      * or `ScoringView.rerankerFor`.
+     * @param scoreFunction the primary, fast scoring function
+     * @param reranker optional reranking function
      */
     public DefaultSearchScoreProvider(ScoreFunction scoreFunction, ScoreFunction.ExactScoreFunction reranker) {
         assert scoreFunction != null;
@@ -67,6 +65,10 @@ public final class DefaultSearchScoreProvider implements SearchScoreProvider {
      * A SearchScoreProvider for a single-pass search based on exact similarity.
      * Generally only suitable when your RandomAccessVectorValues is entirely in-memory,
      * e.g. during construction.
+     * @param v the v
+     * @param vsf the vsf
+     * @param ravv the ravv
+     * @return the return value
      */
     public static DefaultSearchScoreProvider exact(VectorFloat<?> v, VectorSimilarityFunction vsf, RandomAccessVectorValues ravv) {
         // don't use ESF.reranker, we need thread safety here

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/ScoreFunction.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/ScoreFunction.java
@@ -29,19 +29,29 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
  * can be defined as a simple lambda.
  */
 public interface ScoreFunction {
+    /** Provides access to vector operations and SIMD implementations */
     VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
 
     /**
+     * Indicates whether this score function returns exact or approximate scores.
+     *
      * @return true if the ScoreFunction returns exact, full-resolution scores
      */
     boolean isExact();
 
     /**
+     * Computes the similarity score between the query and the specified node.
+     *
+     * @param node2 the node ordinal ID to compare against
      * @return the similarity to one other node
      */
     float similarityTo(int node2);
 
     /**
+     * Computes similarity scores to all neighbors of the specified node in a single batch operation.
+     * This is more efficient than calling similarityTo repeatedly when using quantized vectors.
+     *
+     * @param node2 the node whose neighbors should be scored
      * @return the similarity to all of the nodes that `node2` has an edge towards.
      * Used when expanding the neighbors of a search candidate.
      */
@@ -50,18 +60,26 @@ public interface ScoreFunction {
     }
 
     /**
+     * Indicates whether this score function supports batch neighbor scoring via edgeLoadingSimilarityTo.
+     *
      * @return true if `edgeLoadingSimilarityTo` is supported
      */
     default boolean supportsEdgeLoadingSimilarity() {
         return false;
     }
 
+    /**
+     * Marker interface for score functions that compute exact, full-resolution similarity scores.
+     */
     interface ExactScoreFunction extends ScoreFunction {
         default boolean isExact() {
             return true;
         }
     }
 
+    /**
+     * Marker interface for score functions that compute approximate, quantized similarity scores.
+     */
     interface ApproximateScoreFunction extends ScoreFunction {
         default boolean isExact() {
             return false;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/SearchScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/SearchScoreProvider.java
@@ -19,9 +19,21 @@ package io.github.jbellis.jvector.graph.similarity;
 /** Encapsulates comparing node distances to a specific vector for GraphSearcher. */
 public interface SearchScoreProvider {
 
+    /**
+     * Get score function.
+     * @return the return value
+     */
     ScoreFunction scoreFunction();
 
+    /**
+     * Get reranker.
+     * @return the return value
+     */
     ScoreFunction.ExactScoreFunction reranker();
 
+    /**
+     * Get exact score function.
+     * @return the return value
+     */
     ScoreFunction.ExactScoreFunction exactScoreFunction();
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/BQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/BQVectors.java
@@ -28,10 +28,17 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
+/** Base class for BQ vector implementations. */
 public abstract class BQVectors implements CompressedVectors {
+    /** The binary quantization. */
     protected final BinaryQuantization bq;
+    /** The compressed vectors. */
     protected long[][] compressedVectors;
 
+    /**
+     * Create a BQVectors with the specified binary quantization.
+     * @param bq the binary quantization
+     */
     protected BQVectors(BinaryQuantization bq) {
         this.bq = bq;
     }
@@ -55,6 +62,13 @@ public abstract class BQVectors implements CompressedVectors {
         }
     }
 
+    /**
+     * Load BQVectors from the reader.
+     * @param in the reader
+     * @param offset the offset
+     * @return a BQVectors instance
+     * @throws IOException if an error occurs
+     */
     public static BQVectors load(RandomAccessReader in, long offset) throws IOException {
         in.seek(offset);
 
@@ -113,10 +127,21 @@ public abstract class BQVectors implements CompressedVectors {
         };
     }
 
+    /**
+     * Compute the similarity between two encoded vectors.
+     * @param encoded1 the first encoded vector
+     * @param encoded2 the second encoded vector
+     * @return the similarity
+     */
     public float similarityBetween(long[] encoded1, long[] encoded2) {
         return 1 - (float) VectorUtil.hammingDistance(encoded1, encoded2) / bq.getOriginalDimension();
     }
 
+    /**
+     * Get the compressed vector at the specified index.
+     * @param i the index
+     * @return the compressed vector
+     */
     public long[] get(int i) {
         return compressedVectors[i];
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/BinaryQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/BinaryQuantization.java
@@ -37,12 +37,18 @@ public class BinaryQuantization implements VectorCompressor<long[]> {
 
     private final int dimension;
 
+    /**
+     * Create a BinaryQuantization with the specified dimension.
+     * @param dimension the dimension
+     */
     public BinaryQuantization(int dimension) {
         this.dimension = dimension;
     }
 
     /**
      * Use BQ constructor instead
+     * @param ravv the vector values
+     * @return a BinaryQuantization instance
      */
     @Deprecated
     public static BinaryQuantization compute(RandomAccessVectorValues ravv) {
@@ -51,6 +57,9 @@ public class BinaryQuantization implements VectorCompressor<long[]> {
 
     /**
      * Use BQ constructor instead
+     * @param ravv the vector values
+     * @param parallelExecutor the executor
+     * @return a BinaryQuantization instance
      */
     @Deprecated
     public static BinaryQuantization compute(RandomAccessVectorValues ravv, ForkJoinPool parallelExecutor) {
@@ -128,10 +137,20 @@ public class BinaryQuantization implements VectorCompressor<long[]> {
         vts.writeFloatVector(out, vts.createFloatVector(dimension));
     }
 
+    /**
+     * Get the original dimension.
+     * @return the original dimension
+     */
     public int getOriginalDimension() {
         return dimension;
     }
 
+    /**
+     * Load a BinaryQuantization from the reader.
+     * @param in the reader
+     * @return a BinaryQuantization instance
+     * @throws IOException if an error occurs
+     */
     public static BinaryQuantization load(RandomAccessReader in) throws IOException {
         int dimension = in.readInt();
         // We used to record the center of the dataset but this actually degrades performance.

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/CompressedVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/CompressedVectors.java
@@ -25,45 +25,81 @@ import io.github.jbellis.jvector.vector.types.VectorFloat;
 import java.io.DataOutput;
 import java.io.IOException;
 
+/** Interface for compressed vectors. */
 public interface CompressedVectors extends Accountable {
     /**
      * Write the compressed vectors to the given DataOutput
      * @param out the DataOutput to write to
      * @param version the serialization version.  versions 2 and 3 are supported
+     * @throws IOException if an error occurs
      */
     void write(DataOutput out, int version) throws IOException;
 
     /**
      * Write the compressed vectors to the given DataOutput at the current serialization version
+     * @param out the DataOutput to write to
+     * @throws IOException if an error occurs
      */
     default void write(DataOutput out) throws IOException {
         write(out, OnDiskGraphIndex.CURRENT_VERSION);
     }
 
-    /** @return the original size of each vector, in bytes, before compression */
+    /**
+     * Gets the original size of each vector, in bytes, before compression.
+     * @return the original size of each vector, in bytes, before compression
+     */
     int getOriginalSize();
 
-    /** @return the compressed size of each vector, in bytes */
+    /**
+     * Gets the compressed size of each vector, in bytes.
+     * @return the compressed size of each vector, in bytes
+     */
     int getCompressedSize();
 
-    /** @return the compressor used by this instance */
+    /**
+     * Gets the compressor used by this instance.
+     * @return the compressor used by this instance
+     */
     VectorCompressor<?> getCompressor();
 
-    /** precomputes partial scores for the given query with every centroid; suitable for most searches */
+    /**
+     * precomputes partial scores for the given query with every centroid; suitable for most searches
+     * @param q the query vector
+     * @param similarityFunction the similarity function
+     * @return the approximate score function
+     */
     ScoreFunction.ApproximateScoreFunction precomputedScoreFunctionFor(VectorFloat<?> q, VectorSimilarityFunction similarityFunction);
 
-    /** no precomputation; suitable when just a handful of score computations are performed */
+    /**
+     * no precomputation; suitable when just a handful of score computations are performed
+     * @param nodeId the node id
+     * @param similarityFunction the similarity function
+     * @return the approximate score function
+     */
     ScoreFunction.ApproximateScoreFunction diversityFunctionFor(int nodeId, VectorSimilarityFunction similarityFunction);
 
-    /** no precomputation; suitable when just a handful of score computations are performed */
+    /**
+     * no precomputation; suitable when just a handful of score computations are performed
+     * @param q the query vector
+     * @param similarityFunction the similarity function
+     * @return the approximate score function
+     */
     ScoreFunction.ApproximateScoreFunction scoreFunctionFor(VectorFloat<?> q, VectorSimilarityFunction similarityFunction);
 
-
+    /**
+     * Use precomputedScoreFunctionFor instead.
+     * @param q the query vector
+     * @param similarityFunction the similarity function
+     * @return the approximate score function
+     */
     @Deprecated
     default ScoreFunction.ApproximateScoreFunction approximateScoreFunctionFor(VectorFloat<?> q, VectorSimilarityFunction similarityFunction) {
         return precomputedScoreFunctionFor(q, similarityFunction);
     }
 
-    /** the number of vectors */
+    /**
+     * the number of vectors
+     * @return the number of vectors
+     */
     int count();
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/ImmutableBQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/ImmutableBQVectors.java
@@ -16,7 +16,17 @@
 
 package io.github.jbellis.jvector.quantization;
 
+/**
+ * An immutable collection of binary quantized vectors.
+ * Wraps pre-computed compressed vectors for efficient similarity comparisons.
+ */
 public class ImmutableBQVectors extends BQVectors {
+    /**
+     * Constructs an ImmutableBQVectors instance with pre-compressed vectors.
+     *
+     * @param bq the binary quantization scheme used to compress the vectors
+     * @param compressedVectors array of compressed vector representations (one per vector)
+     */
     public ImmutableBQVectors(BinaryQuantization bq, long[][] compressedVectors) {
         super(bq);
         this.compressedVectors = compressedVectors;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/ImmutablePQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/ImmutablePQVectors.java
@@ -25,8 +25,16 @@ import io.github.jbellis.jvector.vector.types.VectorFloat;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * An immutable implementation of PQVectors with optimized similarity computations using precomputed
+ * codebook partial sums for faster scoring.
+ */
 public class ImmutablePQVectors extends PQVectors {
     private final int vectorCount;
+    /**
+     * Cache of precomputed codebook partial sums for different similarity functions, enabling
+     * faster score computation.
+     */
     private final Map<VectorSimilarityFunction, VectorFloat<?>> codebookPartialSumsMap;
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/MutableBQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/MutableBQVectors.java
@@ -18,11 +18,21 @@ package io.github.jbellis.jvector.quantization;
 
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
+/**
+ * A mutable implementation of BQVectors that supports dynamic growth as vectors are added.
+ * Storage expands automatically using a configurable growth factor.
+ */
 @SuppressWarnings("unused")
 public class MutableBQVectors extends BQVectors implements MutableCompressedVectors<VectorFloat<?>> {
     private static final int INITIAL_CAPACITY = 1024;
+    /**
+     * Growth factor used when expanding the internal storage arrays.
+     */
     private static final float GROWTH_FACTOR = 1.5f;
-    
+
+    /**
+     * The current number of vectors stored in this collection.
+     */
     protected int vectorCount;
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/MutableCompressedVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/MutableCompressedVectors.java
@@ -16,6 +16,11 @@
 
 package io.github.jbellis.jvector.quantization;
 
+/**
+ * Interface for compressed vector collections that support modification through encoding and setting
+ * vectors at specific ordinal positions. Implementations must handle dynamic growth as needed.
+ * @param <T> the type of uncompressed vectors that can be encoded and added
+ */
 public interface MutableCompressedVectors<T> extends CompressedVectors {
     /**
      * Encode the given vector and set it at the given ordinal. Done without unnecessary copying.

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/MutablePQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/MutablePQVectors.java
@@ -35,6 +35,9 @@ public class MutablePQVectors extends PQVectors implements MutableCompressedVect
     private static final int INITIAL_CHUNKS = 10;
     private static final float GROWTH_FACTOR = 1.5f;
 
+    /**
+     * Atomic counter tracking the current number of vectors stored, enabling thread-safe concurrent updates.
+     */
     protected AtomicInteger vectorCount;
 
     /**

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/NVQScorer.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/NVQScorer.java
@@ -20,16 +20,29 @@ import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorUtil;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
+/**
+ * Scorer for computing similarities between query vectors and NVQ-quantized database vectors
+ */
 public class NVQScorer {
+    /**
+     * The NVQuantization compressor containing codebooks and parameters for scoring
+     */
     final NVQuantization nvq;
 
     /**
      * Initialize the NVQScorer with an instance of NVQuantization.
+     * @param nvq the NVQuantization compressor providing quantization parameters for scoring
      */
     public NVQScorer(NVQuantization nvq) {
         this.nvq = nvq;
     }
 
+    /**
+     * Creates a score function for comparing the query vector against NVQ-quantized vectors
+     * @param query the unquantized query vector
+     * @param similarityFunction the similarity metric to use (DOT_PRODUCT, EUCLIDEAN, or COSINE)
+     * @return a score function optimized for the specified similarity metric
+     */
     public NVQScoreFunction scoreFunctionFor(VectorFloat<?> query, VectorSimilarityFunction similarityFunction) {
         switch (similarityFunction) {
             case DOT_PRODUCT:
@@ -136,9 +149,14 @@ public class NVQScorer {
         }
     }
 
+    /**
+     * Functional interface for computing similarity scores between query vectors and quantized database vectors
+     */
     public interface NVQScoreFunction {
         /**
-         * @return the similarity to another vector
+         * Computes the similarity score between the pre-configured query vector and a quantized database vector
+         * @param vector2 the quantized database vector to compare against
+         * @return the similarity score normalized to the range appropriate for the similarity function
          */
         float similarityTo(NVQuantization.QuantizedVector vector2);
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/NVQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/NVQVectors.java
@@ -27,14 +27,28 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
+/**
+ * Container for NVQ-compressed vectors with scoring capabilities
+ */
 public class NVQVectors implements CompressedVectors {
+    /**
+     * The NVQuantization compressor defining quantization parameters and codebooks
+     */
     final NVQuantization nvq;
+    /**
+     * Scorer instance for computing similarity between quantized vectors
+     */
     final NVQScorer scorer;
+    /**
+     * Array of compressed vectors stored using NVQ encoding
+     */
     final NVQuantization.QuantizedVector[] compressedVectors;
 
     /**
      * Initialize the NVQVectors with an initial array of vectors.  This array may be
      * mutated, but caller is responsible for thread safety issues when doing so.
+     * @param nvq the NVQuantization compressor defining quantization parameters
+     * @param compressedVectors array of quantized vectors to manage
      */
     public NVQVectors(NVQuantization nvq, NVQuantization.QuantizedVector[] compressedVectors) {
         this.nvq = nvq;
@@ -60,6 +74,12 @@ public class NVQVectors implements CompressedVectors {
         }
     }
 
+    /**
+     * Loads NVQVectors from a RandomAccessReader at the current position
+     * @param in the reader to load from
+     * @return the reconstructed NVQVectors with all quantized vectors
+     * @throws IOException if reading fails
+     */
     public static NVQVectors load(RandomAccessReader in) throws IOException {
         var nvq = NVQuantization.load(in);
 
@@ -77,6 +97,13 @@ public class NVQVectors implements CompressedVectors {
         return new NVQVectors(nvq, compressedVectors);
     }
 
+    /**
+     * Loads NVQVectors from a RandomAccessReader starting at the specified offset
+     * @param in the reader to load from
+     * @param offset the byte position to seek to before reading
+     * @return the reconstructed NVQVectors with all quantized vectors
+     * @throws IOException if reading fails
+     */
     public static NVQVectors load(RandomAccessReader in, long offset) throws IOException {
         in.seek(offset);
         return load(in);
@@ -113,10 +140,19 @@ public class NVQVectors implements CompressedVectors {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Returns the quantized vector at the specified ordinal
+     * @param ordinal the index of the vector to retrieve
+     * @return the quantized vector at the given position
+     */
     public NVQuantization.QuantizedVector get(int ordinal) {
         return compressedVectors[ordinal];
     }
 
+    /**
+     * Returns the NVQuantization compressor used for encoding these vectors
+     * @return the NVQuantization instance containing codebooks and parameters
+     */
     public NVQuantization getNVQuantization() {
         return nvq;
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/VectorCompressor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/VectorCompressor.java
@@ -30,9 +30,15 @@ import java.util.concurrent.ForkJoinPool;
 /**
  * Interface for vector compression.  T is the encoded (compressed) vector type;
  * it will be an array type.
+ * @param <T> the T type parameter
  */
 public interface VectorCompressor<T> {
 
+    /**
+     * Encodes all vectors using the default physical core executor pool.
+     * @param ravv the vectors to encode
+     * @return compressed vectors containing all encoded vectors
+     */
     default CompressedVectors encodeAll(RandomAccessVectorValues ravv) {
         return encodeAll(ravv, PhysicalCoreExecutor.pool());
     }
@@ -46,32 +52,56 @@ public interface VectorCompressor<T> {
      */
     CompressedVectors encodeAll(RandomAccessVectorValues ravv, ForkJoinPool simdExecutor);
 
+    /**
+     * Encodes a vector.
+     * @param v the vector to encode
+     * @return the encoded vector
+     */
     T encode(VectorFloat<?> v);
 
+    /**
+     * Encodes a vector into a destination.
+     * @param v the vector to encode
+     * @param dest the destination
+     */
     void encodeTo(VectorFloat<?> v, T dest);
 
     /**
+     * Writes the compressor to output.
      * @param out DataOutput to write to
      * @param version serialization version.  Versions 2 and 3 are supported
+     * @throws IOException if an I/O error occurs
      */
     void write(DataOutput out, int version) throws IOException;
 
-    /** Write with the current serialization version */
+    /**
+     * Write with the current serialization version.
+     * @param out the output
+     * @throws IOException if an I/O error occurs
+     */
     default void write(DataOutput out) throws IOException {
         write(out, OnDiskGraphIndex.CURRENT_VERSION);
     }
 
     /**
+     * Creates compressed vectors.
      * @param compressedVectors must match the type T for this VectorCompressor, but
      *                          it is declared as Object because we want callers to be able to use this
      *                          without committing to a specific type T.
+     * @return the compressed vectors
      */
     @Deprecated
     CompressedVectors createCompressedVectors(Object[] compressedVectors);
 
-    /** the size of the serialized compressor itself (NOT the size of compressed vectors) */
+    /**
+     * Returns the size of the serialized compressor itself (NOT the size of compressed vectors).
+     * @return the compressor size
+     */
     int compressorSize();
 
-    /** the size of a compressed vector */
+    /**
+     * Returns the size of a compressed vector.
+     * @return the compressed vector size
+     */
     int compressedVectorSize();
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/AbstractLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/AbstractLongHeap.java
@@ -37,7 +37,9 @@ import java.util.PrimitiveIterator;
  */
 public abstract class AbstractLongHeap {
 
+    /** The heap array. */
     protected long[] heap;
+    /** The current size. */
     protected int size = 0;
 
     /**
@@ -60,6 +62,7 @@ public abstract class AbstractLongHeap {
     /**
      * Adds a value to an LongHeap in log(size) time.
      *
+     * @param element the element parameter
      * @return true if the new value was added. (A fixed-size heap will not add the new value
      * if it is full, and the new value is worse than the existing ones.)
      */
@@ -74,6 +77,11 @@ public abstract class AbstractLongHeap {
      */
     public abstract void pushMany(PrimitiveIterator.OfLong elements, int elementsSize);
 
+    /**
+     * Adds an element to the heap.
+     * @param element the element parameter
+     * @return the top element
+     */
     protected long add(long element) {
         size++;
         if (size == heap.length) {
@@ -123,6 +131,7 @@ public abstract class AbstractLongHeap {
      * Returns the least element of the LongHeap in constant time. It is up to the caller to verify
      * that the heap is not empty; no checking is done, and if no elements have been added, 0 is
      * returned.
+     * @return the top element
      */
     public final long top() {
         return heap[1];
@@ -131,6 +140,7 @@ public abstract class AbstractLongHeap {
     /**
      * Removes and returns the least element of the PriorityQueue in log(size) time.
      *
+     * @return the popped element
      * @throws IllegalStateException if the LongHeap is empty.
      */
     public final long pop() {
@@ -145,7 +155,10 @@ public abstract class AbstractLongHeap {
         }
     }
 
-    /** Returns the number of elements currently stored in the PriorityQueue. */
+    /**
+     * Returns the number of elements currently stored in the PriorityQueue.
+     * @return the size
+     */
     public final int size() {
         return size;
     }
@@ -155,6 +168,10 @@ public abstract class AbstractLongHeap {
         size = 0;
     }
 
+    /**
+     * Moves an element up the heap.
+     * @param origPos the original position
+     */
     protected void upHeap(int origPos) {
         int i = origPos;
         long value = heap[i]; // save bottom value
@@ -167,6 +184,10 @@ public abstract class AbstractLongHeap {
         heap[i] = value; // install saved value
     }
 
+    /**
+     * Moves an element down the heap.
+     * @param i the position
+     */
     protected void downHeap(int i) {
         long value = heap[i]; // save top value
         int j = i << 1; // find smaller child
@@ -189,6 +210,8 @@ public abstract class AbstractLongHeap {
     /**
      * Return the element at the ith location in the heap array. Use for iterating over elements when
      * the order doesn't matter. Note that the valid arguments range from [1, size].
+     * @param i the i parameter
+     * @return the element
      */
     public long get(int i) {
         return heap[i];
@@ -201,6 +224,7 @@ public abstract class AbstractLongHeap {
 
     /**
      * Copies the contents and current size from `other`.  Does NOT copy subclass field like BLH's maxSize
+     * @param other the other parameter
      */
     public void copyFrom(AbstractLongHeap other)
     {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/Accountable.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/Accountable.java
@@ -24,6 +24,13 @@
 
 package io.github.jbellis.jvector.util;
 
+/**
+ * Interface for objects that can account for their RAM usage.
+ */
 public interface Accountable {
+    /**
+     * Returns the RAM bytes used.
+     * @return the RAM bytes used
+     */
     long ramBytesUsed();
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/ArrayUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/ArrayUtil.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Array;
  * Methods for manipulating arrays.
  */
 public final class ArrayUtil {
+  /** Maximum array length constant. */
   public static final int MAX_ARRAY_LENGTH =
       Integer.MAX_VALUE - RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
 
@@ -48,6 +49,8 @@ public final class ArrayUtil {
    * specifies the radix to use when parsing the value.
    *
    * @param chars a string representation of an int quantity.
+   * @param offset the offset parameter
+   * @param len the len parameter
    * @param radix the base to use for conversion.
    * @return int the value represented by the argument
    * @throws NumberFormatException if the argument could not be parsed as an int quantity.
@@ -118,6 +121,7 @@ public final class ArrayUtil {
    * @param minTargetSize Minimum required value to be returned.
    * @param bytesPerElement Bytes used by each element of the array. See constants in {@link
    *     RamUsageEstimator}.
+   * @return the return value
    */
   public static int oversize(int minTargetSize, int bytesPerElement) {
 
@@ -203,6 +207,10 @@ public final class ArrayUtil {
 
   /**
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
+   * @param <T> the T type parameter
+   * @param array the array parameter
+   * @param newLength the newLength parameter
+   * @return the return value
    */
   public static <T> T[] growExact(T[] array, int newLength) {
     Class<? extends Object[]> type = array.getClass();
@@ -218,6 +226,10 @@ public final class ArrayUtil {
   /**
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially
+   * @param <T> the T type parameter
+   * @param array the array parameter
+   * @param minSize the minSize parameter
+   * @return the return value
    */
   public static <T> T[] grow(T[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
@@ -229,6 +241,9 @@ public final class ArrayUtil {
 
   /**
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
+   * @param array the array parameter
+   * @param newLength the newLength parameter
+   * @return the return value
    */
   public static short[] growExact(short[] array, int newLength) {
     short[] copy = new short[newLength];
@@ -239,6 +254,9 @@ public final class ArrayUtil {
   /**
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially
+   * @param array the array parameter
+   * @param minSize the minSize parameter
+   * @return the return value
    */
   public static short[] grow(short[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
@@ -249,6 +267,9 @@ public final class ArrayUtil {
 
   /**
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
+   * @param array the array parameter
+   * @param newLength the newLength parameter
+   * @return the return value
    */
   public static float[] growExact(float[] array, int newLength) {
     float[] copy = new float[newLength];
@@ -259,6 +280,9 @@ public final class ArrayUtil {
   /**
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially
+   * @param array the array parameter
+   * @param minSize the minSize parameter
+   * @return the return value
    */
   public static float[] grow(float[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
@@ -271,6 +295,9 @@ public final class ArrayUtil {
 
   /**
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
+   * @param array the array parameter
+   * @param newLength the newLength parameter
+   * @return the return value
    */
   public static double[] growExact(double[] array, int newLength) {
     double[] copy = new double[newLength];
@@ -281,6 +308,9 @@ public final class ArrayUtil {
   /**
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially
+   * @param array the array parameter
+   * @param minSize the minSize parameter
+   * @return the return value
    */
   public static double[] grow(double[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
@@ -291,6 +321,9 @@ public final class ArrayUtil {
 
   /**
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
+   * @param array the array parameter
+   * @param newLength the newLength parameter
+   * @return the return value
    */
   public static int[] growExact(int[] array, int newLength) {
     int[] copy = new int[newLength];
@@ -301,6 +334,9 @@ public final class ArrayUtil {
   /**
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially
+   * @param array the array parameter
+   * @param minSize the minSize parameter
+   * @return the return value
    */
   public static int[] grow(int[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
@@ -309,13 +345,20 @@ public final class ArrayUtil {
     } else return array;
   }
 
-  /** Returns a larger array, generally over-allocating exponentially */
+  /**
+   * Returns a larger array, generally over-allocating exponentially
+   * @param array the array parameter
+   * @return the return value
+   */
   public static int[] grow(int[] array) {
     return grow(array, 1 + array.length);
   }
 
   /**
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
+   * @param array the array parameter
+   * @param newLength the newLength parameter
+   * @return the return value
    */
   public static long[] growExact(long[] array, int newLength) {
     long[] copy = new long[newLength];
@@ -326,6 +369,9 @@ public final class ArrayUtil {
   /**
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially
+   * @param array the array parameter
+   * @param minSize the minSize parameter
+   * @return the return value
    */
   public static long[] grow(long[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
@@ -336,6 +382,9 @@ public final class ArrayUtil {
 
   /**
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
+   * @param array the array parameter
+   * @param newLength the newLength parameter
+   * @return the return value
    */
   public static byte[] growExact(byte[] array, int newLength) {
     byte[] copy = new byte[newLength];
@@ -346,6 +395,9 @@ public final class ArrayUtil {
   /**
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially
+   * @param array the array parameter
+   * @param minSize the minSize parameter
+   * @return the return value
    */
   public static byte[] grow(byte[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
@@ -356,6 +408,9 @@ public final class ArrayUtil {
 
   /**
    * Returns a new array whose size is exact the specified {@code newLength} without over-allocating
+   * @param array the array parameter
+   * @param newLength the newLength parameter
+   * @return the return value
    */
   public static char[] growExact(char[] array, int newLength) {
     char[] copy = new char[newLength];
@@ -366,6 +421,9 @@ public final class ArrayUtil {
   /**
    * Returns an array whose size is at least {@code minSize}, generally over-allocating
    * exponentially
+   * @param array the array parameter
+   * @param minSize the minSize parameter
+   * @return the return value
    */
   public static char[] grow(char[] array, int minSize) {
     assert minSize >= 0 : "size must be positive (got " + minSize + "): likely integer overflow?";
@@ -380,6 +438,7 @@ public final class ArrayUtil {
    * @param array the input array
    * @param from the initial index of range to be copied (inclusive)
    * @param to the final index of range to be copied (exclusive)
+   * @return the return value
    */
   public static byte[] copyOfSubArray(byte[] array, int from, int to) {
     final byte[] copy = new byte[to - from];
@@ -393,6 +452,7 @@ public final class ArrayUtil {
    * @param array the input array
    * @param from the initial index of range to be copied (inclusive)
    * @param to the final index of range to be copied (exclusive)
+   * @return the return value
    */
   public static int[] copyOfSubArray(int[] array, int from, int to) {
     final int[] copy = new int[to - from];
@@ -406,6 +466,7 @@ public final class ArrayUtil {
    * @param array the input array
    * @param from the initial index of range to be copied (inclusive)
    * @param to the final index of range to be copied (exclusive)
+   * @return the return value
    */
   public static float[] copyOfSubArray(float[] array, int from, int to) {
     final float[] copy = new float[to - from];
@@ -416,9 +477,11 @@ public final class ArrayUtil {
   /**
    * Copies the specified range of the given array into a new sub array.
    *
+   * @param <T> the T type parameter
    * @param array the input array
    * @param from the initial index of range to be copied (inclusive)
    * @param to the final index of range to be copied (exclusive)
+   * @return the return value
    */
   public static <T> T[] copyOfSubArray(T[] array, int from, int to) {
     final int subLength = to - from;
@@ -438,6 +501,7 @@ public final class ArrayUtil {
    * @param array the input array
    * @param from the initial index of range to be copied (inclusive)
    * @param to the final index of range to be copied (exclusive)
+   * @return the return value
    */
   public static long[] copyOfSubArray(long[] array, int from, int to) {
     final long[] copy = new long[to - from];

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/AtomicFixedBitSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/AtomicFixedBitSet.java
@@ -31,6 +31,10 @@ public class AtomicFixedBitSet extends BitSet {
 
     private final AtomicLongArray storage;
 
+    /**
+     * Create an AtomicFixedBitSet with the specified number of bits.
+     * @param numBits the number of bits
+     */
     public AtomicFixedBitSet(int numBits) {
         int numLongs = (numBits + 63) >>> 6;
         storage = new AtomicLongArray(numLongs);
@@ -186,6 +190,10 @@ public class AtomicFixedBitSet extends BitSet {
         return BASE_RAM_BYTES_USED + storageSize;
     }
 
+    /**
+     * Create a copy of this AtomicFixedBitSet.
+     * @return a copy of this bitset
+     */
     public AtomicFixedBitSet copy() {
         AtomicFixedBitSet copy = new AtomicFixedBitSet(length());
         for (int i = 0; i < storage.length(); i++) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/BitSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/BitSet.java
@@ -28,6 +28,9 @@ package io.github.jbellis.jvector.util;
  * Base implementation for a bit set.
  */
 public abstract class BitSet implements Bits, Accountable {
+  /** Creates a BitSet. */
+  protected BitSet() {}
+
   /**
    * Clear all the bits of the set.
    *
@@ -38,16 +41,29 @@ public abstract class BitSet implements Bits, Accountable {
     clear(0, length());
   }
 
-  /** The number of bits in the set. */
+  /**
+   * The number of bits in the set.
+   * @return the number of bits
+   */
   public abstract int length();
 
-  /** Set the bit at <code>i</code>. */
+  /**
+   * Set the bit at <code>i</code>.
+   * @param i the bit index
+   */
   public abstract void set(int i);
 
-  /** Set the bit at <code>i</code>, returning <code>true</code> if it was previously set. */
+  /**
+   * Set the bit at <code>i</code>, returning <code>true</code> if it was previously set.
+   * @param i the bit index
+   * @return true if the bit was previously set
+   */
   public abstract boolean getAndSet(int i);
 
-  /** Clear the bit at <code>i</code>. */
+  /**
+   * Clear the bit at <code>i</code>.
+   * @param i the bit index
+   */
   public abstract void clear(int i);
 
   /**
@@ -58,25 +74,33 @@ public abstract class BitSet implements Bits, Accountable {
    */
   public abstract void clear(int startIndex, int endIndex);
 
-  /** Return the number of bits that are set. NOTE: this method is likely to run in linear time */
+  /**
+   * Return the number of bits that are set. NOTE: this method is likely to run in linear time
+   * @return the number of set bits
+   */
   public abstract int cardinality();
 
   /**
    * Return an approximation of the cardinality of this set. Some implementations may trade accuracy
    * for speed if they have the ability to estimate the cardinality of the set without iterating
    * over all the data. The default implementation returns {@link #cardinality()}.
+   * @return the approximate cardinality
    */
   public abstract int approximateCardinality();
 
   /**
    * Returns the index of the last set bit before or on the index specified. -1 is returned if there
    * are no more set bits.
+   * @param index the index
+   * @return the index of the previous set bit
    */
   public abstract int prevSetBit(int index);
 
   /**
    * Returns the index of the first set bit starting at the index specified. {@link
    * DocIdSetIterator#NO_MORE_DOCS} is returned if there are no more set bits.
+   * @param index the index
+   * @return the index of the next set bit
    */
   public abstract int nextSetBit(int index);
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/Bits.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/Bits.java
@@ -28,7 +28,9 @@ package io.github.jbellis.jvector.util;
  * Interface for Bitset-like structures.
  */
 public interface Bits {
+    /** Bits with all bits set. */
     Bits ALL = new MatchAllBits();
+    /** Bits with no bits set. */
     Bits NONE = new MatchNoBits();
 
     /**
@@ -42,6 +44,8 @@ public interface Bits {
 
     /**
      * Returns a Bits that is true when `bits` is false, and false when `bits` is true
+     * @param bits the bits to invert
+     * @return the inverted bits
      */
     static Bits inverseOf(Bits bits) {
         return new Bits() {
@@ -54,6 +58,9 @@ public interface Bits {
 
     /**
      * Return a Bits that is set for a given ordinal iff both it is set in both `a` and `b`.
+     * @param a the first bits
+     * @param b the second bits
+     * @return the intersection of a and b
      */
     static Bits intersectionOf(Bits a, Bits b) {
         if (a instanceof MatchAllBits) {
@@ -80,6 +87,9 @@ public interface Bits {
 
     /** Bits with all bits set. */
     class MatchAllBits implements Bits {
+        /** Creates a MatchAllBits instance. */
+        MatchAllBits() {}
+
         @Override
         public boolean get(int index) {
             return true;
@@ -88,6 +98,9 @@ public interface Bits {
 
     /** Bits with no bits set. */
     class MatchNoBits implements Bits {
+        /** Creates a MatchNoBits instance. */
+        MatchNoBits() {}
+
         @Override
         public boolean get(int index) {
             return false;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/BoundedLongHeap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/BoundedLongHeap.java
@@ -43,11 +43,20 @@ public class BoundedLongHeap extends AbstractLongHeap {
         this(maxSize, maxSize);
     }
 
+    /**
+     * Create an empty Heap with the configured initial size and maximum size.
+     * @param initialSize the initial size
+     * @param maxSize the maximum size
+     */
     public BoundedLongHeap(int initialSize, int maxSize) {
         super(initialSize);
         this.maxSize = maxSize;
     }
 
+    /**
+     * Set the maximum size of the heap.
+     * @param maxSize the maximum size
+     */
     public void setMaxSize(int maxSize) {
         if (size > maxSize) {
             throw new IllegalArgumentException("Cannot set maxSize smaller than current size");

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/DenseIntMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/DenseIntMap.java
@@ -30,6 +30,7 @@ import java.util.stream.IntStream;
  * <p>
  * "Dense-ish" means that space is allocated for all keys from 0 to the highest key, but
  * it is valid to have gaps in the keys.  The value associated with "gap" keys is null.
+ * @param <T> the T type parameter
  */
 public class DenseIntMap<T> implements IntMap<T> {
     // locking strategy:
@@ -40,6 +41,10 @@ public class DenseIntMap<T> implements IntMap<T> {
     private volatile AtomicReferenceArray<T> objects;
     private final AtomicInteger size;
 
+    /**
+     * Constructor.
+     * @param initialCapacity the initialCapacity
+     */
     public DenseIntMap(int initialCapacity) {
         objects = new AtomicReferenceArray<>(initialCapacity);
         size = new AtomicInteger();

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/DocIdSetIterator.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/DocIdSetIterator.java
@@ -24,6 +24,16 @@
 
 package io.github.jbellis.jvector.util;
 
+/**
+ * Document ID set iterator.
+ */
 public class DocIdSetIterator {
+    /** the NO_MORE_DOCS constant */
     public static final int NO_MORE_DOCS = Integer.MAX_VALUE;
+
+    /**
+     * Constructor.
+     */
+    public DocIdSetIterator() {
+    }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/ExceptionUtils.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/ExceptionUtils.java
@@ -18,7 +18,21 @@ package io.github.jbellis.jvector.util;
 
 import java.io.IOException;
 
+/**
+ * Exception utilities.
+ */
 public class ExceptionUtils {
+    /**
+     * Constructor.
+     */
+    public ExceptionUtils() {
+    }
+
+    /**
+     * Throw IO exception.
+     * @param t the t
+     * @throws IOException if an error occurs
+     */
     public static void throwIoException(Throwable t) throws IOException {
         if (t instanceof RuntimeException) {
             throw (RuntimeException) t;

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/ExplicitThreadLocal.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/ExplicitThreadLocal.java
@@ -36,6 +36,7 @@ import java.util.function.Supplier;
  * ExplicitThreadLocal also implements AutoCloseable to cleanup non-GC'd resources.
  * <p>
  * ExplicitThreadLocal is a drop-in replacement for ThreadLocal, and is used in the same way.
+ * @param <U> the U type parameter
  */
 public abstract class ExplicitThreadLocal<U> implements AutoCloseable {
     // thread id -> instance
@@ -46,10 +47,24 @@ public abstract class ExplicitThreadLocal<U> implements AutoCloseable {
     // it just once here as a field instead.
     private final Function<Long, U> initialSupplier = k -> initialValue();
 
+    /**
+     * Constructor.
+     */
+    public ExplicitThreadLocal() {
+    }
+
+    /**
+     * Get value.
+     * @return the return value
+     */
     public U get() {
         return map.computeIfAbsent(Thread.currentThread().getId(), initialSupplier);
     }
 
+    /**
+     * Get initial value.
+     * @return the return value
+     */
     protected abstract U initialValue();
 
     /**
@@ -67,6 +82,12 @@ public abstract class ExplicitThreadLocal<U> implements AutoCloseable {
         map.clear();
     }
 
+    /**
+     * Create with initial value.
+     * @param initialValue the initialValue
+     * @param <U> the U type parameter
+     * @return the return value
+     */
     public static <U> ExplicitThreadLocal<U> withInitial(Supplier<U> initialValue) {
         return new ExplicitThreadLocal<>() {
             @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/FixedBitSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/FixedBitSet.java
@@ -45,6 +45,9 @@ public final class FixedBitSet extends BitSet {
      * <p><b>NOTE:</b> the returned bitset reuses the underlying {@code long[]} of the given {@code
      * bits} if possible. Also, calling {@link #length()} on the returned bits may return a value
      * greater than {@code numBits}.
+     * @param bits the bits
+     * @param numBits the numBits
+     * @return the return value
      */
     public static FixedBitSet ensureCapacity(FixedBitSet bits, int numBits) {
         if (numBits < bits.numBits) {
@@ -61,7 +64,11 @@ public final class FixedBitSet extends BitSet {
         }
     }
 
-    /** returns the number of 64 bit words it would take to hold numBits */
+    /**
+     * Returns the number of 64 bit words it would take to hold numBits.
+     * @param numBits the numBits
+     * @return the return value
+     */
     public static int bits2words(int numBits) {
         // I.e.: get the word-offset of the last bit and add one (make sure to use >> so 0
         // returns 0!)
@@ -71,6 +78,9 @@ public final class FixedBitSet extends BitSet {
     /**
      * Returns the popcount or cardinality of the intersection of the two sets. Neither set is
      * modified.
+     * @param a the a
+     * @param b the b
+     * @return the return value
      */
     public static long intersectionCount(FixedBitSet a, FixedBitSet b) {
         // Depends on the ghost bits being clear!
@@ -82,7 +92,12 @@ public final class FixedBitSet extends BitSet {
         return tot;
     }
 
-    /** Returns the popcount or cardinality of the union of the two sets. Neither set is modified. */
+    /**
+     * Returns the popcount or cardinality of the union of the two sets. Neither set is modified.
+     * @param a the a
+     * @param b the b
+     * @return the return value
+     */
     public static long unionCount(FixedBitSet a, FixedBitSet b) {
         // Depends on the ghost bits being clear!
         long tot = 0;
@@ -102,6 +117,9 @@ public final class FixedBitSet extends BitSet {
     /**
      * Returns the popcount or cardinality of "a and not b" or "intersection(a, not(b))". Neither set
      * is modified.
+     * @param a the a
+     * @param b the b
+     * @return the return value
      */
     public static long andNotCount(FixedBitSet a, FixedBitSet b) {
         // Depends on the ghost bits being clear!
@@ -176,7 +194,10 @@ public final class FixedBitSet extends BitSet {
         return numBits;
     }
 
-    /** Expert. */
+    /**
+     * Expert.
+     * @return the return value
+     */
     public long[] getBits() {
         return bits;
     }
@@ -257,6 +278,11 @@ public final class FixedBitSet extends BitSet {
         bits[wordNum] &= ~bitmask;
     }
 
+    /**
+     * Get and clear bit.
+     * @param index the index
+     * @return the return value
+     */
     public boolean getAndClear(int index) {
         assert index >= 0 && index < numBits : "index=" + index + ", numBits=" + numBits;
         int wordNum = index >> 6; // div 64
@@ -312,7 +338,10 @@ public final class FixedBitSet extends BitSet {
         return -1;
     }
 
-    /** this = this OR other */
+    /**
+     * this = this OR other.
+     * @param other the other
+     */
     public void or(FixedBitSet other) {
         or(0, other.bits, other.numWords);
     }
@@ -331,7 +360,10 @@ public final class FixedBitSet extends BitSet {
         }
     }
 
-    /** this = this XOR other */
+    /**
+     * this = this XOR other.
+     * @param other the other
+     */
     public void xor(FixedBitSet other) {
         xor(other.bits, other.numWords);
     }
@@ -345,7 +377,11 @@ public final class FixedBitSet extends BitSet {
         }
     }
 
-    /** returns true if the sets have any elements in common */
+    /**
+     * Returns true if the sets have any elements in common.
+     * @param other the other
+     * @return the return value
+     */
     public boolean intersects(FixedBitSet other) {
         // Depends on the ghost bits being clear!
         int pos = Math.min(numWords, other.numWords);
@@ -355,7 +391,10 @@ public final class FixedBitSet extends BitSet {
         return false;
     }
 
-    /** this = this AND other */
+    /**
+     * this = this AND other.
+     * @param other the other
+     */
     public void and(FixedBitSet other) {
         and(other.bits, other.numWords);
     }
@@ -371,7 +410,10 @@ public final class FixedBitSet extends BitSet {
         }
     }
 
-    /** this = this AND NOT other */
+    /**
+     * this = this AND NOT other.
+     * @param other the other
+     */
     public void andNot(FixedBitSet other) {
         andNot(0, other.bits, other.numWords);
     }
@@ -448,7 +490,10 @@ public final class FixedBitSet extends BitSet {
         bits[endWord] ^= endmask;
     }
 
-    /** Flip the bit at the provided index. */
+    /**
+     * Flip the bit at the provided index.
+     * @param index the index
+     */
     public void flip(int index) {
         assert index >= 0 && index < numBits : "index=" + index + " numBits=" + numBits;
         int wordNum = index >> 6; // div 64

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/GrowableBitSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/GrowableBitSet.java
@@ -28,10 +28,20 @@ public class GrowableBitSet extends BitSet {
 
   private final java.util.BitSet bitSet;
 
+  /**
+   * Constructs a GrowableBitSet wrapping an existing Java BitSet.
+   *
+   * @param bitSet the underlying BitSet to wrap
+   */
   public GrowableBitSet(java.util.BitSet bitSet) {
     this.bitSet = bitSet;
   }
 
+  /**
+   * Constructs a GrowableBitSet with the specified initial capacity.
+   *
+   * @param initialBits the initial number of bits to allocate
+   */
   public GrowableBitSet(int initialBits) {
     this.bitSet = new java.util.BitSet(initialBits);
   }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/IntMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/IntMap.java
@@ -20,41 +20,65 @@ import io.github.jbellis.jvector.graph.NodesIterator;
 
 import java.util.stream.IntStream;
 
+/**
+ * A specialized map interface using primitive int keys instead of Integer objects, providing
+ * better performance and lower memory overhead for integer-keyed collections.
+ * @param <T> the type of values stored in the map
+ */
 public interface IntMap<T> {
     /**
+     * Compare and put.
      * @param key ordinal
+     * @param existing the existing
+     * @param value the value
      * @return true if successful, false if the current value != `existing`
      */
     boolean compareAndPut(int key, T existing, T value);
 
     /**
+     * Size of the map.
      * @return number of items that have been added
      */
     int size();
 
     /**
+     * Get value for key.
      * @param key ordinal
      * @return the value of the key, or null if not set
      */
     T get(int key);
 
     /**
+     * Remove key from map.
+     * @param key the key
      * @return the former value of the key, or null if it was not set
      */
     T remove(int key);
 
     /**
+     * Check if key is in map.
+     * @param key the key
      * @return true iff the given key is set in the map
      */
     boolean containsKey(int key);
 
     /**
      * Iterates keys in ascending order and calls the consumer for each non-null key-value pair.
+     * @param consumer the consumer
      */
     void forEach(IntBiConsumer<T> consumer);
 
+    /**
+     * Functional interface for consuming key-value pairs where keys are primitive ints.
+     * @param <T2> the type of values being consumed
+     */
     @FunctionalInterface
     interface IntBiConsumer<T2> {
+        /**
+         * Processes a key-value pair from the map.
+         * @param key the primitive int key
+         * @param value the value associated with the key
+         */
         void consume(int key, T2 value);
     }
 }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/MathUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/MathUtil.java
@@ -16,8 +16,20 @@
 
 package io.github.jbellis.jvector.util;
 
+/**
+ * Utility class providing common mathematical operations. This class cannot be instantiated.
+ */
 public class MathUtil {
-    // looks silly at first but it really does make code more readable
+    private MathUtil() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Returns the square of a float value. While simple, this method improves code readability
+     * by making the squaring operation explicit.
+     * @param a the value to square
+     * @return a * a
+     */
     public static float square(float a) {
         return a * a;
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/NumericUtils.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/NumericUtils.java
@@ -44,6 +44,8 @@ public final class NumericUtils {
    * reduced, but the value can easily used as an int. The sort order (including {@link Float#NaN})
    * is defined by {@link Float#compareTo}; {@code NaN} is greater than positive infinity.
    *
+   * @param value the float value to convert to sortable integer representation
+   * @return the sortable integer encoding of the float value
    * @see #sortableIntToFloat
    */
   public static int floatToSortableInt(float value) {
@@ -53,13 +55,18 @@ public final class NumericUtils {
   /**
    * Converts a sortable <code>int</code> back to a <code>float</code>.
    *
+   * @param encoded the sortable integer representation to decode
+   * @return the original float value
    * @see #floatToSortableInt
    */
   public static float sortableIntToFloat(int encoded) {
     return Float.intBitsToFloat(sortableFloatBits(encoded));
   }
 
-  /** Converts IEEE 754 representation of a float to sortable order (or back to the original) */
+  /** Converts IEEE 754 representation of a float to sortable order (or back to the original)
+   * @param bits the IEEE 754 bit representation to transform
+   * @return the transformed bit pattern suitable for integer comparison
+   */
   public static int sortableFloatBits(int bits) {
     return bits ^ (bits >> 31) & 0x7fffffff;
   }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
@@ -33,29 +33,60 @@ import java.util.function.Supplier;
  * Knowing how many physical cores a machine has is left to the operator (however the default of 1/2 cores is today often correct).
  */
 public class PhysicalCoreExecutor implements Closeable {
+    /**
+     * Number of physical CPU cores detected, configurable via jvector.physical_core_count system property
+     */
     private static final int physicalCoreCount = Integer.getInteger("jvector.physical_core_count", Math.max(1, Runtime.getRuntime().availableProcessors()/2));
 
+    /**
+     * Singleton instance providing a shared ForkJoinPool sized to physical core count
+     */
     public static final PhysicalCoreExecutor instance = new PhysicalCoreExecutor(physicalCoreCount);
 
+    /**
+     * Returns the shared ForkJoinPool sized to physical core count
+     * @return the executor pool for CPU-intensive vectorized operations
+     */
     public static ForkJoinPool pool() {
         return instance.pool;
     }
-    
+
+    /**
+     * The underlying ForkJoinPool sized to match physical core count
+     */
     private final ForkJoinPool pool;
 
+    /**
+     * Private constructor creating an executor with the specified core count
+     * @param cores the number of threads in the pool
+     */
     private PhysicalCoreExecutor(int cores) {
         assert cores > 0 && cores <= Runtime.getRuntime().availableProcessors() : "Invalid core count: " + cores;
         this.pool = new ForkJoinPool(cores);
     }
 
+    /**
+     * Executes a runnable task and waits for completion
+     * @param run the task to execute
+     */
     public void execute(Runnable run) {
         pool.submit(run).join();
     }
 
+    /**
+     * Submits a callable task and returns its result
+     * @param <T> the result type
+     * @param run the task supplier to execute
+     * @return the computed result
+     */
     public <T> T submit(Supplier<T> run) {
         return pool.submit(run::get).join();
     }
 
+    /**
+     * Returns the detected or configured physical core count
+     * @return the number of physical cores being used for parallel execution
+     */
     public static int getPhysicalCoreCount() {
         return physicalCoreCount;
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/RamUsageEstimator.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/RamUsageEstimator.java
@@ -187,7 +187,11 @@ public final class RamUsageEstimator {
       // hash tables need to be oversized to avoid collisions, assume 2x capacity
       (2L * NUM_BYTES_OBJECT_REF) * 2;
 
-  /** Aligns an object size to be the next multiple of {@link #NUM_BYTES_OBJECT_ALIGNMENT}. */
+  /**
+   * Aligns an object size to be the next multiple of {@link #NUM_BYTES_OBJECT_ALIGNMENT}.
+   * @param size the unaligned object size in bytes to be rounded up
+   * @return the size rounded up to the next multiple of the JVM's object alignment boundary
+   */
   public static long alignObjectSize(long size) {
     size += (long) NUM_BYTES_OBJECT_ALIGNMENT - 1L;
     return size - (size % NUM_BYTES_OBJECT_ALIGNMENT);
@@ -196,6 +200,8 @@ public final class RamUsageEstimator {
   /**
    * Return the shallow size of the provided {@link Integer} object. Ignores the possibility that
    * this object is part of the VM IntegerCache
+   * @param ignored the Integer instance (not used, only for type dispatch)
+   * @return the shallow size in bytes of an Integer object
    */
   public static long sizeOf(Integer ignored) {
     return INTEGER_SIZE;
@@ -204,52 +210,90 @@ public final class RamUsageEstimator {
   /**
    * Return the shallow size of the provided {@link Long} object. Ignores the possibility that this
    * object is part of the VM LongCache
+   * @param ignored the Long instance (not used, only for type dispatch)
+   * @return the shallow size in bytes of a Long object
    */
   public static long sizeOf(Long ignored) {
     return LONG_SIZE;
   }
 
-  /** Returns the size in bytes of the byte[] object. */
+  /**
+   * Returns the size in bytes of the byte[] object.
+   * @param arr the byte array to measure
+   * @return the total size in bytes including array header and content
+   */
   public static long sizeOf(byte[] arr) {
     return alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + arr.length);
   }
 
-  /** Returns the size in bytes of the boolean[] object. */
+  /**
+   * Returns the size in bytes of the boolean[] object.
+   * @param arr the boolean array to measure
+   * @return the total size in bytes including array header and content
+   */
   public static long sizeOf(boolean[] arr) {
     return alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + arr.length);
   }
 
-  /** Returns the size in bytes of the char[] object. */
+  /**
+   * Returns the size in bytes of the char[] object.
+   * @param arr the char array to measure
+   * @return the total size in bytes including array header and content
+   */
   public static long sizeOf(char[] arr) {
     return alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Character.BYTES * arr.length);
   }
 
-  /** Returns the size in bytes of the short[] object. */
+  /**
+   * Returns the size in bytes of the short[] object.
+   * @param arr the short array to measure
+   * @return the total size in bytes including array header and content
+   */
   public static long sizeOf(short[] arr) {
     return alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Short.BYTES * arr.length);
   }
 
-  /** Returns the size in bytes of the int[] object. */
+  /**
+   * Returns the size in bytes of the int[] object.
+   * @param arr the int array to measure
+   * @return the total size in bytes including array header and content
+   */
   public static long sizeOf(int[] arr) {
     return alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Integer.BYTES * arr.length);
   }
 
-  /** Returns the size in bytes of the float[] object. */
+  /**
+   * Returns the size in bytes of the float[] object.
+   * @param arr the float array to measure
+   * @return the total size in bytes including array header and content
+   */
   public static long sizeOf(float[] arr) {
     return alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Float.BYTES * arr.length);
   }
 
-  /** Returns the size in bytes of the long[] object. */
+  /**
+   * Returns the size in bytes of the long[] object.
+   * @param arr the long array to measure
+   * @return the total size in bytes including array header and content
+   */
   public static long sizeOf(long[] arr) {
     return alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * arr.length);
   }
 
-  /** Returns the size in bytes of the double[] object. */
+  /**
+   * Returns the size in bytes of the double[] object.
+   * @param arr the double array to measure
+   * @return the total size in bytes including array header and content
+   */
   public static long sizeOf(double[] arr) {
     return alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Double.BYTES * arr.length);
   }
 
-  /** Returns the size in bytes of the String[] object. */
+  /**
+   * Returns the size in bytes of the String[] object.
+   * @param arr the String array to measure (includes the size of the String objects themselves)
+   * @return the total size in bytes including array header, references, and String content
+   */
   public static long sizeOf(String[] arr) {
     long size = shallowSizeOf(arr);
     for (String s : arr) {
@@ -261,6 +305,11 @@ public final class RamUsageEstimator {
     return size;
   }
 
+  /**
+   * Returns the size in bytes of an Accountable object by delegating to its ramBytesUsed method.
+   * @param a the Accountable object to measure
+   * @return the total size in bytes as reported by the Accountable implementation
+   */
   public static long sizeOf(Accountable a) {
     return a.ramBytesUsed();
   }
@@ -349,7 +398,11 @@ public final class RamUsageEstimator {
     return size;
   }
 
-  /** Returns the size in bytes of the String object. */
+  /**
+   * Returns the size in bytes of the String object.
+   * @param s the String to measure
+   * @return the total size in bytes including the String object and its character array
+   */
   public static long sizeOf(String s) {
     if (s == null) {
       return 0;
@@ -361,8 +414,12 @@ public final class RamUsageEstimator {
     return alignObjectSize(size);
   }
 
-  /** Returns the shallow size in bytes of the Object[] object. */
-  // Use this method instead of #shallowSizeOf(Object) to avoid costly reflection
+  /**
+   * Returns the shallow size in bytes of the Object[] object.
+   * Use this method instead of #shallowSizeOf(Object) to avoid costly reflection
+   * @param arr the Object array to measure (only the array structure, not the referenced objects)
+   * @return the shallow size in bytes including array header and object references
+   */
   public static long shallowSizeOf(Object[] arr) {
     return alignObjectSize(
         (long) NUM_BYTES_ARRAY_HEADER + (long) NUM_BYTES_OBJECT_REF * arr.length);
@@ -374,6 +431,8 @@ public final class RamUsageEstimator {
    * memory taken by the fields.
    *
    * <p>JVM object alignments are also applied.
+   * @param obj the object to measure (arrays or instances)
+   * @return the shallow size in bytes of the object's structure, excluding referenced objects
    */
   public static long shallowSizeOf(Object obj) {
     if (obj == null) return 0;
@@ -390,6 +449,8 @@ public final class RamUsageEstimator {
    * works with all conventional classes and primitive types, but not with arrays (the size then
    * depends on the number of elements and varies from object to object).
    *
+   * @param clazz the class whose instance size should be calculated
+   * @return the shallow instance size in bytes including object header and all fields
    * @see #shallowSizeOf(Object)
    * @throws IllegalArgumentException if {@code clazz} is an array class.
    */
@@ -447,6 +508,9 @@ public final class RamUsageEstimator {
    *
    * <p>The returned offset will be the maximum of whatever was measured so far and <code>f</code>
    * field's offset and representation size (unaligned).
+   * @param sizeSoFar the cumulative object size measured up to this point
+   * @param f the field being examined for its size contribution
+   * @return the updated size including this field's contribution
    */
   public static long adjustForField(long sizeSoFar, final Field f) {
     final Class<?> type = f.getType();
@@ -454,7 +518,12 @@ public final class RamUsageEstimator {
     return sizeSoFar + fsize;
   }
 
-  /** Returns <code>size</code> in human-readable units (GB, MB, KB or bytes). */
+  /**
+   * Returns <code>size</code> in human-readable units (GB, MB, KB or bytes).
+   * @param bytes the size in bytes to format
+   * @param df the DecimalFormat to use for formatting the numeric portion
+   * @return a human-readable string representation of the size
+   */
   public static String humanReadableUnits(long bytes, DecimalFormat df) {
     if (bytes / ONE_GB > 0) {
       return df.format((float) bytes / ONE_GB) + " GB";

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/SparseBits.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/SparseBits.java
@@ -19,24 +19,42 @@ package io.github.jbellis.jvector.util;
 import org.agrona.collections.IntHashSet;
 
 /**
- * Implements the membership parts of an updatable BitSet (but not prev/next bits)
+ * Implements the membership parts of an updatable BitSet (but not prev/next bits).
+ * Uses a hash set internally for sparse storage of set bits.
  */
 public class SparseBits implements Bits {
     private final IntHashSet set = new IntHashSet();
+
+    /**
+     * Creates a new empty SparseBits.
+     */
+    public SparseBits() {
+    }
 
     @Override
     public boolean get(int index) {
         return set.contains(index);
     }
 
+    /**
+     * Sets the bit at the specified index to true.
+     * @param index the bit index to set
+     */
     public void set(int index) {
         set.add(index);
     }
 
+    /**
+     * Clears all bits in this bit set, resetting it to empty.
+     */
     public void clear() {
         set.clear();
     }
 
+    /**
+     * Returns the number of bits set to true in this bit set.
+     * @return the count of set bits
+     */
     public int cardinality() {
         return set.size();
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/SparseFixedBitSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/SparseFixedBitSet.java
@@ -68,6 +68,7 @@ public class SparseFixedBitSet extends BitSet {
   /**
    * Create a {@link SparseFixedBitSet} that can contain bits between <code>0</code> included and
    * <code>length</code> excluded.
+   * @param length the maximum number of bits this set can hold
    */
   public SparseFixedBitSet(int length) {
     if (length < 1) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/SparseIntMap.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/SparseIntMap.java
@@ -21,9 +21,18 @@ import io.github.jbellis.jvector.graph.NodesIterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.IntStream;
 
+/**
+ * A thread-safe implementation of IntMap backed by a ConcurrentHashMap.
+ * Efficient for sparse key spaces where not all integer keys are used.
+ * @param <T> the type of values stored in the map
+ */
 public class SparseIntMap<T> implements IntMap<T> {
+    /** The underlying concurrent hash map storing integer keys and values */
     private final ConcurrentHashMap<Integer, T> map;
 
+    /**
+     * Creates a new empty SparseIntMap.
+     */
     public SparseIntMap() {
         this.map = new ConcurrentHashMap<>();
     }
@@ -62,6 +71,10 @@ public class SparseIntMap<T> implements IntMap<T> {
         return map.containsKey(key);
     }
 
+    /**
+     * Returns a stream of all keys in this map.
+     * @return an IntStream of the keys in this map
+     */
     public IntStream keysStream() {
         return map.keySet().stream().mapToInt(key -> key);
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/ThreadSafeGrowableBitSet.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/ThreadSafeGrowableBitSet.java
@@ -29,13 +29,23 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public class ThreadSafeGrowableBitSet extends BitSet {
 
+  /** The underlying JDK BitSet that stores the actual bit data */
   private final java.util.BitSet bitSet;
+  /** Lock for coordinating concurrent read and write access */
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
+  /**
+   * Creates a thread-safe wrapper around an existing BitSet.
+   * @param bitSet the JDK BitSet to wrap with thread-safe operations
+   */
   public ThreadSafeGrowableBitSet(java.util.BitSet bitSet) {
     this.bitSet = bitSet;
   }
 
+  /**
+   * Creates a new thread-safe growable bit set with the specified initial capacity.
+   * @param initialBits the initial number of bits to allocate
+   */
   public ThreadSafeGrowableBitSet(int initialBits) {
     this.bitSet = new java.util.BitSet(initialBits);
   }
@@ -167,6 +177,10 @@ public class ThreadSafeGrowableBitSet extends BitSet {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Creates a copy of this bit set including all currently set bits.
+   * @return a new independent ThreadSafeGrowableBitSet with the same bit values
+   */
   public ThreadSafeGrowableBitSet copy() {
     lock.readLock().lock();
     try {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArraySliceByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArraySliceByteSequence.java
@@ -28,6 +28,12 @@ public class ArraySliceByteSequence implements ByteSequence<byte[]> {
     private final int offset;
     private final int length;
 
+    /**
+     * Constructs an ArraySliceByteSequence.
+     * @param data the data parameter
+     * @param offset the offset parameter
+     * @param length the length parameter
+     */
     public ArraySliceByteSequence(ByteSequence<byte[]> data, int offset, int length) {
         if (offset < 0 || length < 0 || offset + length > data.length()) {
             throw new IllegalArgumentException("Invalid offset or length");

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorizationProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorizationProvider.java
@@ -32,7 +32,9 @@ final public class DefaultVectorizationProvider extends VectorizationProvider {
   private final VectorUtilSupport vectorUtilSupport;
   private final VectorTypeSupport vectorTypes;
 
-
+  /**
+   * Constructor.
+   */
   public DefaultVectorizationProvider() {
     vectorUtilSupport = new DefaultVectorUtilSupport();
     vectorTypes = new ArrayVectorProvider();

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/Matrix.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/Matrix.java
@@ -28,12 +28,27 @@ import static java.lang.Math.abs;
 public class Matrix {
     private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
 
+    /**
+     * The matrix data stored as rows, where each row is a VectorFloat. This layout optimizes
+     * matrix-vector multiplication by making dot products with each row efficient.
+     */
     VectorFloat<?>[] data;
 
+    /**
+     * Constructs an m-by-n matrix with all elements initialized to zero.
+     * @param m the number of rows
+     * @param n the number of columns
+     */
     public Matrix(int m, int n) {
         this(m, n, true);
     }
 
+    /**
+     * Constructs an m-by-n matrix with optional zero initialization.
+     * @param m the number of rows
+     * @param n the number of columns
+     * @param allocateZeroed if true, all elements are initialized to zero; if false, rows are unallocated
+     */
     public Matrix(int m, int n, boolean allocateZeroed) {
         data = new VectorFloat[m];
         if (allocateZeroed) {
@@ -43,14 +58,31 @@ public class Matrix {
         }
     }
 
+    /**
+     * Returns the element at row i and column j.
+     * @param i the row index
+     * @param j the column index
+     * @return the matrix element at position (i, j)
+     */
     public float get(int i, int j) {
         return data[i].get(j);
     }
 
+    /**
+     * Sets the element at row i and column j to the specified value.
+     * @param i the row index
+     * @param j the column index
+     * @param value the value to set
+     */
     public void set(int i, int j, float value) {
         data[i].set(j, value);
     }
 
+    /**
+     * Checks if this matrix has the same dimensions as another matrix.
+     * @param other the matrix to compare dimensions with
+     * @return true if both matrices have the same number of rows and columns, false otherwise
+     */
     public boolean isIsomorphicWith(Matrix other) {
         return data.length == other.data.length && data[0].length() == other.data[0].length();
     }
@@ -122,10 +154,22 @@ public class Matrix {
         return inverse;
     }
 
+    /**
+     * Adds a delta value to the element at row i and column j.
+     * @param i the row index
+     * @param j the column index
+     * @param delta the value to add to the current element
+     */
     public void addTo(int i, int j, float delta) {
         data[i].set(j, data[i].get(j) + delta);
     }
 
+    /**
+     * Adds another matrix to this matrix element-wise, modifying this matrix in place.
+     * Both matrices must have the same dimensions.
+     * @param other the matrix to add to this matrix
+     * @throws IllegalArgumentException if the matrices have different dimensions
+     */
     public void addInPlace(Matrix other) {
         if (!this.isIsomorphicWith(other)) {
             throw new IllegalArgumentException("matrix dimensions differ for " + this + "!=" + other);
@@ -136,6 +180,14 @@ public class Matrix {
         }
     }
 
+    /**
+     * Multiplies this matrix by a column vector, returning the resulting vector. For an m-by-n matrix
+     * and an n-dimensional vector, this returns an m-dimensional vector where each element is the dot
+     * product of the corresponding matrix row with the input vector.
+     * @param v the vector to multiply with this matrix
+     * @return the resulting vector from the matrix-vector multiplication
+     * @throws IllegalArgumentException if the vector dimension doesn't match the matrix column count
+     */
     public VectorFloat<?> multiply(VectorFloat<?> v) {
         if (data.length == 0) {
             throw new IllegalArgumentException("Cannot multiply empty matrix");
@@ -151,6 +203,13 @@ public class Matrix {
         return result;
     }
 
+    /**
+     * Computes the outer product of two vectors, resulting in a matrix where element (i,j) equals a[i] * b[j].
+     * For vectors of dimensions m and n, this produces an m-by-n matrix.
+     * @param a the first vector (determines the number of rows)
+     * @param b the second vector (determines the number of columns)
+     * @return the outer product matrix
+     */
     public static Matrix outerProduct(VectorFloat<?> a, VectorFloat<?> b) {
         var result = new Matrix(a.length(), b.length(), false);
 
@@ -163,6 +222,10 @@ public class Matrix {
         return result;
     }
 
+    /**
+     * Multiplies all elements in the matrix by a scalar value, modifying the matrix in place.
+     * @param multiplier the scalar value to multiply each matrix element by
+     */
     public void scale(float multiplier) {
         for (var row : data) {
             VectorUtil.scale(row, multiplier);
@@ -186,6 +249,11 @@ public class Matrix {
         return true;
     }
 
+    /**
+     * Creates a matrix from a 2D array of float values. Each row of the array becomes a row in the matrix.
+     * @param values the 2D array containing the matrix elements (values[row][column])
+     * @return a new Matrix initialized with the provided values
+     */
     public static Matrix from(float[][] values) {
         var result = new Matrix(values.length, values[0].length, false);
         for (int i = 0; i < values.length; i++) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -40,6 +40,9 @@ public final class VectorUtil {
   /**
    * Returns the vector dot product of the two vectors.
    *
+   * @param a the first vector
+   * @param b the second vector
+   * @return the dot product of the two vectors
    * @throws IllegalArgumentException if the vectors' dimensions differ.
    */
   public static float dotProduct(VectorFloat<?> a, VectorFloat<?> b) {
@@ -51,6 +54,16 @@ public final class VectorUtil {
     return r;
   }
 
+  /**
+   * Returns the vector dot product of two subvectors.
+   *
+   * @param a the first vector
+   * @param aoffset the starting offset in the first vector
+   * @param b the second vector
+   * @param boffset the starting offset in the second vector
+   * @param length the length of the subvectors to compute
+   * @return the dot product of the two subvectors
+   */
   public static float dotProduct(VectorFloat<?> a, int aoffset, VectorFloat<?> b, int boffset, int length) {
     //This check impacts FLOPS
     /*if ( length > Math.min(a.length - aoffset, b.length - boffset) ) {
@@ -65,6 +78,9 @@ public final class VectorUtil {
   /**
    * Returns the cosine similarity between the two vectors.
    *
+   * @param a the first vector
+   * @param b the second vector
+   * @return the cosine similarity between the two vectors
    * @throws IllegalArgumentException if the vectors' dimensions differ.
    */
   public static float cosine(VectorFloat<?> a, VectorFloat<?> b) {
@@ -79,6 +95,9 @@ public final class VectorUtil {
   /**
    * Returns the sum of squared differences of the two vectors.
    *
+   * @param a the first vector
+   * @param b the second vector
+   * @return the squared Euclidean distance between the two vectors
    * @throws IllegalArgumentException if the vectors' dimensions differ.
    */
   public static float squareL2Distance(VectorFloat<?> a, VectorFloat<?> b) {
@@ -92,6 +111,13 @@ public final class VectorUtil {
 
   /**
    * Returns the sum of squared differences of the two vectors, or subvectors, of the given length.
+   *
+   * @param a the first vector
+   * @param aoffset the starting offset in the first vector
+   * @param b the second vector
+   * @param boffset the starting offset in the second vector
+   * @param length the length of the subvectors to compute
+   * @return the squared Euclidean distance between the two subvectors
    */
   public static float squareL2Distance(VectorFloat<?> a, int aoffset, VectorFloat<?> b, int boffset, int length) {
     float r = impl.squareDistance(a, aoffset, b, boffset, length);
@@ -114,6 +140,13 @@ public final class VectorUtil {
     scale(v, (float) (1.0 / length));
   }
 
+  /**
+   * Computes the element-wise sum of multiple vectors.
+   *
+   * @param vectors the list of vectors to sum
+   * @return a new vector containing the element-wise sum of all input vectors
+   * @throws IllegalArgumentException if the input list is empty
+   */
   public static VectorFloat<?> sum(List<VectorFloat<?>> vectors) {
     if (vectors.isEmpty()) {
       throw new IllegalArgumentException("Input list cannot be empty");
@@ -122,62 +155,183 @@ public final class VectorUtil {
     return impl.sum(vectors);
   }
 
+  /**
+   * Computes the sum of all elements in the vector.
+   *
+   * @param vector the vector to sum
+   * @return the sum of all elements in the vector
+   */
   public static float sum(VectorFloat<?> vector) {
     return impl.sum(vector);
   }
 
+  /**
+   * Multiplies each element of the vector by the given multiplier in place.
+   *
+   * @param vector the vector to scale
+   * @param multiplier the scaling factor to apply to each element
+   */
   public static void scale(VectorFloat<?> vector, float multiplier) {
     impl.scale(vector, multiplier);
   }
 
+  /**
+   * Adds the elements of v2 to the corresponding elements of v1 in place.
+   *
+   * @param v1 the vector to modify (will contain the sum)
+   * @param v2 the vector to add to v1
+   */
   public static void addInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
     impl.addInPlace(v1, v2);
   }
 
+  /**
+   * Adds a scalar value to each element of v1 in place.
+   *
+   * @param v1 the vector to modify
+   * @param value the scalar value to add to each element
+   */
   public static void addInPlace(VectorFloat<?> v1, float value) {
     impl.addInPlace(v1, value);
   }
 
+  /**
+   * Subtracts the elements of v2 from the corresponding elements of v1 in place.
+   *
+   * @param v1 the vector to modify (will contain the difference)
+   * @param v2 the vector to subtract from v1
+   */
   public static void subInPlace(VectorFloat<?> v1, VectorFloat<?> v2) {
     impl.subInPlace(v1, v2);
   }
 
+  /**
+   * Subtracts a scalar value from each element of the vector in place.
+   *
+   * @param vector the vector to modify
+   * @param value the scalar value to subtract from each element
+   */
   public static void subInPlace(VectorFloat<?> vector, float value) {
     impl.subInPlace(vector, value);
   }
 
+  /**
+   * Subtracts rhs from lhs element-wise and returns a new vector.
+   *
+   * @param lhs the vector to subtract from
+   * @param rhs the vector to subtract
+   * @return a new vector containing the element-wise difference
+   */
   public static VectorFloat<?> sub(VectorFloat<?> lhs, VectorFloat<?> rhs) {
     return impl.sub(lhs, rhs);
   }
 
+  /**
+   * Subtracts a scalar value from each element of lhs and returns a new vector.
+   *
+   * @param lhs the vector to subtract from
+   * @param value the scalar value to subtract from each element
+   * @return a new vector containing the result
+   */
   public static VectorFloat<?> sub(VectorFloat<?> lhs, float value) {
     return impl.sub(lhs, value);
   }
 
+  /**
+   * Subtracts subvectors element-wise and returns a new vector.
+   *
+   * @param a the first vector
+   * @param aOffset the starting offset in the first vector
+   * @param b the second vector
+   * @param bOffset the starting offset in the second vector
+   * @param length the length of the subvectors
+   * @return a new vector containing the element-wise difference
+   */
   public static VectorFloat<?> sub(VectorFloat<?> a, int aOffset, VectorFloat<?> b, int bOffset, int length) {
     return impl.sub(a, aOffset, b, bOffset, length);
   }
 
+  /**
+   * Computes the element-wise minimum of two vectors and stores the result in distances1.
+   *
+   * @param distances1 the first vector (will be modified to contain the minimums)
+   * @param distances2 the second vector
+   */
   public static void minInPlace(VectorFloat<?> distances1, VectorFloat<?> distances2) {
     impl.minInPlace(distances1, distances2);
   }
 
+  /**
+   * Assembles sparse vector elements from a data array using byte offsets and computes their sum.
+   *
+   * @param data the vector containing all data points
+   * @param dataBase the base index in the data vector
+   * @param dataOffsets byte sequence containing offsets from the base index
+   * @return the sum of the assembled elements
+   */
   public static float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> dataOffsets) {
     return impl.assembleAndSum(data, dataBase, dataOffsets);
   }
 
+  /**
+   * Assembles sparse vector elements from a data array using a subset of byte offsets and computes their sum.
+   *
+   * @param data the vector containing all data points
+   * @param dataBase the base index in the data vector
+   * @param dataOffsets byte sequence containing offsets from the base index
+   * @param dataOffsetsOffset the starting offset within the dataOffsets sequence
+   * @param dataOffsetsLength the number of offsets to use
+   * @return the sum of the assembled elements
+   */
   public static float assembleAndSum(VectorFloat<?> data, int dataBase, ByteSequence<?> dataOffsets, int dataOffsetsOffset, int dataOffsetsLength) {
     return impl.assembleAndSum(data, dataBase, dataOffsets, dataOffsetsOffset, dataOffsetsLength);
   }
 
+  /**
+   * Computes distance between two product quantization-encoded vectors using precomputed codebook partial sums.
+   *
+   * @param data the vector of precomputed partial sums from the codebook
+   * @param subspaceCount the number of PQ subspaces
+   * @param dataOffsets1 byte sequence specifying centroid indices for the first vector
+   * @param dataOffsetsOffset1 the starting offset within dataOffsets1
+   * @param dataOffsets2 byte sequence specifying centroid indices for the second vector
+   * @param dataOffsetsOffset2 the starting offset within dataOffsets2
+   * @param clusterCount the number of clusters per subspace
+   * @return the distance between the two encoded vectors
+   */
   public static float assembleAndSumPQ(VectorFloat<?> data, int subspaceCount, ByteSequence<?> dataOffsets1, int dataOffsetsOffset1, ByteSequence<?> dataOffsets2, int dataOffsetsOffset2, int clusterCount) {
     return impl.assembleAndSumPQ(data, subspaceCount, dataOffsets1, dataOffsetsOffset1, dataOffsets2, dataOffsetsOffset2, clusterCount);
   }
 
+  /**
+   * Computes similarity scores for multiple PQ-encoded vectors against a query using quantized partial sums.
+   *
+   * @param shuffles transposed PQ-encoded vectors where all first components are contiguous, then all second components, etc.
+   * @param codebookCount the number of codebooks used in PQ encoding
+   * @param quantizedPartials quantized precomputed score fragments for each codebook entry
+   * @param delta the quantization delta used for dequantizing scores
+   * @param minDistance the minimum distance used during quantization
+   * @param results output vector to store the computed similarity scores
+   * @param vsf the vector similarity function to apply
+   */
   public static void bulkShuffleQuantizedSimilarity(ByteSequence<?> shuffles, int codebookCount, ByteSequence<?> quantizedPartials, float delta, float minDistance, VectorFloat<?> results, VectorSimilarityFunction vsf) {
     impl.bulkShuffleQuantizedSimilarity(shuffles, codebookCount, quantizedPartials, delta, minDistance, vsf, results);
   }
 
+  /**
+   * Computes cosine similarity scores for multiple PQ-encoded vectors against a query using quantized partial sums and magnitudes.
+   *
+   * @param shuffles transposed PQ-encoded vectors where all first components are contiguous, then all second components, etc.
+   * @param codebookCount the number of codebooks used in PQ encoding
+   * @param quantizedPartialSums quantized dot product fragments between query and codebook entries
+   * @param sumDelta the quantization delta used for quantizedPartialSums
+   * @param minDistance the minimum distance used for quantizing sums
+   * @param quantizedPartialMagnitudes quantized squared magnitudes of codebook entries
+   * @param magnitudeDelta the quantization delta used for quantizedPartialMagnitudes
+   * @param minMagnitude the minimum magnitude used for quantizing magnitudes
+   * @param queryMagnitudeSquared the squared magnitude of the query vector
+   * @param results output vector to store the computed cosine similarity scores
+   */
   public static void bulkShuffleQuantizedSimilarityCosine(ByteSequence<?> shuffles, int codebookCount,
                                                           ByteSequence<?> quantizedPartialSums, float sumDelta, float minDistance,
                                                           ByteSequence<?> quantizedPartialMagnitudes, float magnitudeDelta, float minMagnitude,
@@ -185,18 +339,58 @@ public final class VectorUtil {
     impl.bulkShuffleQuantizedSimilarityCosine(shuffles, codebookCount, quantizedPartialSums, sumDelta, minDistance, quantizedPartialMagnitudes, magnitudeDelta, minMagnitude, queryMagnitudeSquared, results);
   }
 
+  /**
+   * Computes the Hamming distance between two bit vectors represented as long arrays.
+   *
+   * @param v1 the first bit vector
+   * @param v2 the second bit vector
+   * @return the number of bit positions where the two vectors differ
+   */
   public static int hammingDistance(long[] v1, long[] v2) {
     return impl.hammingDistance(v1, v2);
   }
 
+  /**
+   * Calculates partial similarity sums and best distances for PQ codebook clusters against a query subvector.
+   *
+   * @param codebook the codebook containing all centroid vectors
+   * @param codebookIndex the index of the codebook to use
+   * @param size the dimensionality of each centroid vector
+   * @param clusterCount the number of clusters in the codebook
+   * @param query the query vector
+   * @param offset the starting offset in the query vector for this subspace
+   * @param vsf the vector similarity function to use
+   * @param partialSums output vector to store the computed partial sums
+   * @param partialBestDistances output vector to store the best distances per cluster
+   */
   public static void calculatePartialSums(VectorFloat<?> codebook, int codebookIndex, int size, int clusterCount, VectorFloat<?> query, int offset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums, VectorFloat<?> partialBestDistances) {
     impl.calculatePartialSums(codebook, codebookIndex, size, clusterCount, query, offset, vsf, partialSums, partialBestDistances);
   }
 
+  /**
+   * Calculates partial similarity sums for PQ codebook clusters against a query subvector.
+   *
+   * @param codebook the codebook containing all centroid vectors
+   * @param codebookIndex the index of the codebook to use
+   * @param size the dimensionality of each centroid vector
+   * @param clusterCount the number of clusters in the codebook
+   * @param query the query vector
+   * @param offset the starting offset in the query vector for this subspace
+   * @param vsf the vector similarity function to use
+   * @param partialSums output vector to store the computed partial sums
+   */
   public static void calculatePartialSums(VectorFloat<?> codebook, int codebookIndex, int size, int clusterCount, VectorFloat<?> query, int offset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums) {
     impl.calculatePartialSums(codebook, codebookIndex, size, clusterCount, query, offset, vsf, partialSums);
   }
 
+  /**
+   * Quantizes partial sum values into unsigned 16-bit integers for efficient storage.
+   *
+   * @param delta the quantization step size (divisor)
+   * @param partials the partial sum values to quantize
+   * @param partialBase the base values to subtract before quantization
+   * @param quantizedPartials output byte sequence to store the quantized values
+   */
   public static void quantizePartials(float delta, VectorFloat<?> partials, VectorFloat<?> partialBase, ByteSequence<?> quantizedPartials) {
     impl.quantizePartials(delta, partials, partialBase, quantizedPartials);
   }
@@ -219,38 +413,129 @@ public final class VectorUtil {
     return impl.min(v);
   }
 
+  /**
+   * Computes cosine similarity between a PQ-encoded vector and a query using precomputed partial sums and magnitudes.
+   *
+   * @param encoded the PQ-encoded vector (centroid indices)
+   * @param clusterCount the number of clusters per subspace
+   * @param partialSums precomputed dot products between query and codebook centroids
+   * @param aMagnitude precomputed squared magnitudes of codebook centroids
+   * @param bMagnitude the magnitude of the second vector
+   * @return the cosine similarity score
+   */
   public static float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude) {
     return impl.pqDecodedCosineSimilarity(encoded, clusterCount, partialSums, aMagnitude, bMagnitude);
   }
 
+  /**
+   * Computes cosine similarity between a PQ-encoded vector subset and a query using precomputed partial sums and magnitudes.
+   *
+   * @param encoded the PQ-encoded vector (centroid indices)
+   * @param encodedOffset the starting offset within the encoded sequence
+   * @param encodedLength the length of the encoded sequence to use
+   * @param clusterCount the number of clusters per subspace
+   * @param partialSums precomputed dot products between query and codebook centroids
+   * @param aMagnitude precomputed squared magnitudes of codebook centroids
+   * @param bMagnitude the magnitude of the second vector
+   * @return the cosine similarity score
+   */
   public static float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int encodedOffset, int encodedLength, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude) {
     return impl.pqDecodedCosineSimilarity(encoded, encodedOffset, encodedLength, clusterCount, partialSums, aMagnitude, bMagnitude);
   }
 
+  /**
+   * Computes the dot product between a vector and an 8-bit NVQ-quantized vector.
+   *
+   * @param vector the query vector
+   * @param bytes the 8-bit quantized vector
+   * @param growthRate the growth rate parameter of the logistic quantization function
+   * @param midpoint the midpoint parameter of the logistic quantization function
+   * @param minValue the minimum value used during quantization
+   * @param maxValue the maximum value used during quantization
+   * @return the dot product
+   */
   public static float nvqDotProduct8bit(VectorFloat<?> vector, ByteSequence<?> bytes, float growthRate, float midpoint, float minValue, float maxValue) {
     return impl.nvqDotProduct8bit(vector, bytes, growthRate, midpoint, minValue, maxValue);
   }
 
+  /**
+   * Computes the squared Euclidean distance between a vector and an 8-bit NVQ-quantized vector.
+   *
+   * @param vector the query vector
+   * @param bytes the 8-bit quantized vector
+   * @param growthRate the growth rate parameter of the logistic quantization function
+   * @param midpoint the midpoint parameter of the logistic quantization function
+   * @param minValue the minimum value used during quantization
+   * @param maxValue the maximum value used during quantization
+   * @return the squared Euclidean distance
+   */
   public static float nvqSquareL2Distance8bit(VectorFloat<?> vector, ByteSequence<?> bytes, float growthRate, float midpoint, float minValue, float maxValue) {
     return impl.nvqSquareL2Distance8bit(vector, bytes, growthRate, midpoint, minValue, maxValue);
   }
 
+  /**
+   * Computes the cosine similarity between a vector and an 8-bit NVQ-quantized vector.
+   *
+   * @param vector the query vector
+   * @param bytes the 8-bit quantized vector
+   * @param growthRate the growth rate parameter of the logistic quantization function
+   * @param midpoint the midpoint parameter of the logistic quantization function
+   * @param minValue the minimum value used during quantization
+   * @param maxValue the maximum value used during quantization
+   * @param centroid the global mean vector used to re-center the quantized vector
+   * @return an array containing cosine similarity components
+   */
   public static float[] nvqCosine8bit(VectorFloat<?> vector, ByteSequence<?> bytes, float growthRate, float midpoint, float minValue, float maxValue, VectorFloat<?> centroid) {
     return impl.nvqCosine8bit(vector, bytes, growthRate, midpoint, minValue, maxValue, centroid);
   }
 
+  /**
+   * Shuffles the query vector in place to optimize NVQ distance computation order.
+   *
+   * @param vector the vector to shuffle (will be modified)
+   */
   public static void nvqShuffleQueryInPlace8bit(VectorFloat<?> vector) {
     impl.nvqShuffleQueryInPlace8bit(vector);
   }
 
+  /**
+   * Quantizes a vector to 8-bit NVQ representation using a logistic quantization function.
+   *
+   * @param vector the vector to quantize
+   * @param growthRate the growth rate parameter of the logistic quantization function
+   * @param midpoint the midpoint parameter of the logistic quantization function
+   * @param minValue the minimum value for quantization
+   * @param maxValue the maximum value for quantization
+   * @param destination the byte sequence to store the quantized result
+   */
   public static void nvqQuantize8bit(VectorFloat<?> vector, float growthRate, float midpoint, float minValue, float maxValue, ByteSequence<?> destination) {
     impl.nvqQuantize8bit(vector, growthRate, midpoint, minValue, maxValue, destination);
   }
 
+  /**
+   * Computes the quantization error (squared loss) for NVQ quantization with logistic function.
+   *
+   * @param vector the vector to quantize
+   * @param growthRate the growth rate parameter of the logistic quantization function
+   * @param midpoint the midpoint parameter of the logistic quantization function
+   * @param minValue the minimum value for quantization
+   * @param maxValue the maximum value for quantization
+   * @param nBits the number of bits per dimension
+   * @return the squared error of quantization
+   */
   public static float nvqLoss(VectorFloat<?> vector, float growthRate, float midpoint, float minValue, float maxValue, int nBits) {
     return impl.nvqLoss(vector, growthRate, midpoint, minValue, maxValue, nBits);
   }
 
+  /**
+   * Computes the quantization error (squared loss) for uniform quantization.
+   *
+   * @param vector the vector to quantize
+   * @param minValue the minimum value for quantization
+   * @param maxValue the maximum value for quantization
+   * @param nBits the number of bits per dimension
+   * @return the squared error of quantization
+   */
   public static float nvqUniformLoss(VectorFloat<?> vector, float minValue, float maxValue, int nBits) {
     return impl.nvqUniformLoss(vector, minValue, maxValue, nBits);
   }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
@@ -35,55 +35,161 @@ import java.util.List;
  */
 public interface VectorUtilSupport {
 
-  /** Calculates the dot product of the given float arrays. */
+  /**
+   * Calculates the dot product of the given float arrays.
+   *
+   * @param a the first vector
+   * @param b the second vector
+   * @return the dot product of the two vectors
+   */
   float dotProduct(VectorFloat<?> a, VectorFloat<?> b);
 
-  /** Calculates the dot product of float arrays of differing sizes, or a subset of the data */
+  /**
+   * Calculates the dot product of float arrays of differing sizes, or a subset of the data.
+   *
+   * @param a the first vector
+   * @param aoffset the starting offset in the first vector
+   * @param b the second vector
+   * @param boffset the starting offset in the second vector
+   * @param length the length of the subvectors to compute
+   * @return the dot product of the two subvectors
+   */
   float dotProduct(VectorFloat<?> a, int aoffset, VectorFloat<?> b, int boffset, int length);
 
-  /** Returns the cosine similarity between the two vectors. */
+  /**
+   * Returns the cosine similarity between the two vectors.
+   *
+   * @param v1 the first vector
+   * @param v2 the second vector
+   * @return the cosine similarity between the two vectors
+   */
   float cosine(VectorFloat<?> v1, VectorFloat<?> v2);
 
-  /** Calculates the cosine similarity of VectorFloats of differing sizes, or a subset of the data */
+  /**
+   * Calculates the cosine similarity of VectorFloats of differing sizes, or a subset of the data.
+   *
+   * @param a the first vector
+   * @param aoffset the starting offset in the first vector
+   * @param b the second vector
+   * @param boffset the starting offset in the second vector
+   * @param length the length of the subvectors to compute
+   * @return the cosine similarity between the two subvectors
+   */
   float cosine(VectorFloat<?> a, int aoffset, VectorFloat<?> b, int boffset, int length);
 
-  /** Returns the sum of squared differences of the two vectors. */
+  /**
+   * Returns the sum of squared differences of the two vectors.
+   *
+   * @param a the first vector
+   * @param b the second vector
+   * @return the squared Euclidean distance between the two vectors
+   */
   float squareDistance(VectorFloat<?> a, VectorFloat<?> b);
 
-  /** Calculates the sum of squared differences of float arrays of differing sizes, or a subset of the data */
+  /**
+   * Calculates the sum of squared differences of float arrays of differing sizes, or a subset of the data.
+   *
+   * @param a the first vector
+   * @param aoffset the starting offset in the first vector
+   * @param b the second vector
+   * @param boffset the starting offset in the second vector
+   * @param length the length of the subvectors to compute
+   * @return the squared Euclidean distance between the two subvectors
+   */
   float squareDistance(VectorFloat<?> a, int aoffset, VectorFloat<?> b, int boffset, int length);
 
-  /** returns the sum of the given vectors. */
+  /**
+   * Returns the element-wise sum of the given vectors.
+   *
+   * @param vectors the list of vectors to sum
+   * @return a new vector containing the element-wise sum of all input vectors
+   */
   VectorFloat<?> sum(List<VectorFloat<?>> vectors);
 
-  /** return the sum of the components of the vector */
+  /**
+   * Returns the sum of all components in the vector.
+   *
+   * @param vector the vector to sum
+   * @return the sum of all elements in the vector
+   */
   float sum(VectorFloat<?> vector);
 
-  /** Multiply vector by multiplier, in place (vector will be modified) */
+  /**
+   * Multiplies each element of the vector by the given multiplier in place.
+   *
+   * @param vector the vector to scale (will be modified)
+   * @param multiplier the scaling factor to apply to each element
+   */
   void scale(VectorFloat<?> vector, float multiplier);
 
-  /** Adds v2 into v1, in place (v1 will be modified) */
+  /**
+   * Adds the elements of v2 to the corresponding elements of v1 in place.
+   *
+   * @param v1 the vector to modify (will contain the sum)
+   * @param v2 the vector to add to v1
+   */
   void addInPlace(VectorFloat<?> v1, VectorFloat<?> v2);
 
-  /** Adds value to each element of v1, in place (v1 will be modified) */
+  /**
+   * Adds a scalar value to each element of v1 in place.
+   *
+   * @param v1 the vector to modify (will contain the result)
+   * @param value the scalar value to add to each element
+   */
   void addInPlace(VectorFloat<?> v1, float value);
 
-  /** Subtracts v2 from v1, in place (v1 will be modified) */
+  /**
+   * Subtracts the elements of v2 from the corresponding elements of v1 in place.
+   *
+   * @param v1 the vector to modify (will contain the difference)
+   * @param v2 the vector to subtract from v1
+   */
   void subInPlace(VectorFloat<?> v1, VectorFloat<?> v2);
 
-  /** Subtracts value from each element of v1, in place (v1 will be modified) */
+  /**
+   * Subtracts a scalar value from each element of the vector in place.
+   *
+   * @param vector the vector to modify (will contain the result)
+   * @param value the scalar value to subtract from each element
+   */
   void subInPlace(VectorFloat<?> vector, float value);
 
-  /** @return a - b, element-wise */
+  /**
+   * Subtracts b from a element-wise and returns a new vector.
+   *
+   * @param a the vector to subtract from
+   * @param b the vector to subtract
+   * @return a new vector containing the element-wise difference (a - b)
+   */
   VectorFloat<?> sub(VectorFloat<?> a, VectorFloat<?> b);
 
-  /** Subtracts value from each element of a */
+  /**
+   * Subtracts a scalar value from each element of a and returns a new vector.
+   *
+   * @param a the vector to subtract from
+   * @param value the scalar value to subtract from each element
+   * @return a new vector containing the result
+   */
   VectorFloat<?> sub(VectorFloat<?> a, float value);
 
-  /** @return a - b, element-wise, starting at aOffset and bOffset respectively */
+  /**
+   * Subtracts subvectors element-wise and returns a new vector.
+   *
+   * @param a the first vector
+   * @param aOffset the starting offset in the first vector
+   * @param b the second vector
+   * @param bOffset the starting offset in the second vector
+   * @param length the length of the subvectors
+   * @return a new vector containing the element-wise difference starting at the specified offsets
+   */
   VectorFloat<?> sub(VectorFloat<?> a, int aOffset, VectorFloat<?> b, int bOffset, int length);
 
-  /** Calculates the minimum value for every corresponding lane values in v1 and v2, in place (v1 will be modified) */
+  /**
+   * Computes the element-wise minimum of two vectors and stores the result in v1.
+   *
+   * @param v1 the first vector (will be modified to contain the minimums)
+   * @param v2 the second vector
+   */
   void minInPlace(VectorFloat<?> v1, VectorFloat<?> v2);
 
   /**
@@ -130,6 +236,13 @@ public interface VectorUtilSupport {
    */
   float assembleAndSumPQ(VectorFloat<?> codebookPartialSums, int subspaceCount, ByteSequence<?> vector1Ordinals, int vector1OrdinalOffset, ByteSequence<?> node2Ordinals, int node2OrdinalOffset, int clusterCount);
 
+  /**
+   * Computes the Hamming distance between two bit vectors represented as long arrays.
+   *
+   * @param v1 the first bit vector
+   * @param v2 the second bit vector
+   * @return the number of bit positions where the two vectors differ
+   */
   int hammingDistance(long[] v1, long[] v2);
 
   // default implementation used here because Panama SIMD can't express necessary SIMD operations and degrades to scalar
@@ -143,6 +256,8 @@ public interface VectorUtilSupport {
    * @param quantizedPartials The quantized precomputed score fragments for each codebook entry. These are stored as a contiguous vector of all
    *                          the fragments for one codebook, followed by all the fragments for the next codebook, and so on. These have been
    *                          quantized by quantizePartialSums.
+   * @param delta the quantization delta used for dequantizing scores
+   * @param minDistance the minimum distance used during quantization
    * @param vsf      The similarity function to use.
    * @param results  The output vector to store the similarity scores. This should be pre-allocated to the same size as the number of shuffles.
    */
@@ -219,8 +334,33 @@ public interface VectorUtilSupport {
     }
   }
 
+  /**
+   * Calculates partial similarity sums for PQ codebook clusters against a query subvector.
+   *
+   * @param codebook the codebook containing all centroid vectors
+   * @param codebookIndex the index of the codebook to use
+   * @param size the dimensionality of each centroid vector
+   * @param clusterCount the number of clusters in the codebook
+   * @param query the query vector
+   * @param offset the starting offset in the query vector for this subspace
+   * @param vsf the vector similarity function to use
+   * @param partialSums output vector to store the computed partial sums
+   */
   void calculatePartialSums(VectorFloat<?> codebook, int codebookIndex, int size, int clusterCount, VectorFloat<?> query, int offset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums);
 
+  /**
+   * Calculates partial similarity sums and best distances for PQ codebook clusters against a query subvector.
+   *
+   * @param codebook the codebook containing all centroid vectors
+   * @param codebookIndex the index of the codebook to use
+   * @param size the dimensionality of each centroid vector
+   * @param clusterCount the number of clusters in the codebook
+   * @param query the query vector
+   * @param offset the starting offset in the query vector for this subspace
+   * @param vsf the vector similarity function to use
+   * @param partialSums output vector to store the computed partial sums
+   * @param partialMins output vector to store the best distances per cluster
+   */
   void calculatePartialSums(VectorFloat<?> codebook, int codebookIndex, int size, int clusterCount, VectorFloat<?> query, int offset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums, VectorFloat<?> partialMins);
 
   /**
@@ -237,14 +377,49 @@ public interface VectorUtilSupport {
    */
   void quantizePartials(float delta, VectorFloat<?> partials, VectorFloat<?> partialBases, ByteSequence<?> quantizedPartials);
 
+  /**
+   * Calculates the maximum value in the vector.
+   *
+   * @param v the vector to search
+   * @return the maximum value in the vector
+   */
   float max(VectorFloat<?> v);
+
+  /**
+   * Calculates the minimum value in the vector.
+   *
+   * @param v the vector to search
+   * @return the minimum value in the vector
+   */
   float min(VectorFloat<?> v);
 
+  /**
+   * Computes cosine similarity between a PQ-encoded vector and a query using precomputed partial sums and magnitudes.
+   *
+   * @param encoded the PQ-encoded vector (centroid indices)
+   * @param clusterCount the number of clusters per subspace
+   * @param partialSums precomputed dot products between query and codebook centroids
+   * @param aMagnitude precomputed squared magnitudes of codebook centroids
+   * @param bMagnitude the magnitude of the second vector
+   * @return the cosine similarity score
+   */
   default float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude)
   {
     return pqDecodedCosineSimilarity(encoded, 0, encoded.length(), clusterCount, partialSums, aMagnitude, bMagnitude);
   }
 
+  /**
+   * Computes cosine similarity between a PQ-encoded vector subset and a query using precomputed partial sums and magnitudes.
+   *
+   * @param encoded the PQ-encoded vector (centroid indices)
+   * @param encodedOffset the starting offset within the encoded sequence
+   * @param encodedLength the length of the encoded sequence to use
+   * @param clusterCount the number of clusters per subspace
+   * @param partialSums precomputed dot products between query and codebook centroids
+   * @param aMagnitude precomputed squared magnitudes of codebook centroids
+   * @param bMagnitude the magnitude of the second vector
+   * @return the cosine similarity score
+   */
   default float pqDecodedCosineSimilarity(ByteSequence<?> encoded, int encodedOffset, int encodedLength, int clusterCount, VectorFloat<?> partialSums, VectorFloat<?> aMagnitude, float bMagnitude)
   {
     float sum = 0.0f;
@@ -326,6 +501,7 @@ public interface VectorUtilSupport {
    * @param minValue The minimum value of the subvector
    * @param maxValue The maximum value of the subvector
    * @param nBits the number of bits per dimension
+   * @return the squared error of quantization
    */
   float nvqLoss(VectorFloat<?> vector, float growthRate, float midpoint, float minValue, float maxValue, int nBits);
 
@@ -335,6 +511,7 @@ public interface VectorUtilSupport {
    * @param minValue The minimum value of the subvector
    * @param maxValue The maximum value of the subvector
    * @param nBits the number of bits per dimension
+   * @return the squared error of quantization
    */
   float nvqUniformLoss(VectorFloat<?> vector, float minValue, float maxValue, int nBits);
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorizationProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorizationProvider.java
@@ -46,12 +46,16 @@ public abstract class VectorizationProvider {
   /**
    * Returns the default instance of the provider matching vectorization possibilities of actual
    * runtime.
+   * @return the return value
    */
   public static VectorizationProvider getInstance() {
     return Objects.requireNonNull(
         Holder.INSTANCE, "call to getInstance() from subclass of VectorizationProvider");
   }
 
+  /**
+   * Protected constructor for subclasses to extend the vectorization provider.
+   */
   protected VectorizationProvider() {
 
   }
@@ -59,17 +63,20 @@ public abstract class VectorizationProvider {
   /**
    * Returns a singleton (stateless) {@link VectorUtilSupport} to support SIMD usage in {@link
    * VectorUtil}.
+   * @return the return value
    */
   public abstract VectorUtilSupport getVectorUtilSupport();
 
   /**
    * Returns a singleton (stateless) {@link VectorTypeSupport} which works with the corresponding {@link VectorUtilSupport}
    * implementation
+   * @return the return value
    */
   public abstract VectorTypeSupport getVectorTypeSupport();
 
   // *** Lookup mechanism: ***
 
+  /** Logger for vectorization provider messages */
   protected static final Logger LOG = Logger.getLogger(VectorizationProvider.class.getName());
 
   /** The minimal version of Java that has the bugfix for JDK-8301190. */

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/ByteSequence.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/ByteSequence.java
@@ -19,33 +19,77 @@ package io.github.jbellis.jvector.vector.types;
 import io.github.jbellis.jvector.util.Accountable;
 import java.util.Objects;
 
+/**
+ * A sequence of bytes with offset and length.
+ * @param <T> the T type parameter
+ */
 public interface ByteSequence<T> extends Accountable
 {
     /**
+     * Gets the entire sequence backing storage.
      * @return entire sequence backing storage
      */
     T get();
 
+    /**
+     * Gets the offset.
+     * @return the offset
+     */
     int offset();
 
+    /**
+     * Gets the length.
+     * @return the length
+     */
     int length();
 
+    /**
+     * Gets the byte at the specified index.
+     * @param i the index
+     * @return the byte
+     */
     byte get(int i);
 
+    /**
+     * Sets the byte at the specified index.
+     * @param i the index
+     * @param value the value
+     */
     void set(int i, byte value);
 
     /**
+     * Sets a short value in little-endian format.
      * @param shortIndex index (as if this was a short array) inside the sequence to set the short value
      * @param value short value to set
      */
     void setLittleEndianShort(int shortIndex, short value);
 
+    /**
+     * Zeroes the sequence.
+     */
     void zero();
 
+    /**
+     * Copies from another sequence.
+     * @param src the source sequence
+     * @param srcOffset the source offset
+     * @param destOffset the destination offset
+     * @param length the length
+     */
     void copyFrom(ByteSequence<?> src, int srcOffset, int destOffset, int length);
 
+    /**
+     * Creates a copy of the sequence.
+     * @return the copy
+     */
     ByteSequence<T> copy();
 
+    /**
+     * Creates a slice of the sequence.
+     * @param offset the offset
+     * @param length the length
+     * @return the slice
+     */
     ByteSequence<T>  slice(int offset, int length);
 
     /**
@@ -65,6 +109,7 @@ public interface ByteSequence<T> extends Accountable
     }
 
     /**
+     * Computes a hash code for this ByteSequence.
      * @return a hash code for this ByteSequence
      */
     default int getHashCode() {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/VectorFloat.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/VectorFloat.java
@@ -18,29 +18,69 @@ package io.github.jbellis.jvector.vector.types;
 
 import io.github.jbellis.jvector.util.Accountable;
 
+/**
+ * A generic interface for float vector storage and manipulation, parameterized by backing storage type T.
+ * @param <T> the type of the backing storage (e.g., float[] or ByteBuffer)
+ */
 public interface VectorFloat<T> extends Accountable
 {
     /**
+     * Gets the entire vector backing storage.
      * @return entire vector backing storage
      */
     T get();
 
+    /**
+     * Gets the length of the vector.
+     * @return the length of the vector
+     */
     int length();
 
+    /**
+     * Computes the physical offset in the backing storage for the logical vector index.
+     * @param i the logical index in the vector
+     * @return the physical offset in the backing storage
+     */
     default int offset(int i) {
         return i;
     }
 
+    /**
+     * Creates a copy of this vector.
+     * @return a copy of this vector
+     */
     VectorFloat<T> copy();
 
+    /**
+     * Copy from another vector.
+     * @param src the source vector
+     * @param srcOffset the source offset
+     * @param destOffset the destination offset
+     * @param length the length to copy
+     */
     void copyFrom(VectorFloat<?> src, int srcOffset, int destOffset, int length);
 
+    /**
+     * Get the value at the specified index.
+     * @param i the index
+     * @return the value at index i
+     */
     float get(int i);
 
+    /**
+     * Set the value at the specified index.
+     * @param i the index
+     * @param value the value to set
+     */
     void set(int i, float value);
 
+    /** Set all values to zero. */
     void zero();
 
+    /**
+     * Computes a hash code for this vector based on its non-zero elements.
+     * @return the hash code for this vector
+     */
     default int getHashCode() {
         int result = 1;
         for (int i = 0; i < length(); i++) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/VectorTypeSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/VectorTypeSupport.java
@@ -21,6 +21,10 @@ import io.github.jbellis.jvector.disk.RandomAccessReader;
 import java.io.DataOutput;
 import java.io.IOException;
 
+/**
+ * Interface for vector type serialization and deserialization operations.
+ * Provides support for converting between different vector representations and I/O operations.
+ */
 public interface VectorTypeSupport {
     /**
      * Create a vector from the given data.
@@ -42,7 +46,7 @@ public interface VectorTypeSupport {
      * @param r the reader to read the vector from.
      * @param size the size of the vector to read.
      * @return the vector.
-     * @throws IOException
+     * @throws IOException if an I/O error occurs during reading
      */
     VectorFloat<?> readFloatVector(RandomAccessReader r, int size) throws IOException;
 
@@ -52,7 +56,7 @@ public interface VectorTypeSupport {
      * @param size the size of the vector to read.
      * @param vector the vector to store the read data in.
      * @param offset the offset in the vector to store the read data at.
-     * @throws IOException
+     * @throws IOException if an I/O error occurs during reading
      */
     void readFloatVector(RandomAccessReader r, int size, VectorFloat<?> vector, int offset) throws IOException;
 
@@ -60,7 +64,7 @@ public interface VectorTypeSupport {
      * Write the given vector to the given DataOutput.
      * @param out the output to write the vector to.
      * @param vector the vector to write.
-     * @throws IOException
+     * @throws IOException if an I/O error occurs during writing
      */
     void writeFloatVector(DataOutput out, VectorFloat<?> vector) throws IOException;
 
@@ -79,9 +83,28 @@ public interface VectorTypeSupport {
      */
     ByteSequence<?> createByteSequence(int length);
 
+    /**
+     * Read a byte sequence from the given RandomAccessReader.
+     * @param r the reader to read the byte sequence from
+     * @param size the size of the byte sequence to read
+     * @return the byte sequence
+     * @throws IOException if an I/O error occurs during reading
+     */
     ByteSequence<?> readByteSequence(RandomAccessReader r, int size) throws IOException;
 
+    /**
+     * Read a byte sequence from the given RandomAccessReader and store it in the given sequence.
+     * @param r the reader to read the byte sequence from
+     * @param sequence the byte sequence to store the read data in
+     * @throws IOException if an I/O error occurs during reading
+     */
     void readByteSequence(RandomAccessReader r, ByteSequence<?> sequence) throws IOException;
 
+    /**
+     * Write the given byte sequence to the given DataOutput.
+     * @param out the output to write the byte sequence to
+     * @param sequence the byte sequence to write
+     * @throws IOException if an I/O error occurs during writing
+     */
     void writeByteSequence(DataOutput out, ByteSequence<?> sequence) throws IOException;
 }

--- a/jvector-examples/pom.xml
+++ b/jvector-examples/pom.xml
@@ -26,6 +26,21 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalJOptions>
+                        <additionalJOption>--add-modules=jdk.incubator.vector</additionalJOption>
+                    </additionalJOptions>
+                    <release>22</release>
+                    <detectOfflineLinks>false</detectOfflineLinks>
+                    <includeDependencySources>true</includeDependencySources>
+                    <dependencySourceIncludes>
+                        <dependencySourceInclude>io.github.jbellis:*</dependencySourceInclude>
+                    </dependencySourceIncludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.6.0</version>
                 <configuration>

--- a/jvector-native/pom.xml
+++ b/jvector-native/pom.xml
@@ -49,6 +49,16 @@
                     </argLine>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalJOptions>
+                        <additionalJOption>--add-modules=jdk.incubator.vector</additionalJOption>
+                    </additionalJOptions>
+                    <release>22</release>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/disk/MemorySegmentReader.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/disk/MemorySegmentReader.java
@@ -145,10 +145,20 @@ public class MemorySegmentReader implements RandomAccessReader {
         // Individual readers don't close the shared memory
     }
 
+    /**
+     * Factory for creating MemorySegmentReader instances that share the same memory-mapped file.
+     * This supplier manages the lifecycle of the shared Arena and MemorySegment.
+     */
     public static class Supplier implements ReaderSupplier {
         private final Arena arena;
         private final MemorySegment memory;
 
+        /**
+         * Creates a new Supplier that memory-maps the file at the given path with MADV_RANDOM advice.
+         *
+         * @param path the path to the file to be memory-mapped for reading
+         * @throws IOException if the file cannot be opened or mapped, or if madvise fails
+         */
         public Supplier(Path path) throws IOException {
             this.arena = Arena.ofShared();
             try (var ch = FileChannel.open(path, StandardOpenOption.READ)) {

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentVectorProvider.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentVectorProvider.java
@@ -30,6 +30,13 @@ import java.nio.Buffer;
  */
 public class MemorySegmentVectorProvider implements VectorTypeSupport
 {
+    /**
+     * Creates a new MemorySegmentVectorProvider instance.
+     */
+    public MemorySegmentVectorProvider() {
+    }
+
+
     @Override
     public VectorFloat<?> createFloatVector(Object data)
     {

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorizationProvider.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorizationProvider.java
@@ -30,6 +30,12 @@ public class NativeVectorizationProvider extends VectorizationProvider {
     private final VectorUtilSupport vectorUtilSupport;
     private final VectorTypeSupport vectorTypeSupport;
 
+    /**
+     * Creates a new NativeVectorizationProvider using native SIMD operations via Panama FFI.
+     * Attempts to load the native jvector library and verifies CPU compatibility with required SIMD instructions.
+     *
+     * @throws UnsupportedOperationException if the native library fails to load or if the CPU lacks required SIMD support
+     */
     public NativeVectorizationProvider() {
         var libraryLoaded = LibraryLoader.loadJvector();
         if (!libraryLoaded) {

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/LibraryLoader.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/LibraryLoader.java
@@ -25,6 +25,13 @@ import java.nio.file.Files;
  */
 public class LibraryLoader {
     private LibraryLoader() {}
+
+    /**
+     * Attempts to load the jvector native library. First tries to load from the system library path.
+     * If that fails, extracts the library from classpath resources to a temporary directory and loads it from there.
+     *
+     * @return true if the library was successfully loaded, false otherwise
+     */
     public static boolean loadJvector() {
         try {
             System.loadLibrary("jvector");

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/NativeSimdOps.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/NativeSimdOps.java
@@ -12,6 +12,10 @@ import java.util.stream.*;
 import static java.lang.foreign.ValueLayout.*;
 import static java.lang.foreign.MemoryLayout.PathElement.*;
 
+/**
+ * Native SIMD operations for high-performance vector computations using hardware acceleration.
+ * This class provides JNI bindings to optimized native code that leverages AVX-512 and other SIMD instructions.
+ */
 public class NativeSimdOps {
 
     NativeSimdOps() {
@@ -58,21 +62,31 @@ public class NativeSimdOps {
     static final SymbolLookup SYMBOL_LOOKUP = SymbolLookup.loaderLookup()
             .or(Linker.nativeLinker().defaultLookup());
 
+    /** C boolean type layout for native interop */
     public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;
+    /** C char type layout (mapped to Java byte) for native interop */
     public static final ValueLayout.OfByte C_CHAR = ValueLayout.JAVA_BYTE;
+    /** C short type layout for native interop */
     public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT;
+    /** C int type layout for native interop */
     public static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT;
+    /** C long long type layout for native interop */
     public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG;
+    /** C float type layout for native interop */
     public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT;
+    /** C double type layout for native interop */
     public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
+    /** C pointer type layout with byte array target for native interop */
     public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
             .withTargetLayout(MemoryLayout.sequenceLayout(java.lang.Long.MAX_VALUE, JAVA_BYTE));
+    /** C long type layout for native interop */
     public static final ValueLayout.OfLong C_LONG = ValueLayout.JAVA_LONG;
     private static final int true_ = (int)1L;
     /**
      * {@snippet lang=c :
      * #define true 1
      * }
+     * @return the C boolean true value (1)
      */
     public static int true_() {
         return true_;
@@ -82,6 +96,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * #define false 0
      * }
+     * @return the C boolean false value (0)
      */
     public static int false_() {
         return false_;
@@ -91,6 +106,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * #define __bool_true_false_are_defined 1
      * }
+     * @return the value indicating that boolean true and false are defined (1)
      */
     public static int __bool_true_false_are_defined() {
         return __bool_true_false_are_defined;
@@ -110,6 +126,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * _Bool check_compatibility()
      * }
+     * @return the function descriptor for check_compatibility
      */
     public static FunctionDescriptor check_compatibility$descriptor() {
         return check_compatibility.DESC;
@@ -120,6 +137,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * _Bool check_compatibility()
      * }
+     * @return the method handle for invoking check_compatibility
      */
     public static MethodHandle check_compatibility$handle() {
         return check_compatibility.HANDLE;
@@ -130,15 +148,18 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * _Bool check_compatibility()
      * }
+     * @return the memory address of the check_compatibility native function
      */
     public static MemorySegment check_compatibility$address() {
         return check_compatibility.ADDR;
     }
 
     /**
+     * Checks if the native library is compatible with the current system's CPU features.
      * {@snippet lang=c :
      * _Bool check_compatibility()
      * }
+     * @return true if the native SIMD operations are compatible with this CPU, false otherwise
      */
     public static boolean check_compatibility() {
         var mh$ = check_compatibility.HANDLE;
@@ -173,6 +194,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float dot_product_f32(int preferred_size, const float *a, int aoffset, const float *b, int boffset, int length)
      * }
+     * @return the function descriptor for dot_product_f32
      */
     public static FunctionDescriptor dot_product_f32$descriptor() {
         return dot_product_f32.DESC;
@@ -183,6 +205,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float dot_product_f32(int preferred_size, const float *a, int aoffset, const float *b, int boffset, int length)
      * }
+     * @return the method handle for invoking dot_product_f32
      */
     public static MethodHandle dot_product_f32$handle() {
         return dot_product_f32.HANDLE;
@@ -193,15 +216,24 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float dot_product_f32(int preferred_size, const float *a, int aoffset, const float *b, int boffset, int length)
      * }
+     * @return the memory address of the dot_product_f32 native function
      */
     public static MemorySegment dot_product_f32$address() {
         return dot_product_f32.ADDR;
     }
 
     /**
+     * Computes the dot product of two float32 vectors using SIMD operations.
      * {@snippet lang=c :
      * float dot_product_f32(int preferred_size, const float *a, int aoffset, const float *b, int boffset, int length)
      * }
+     * @param preferred_size the preferred SIMD vector size in bits (e.g., 128, 256, 512)
+     * @param a memory segment containing the first vector's data
+     * @param aoffset starting offset in the first vector (element index, not byte offset)
+     * @param b memory segment containing the second vector's data
+     * @param boffset starting offset in the second vector (element index, not byte offset)
+     * @param length number of float elements to process in the dot product calculation
+     * @return the computed dot product as a float value
      */
     public static float dot_product_f32(int preferred_size, MemorySegment a, int aoffset, MemorySegment b, int boffset, int length) {
         var mh$ = dot_product_f32.HANDLE;
@@ -236,6 +268,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float euclidean_f32(int preferred_size, const float *a, int aoffset, const float *b, int boffset, int length)
      * }
+     * @return the function descriptor for euclidean_f32
      */
     public static FunctionDescriptor euclidean_f32$descriptor() {
         return euclidean_f32.DESC;
@@ -246,6 +279,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float euclidean_f32(int preferred_size, const float *a, int aoffset, const float *b, int boffset, int length)
      * }
+     * @return the method handle for invoking euclidean_f32
      */
     public static MethodHandle euclidean_f32$handle() {
         return euclidean_f32.HANDLE;
@@ -256,15 +290,24 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float euclidean_f32(int preferred_size, const float *a, int aoffset, const float *b, int boffset, int length)
      * }
+     * @return the memory address of the euclidean_f32 native function
      */
     public static MemorySegment euclidean_f32$address() {
         return euclidean_f32.ADDR;
     }
 
     /**
+     * Computes the squared Euclidean distance between two float32 vectors using SIMD operations.
      * {@snippet lang=c :
      * float euclidean_f32(int preferred_size, const float *a, int aoffset, const float *b, int boffset, int length)
      * }
+     * @param preferred_size the preferred SIMD vector size in bits (e.g., 128, 256, 512)
+     * @param a memory segment containing the first vector's data
+     * @param aoffset starting offset in the first vector (element index, not byte offset)
+     * @param b memory segment containing the second vector's data
+     * @param boffset starting offset in the second vector (element index, not byte offset)
+     * @param length number of float elements to process in the distance calculation
+     * @return the computed squared Euclidean distance as a float value
      */
     public static float euclidean_f32(int preferred_size, MemorySegment a, int aoffset, MemorySegment b, int boffset, int length) {
         var mh$ = euclidean_f32.HANDLE;
@@ -298,6 +341,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_dot_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
+     * @return the function descriptor for bulk_quantized_shuffle_dot_f32_512
      */
     public static FunctionDescriptor bulk_quantized_shuffle_dot_f32_512$descriptor() {
         return bulk_quantized_shuffle_dot_f32_512.DESC;
@@ -308,6 +352,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_dot_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
+     * @return the method handle for invoking bulk_quantized_shuffle_dot_f32_512
      */
     public static MethodHandle bulk_quantized_shuffle_dot_f32_512$handle() {
         return bulk_quantized_shuffle_dot_f32_512.HANDLE;
@@ -318,15 +363,24 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_dot_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
+     * @return the memory address of the bulk_quantized_shuffle_dot_f32_512 native function
      */
     public static MemorySegment bulk_quantized_shuffle_dot_f32_512$address() {
         return bulk_quantized_shuffle_dot_f32_512.ADDR;
     }
 
     /**
+     * Performs bulk computation of dot product similarity scores for quantized vectors using AVX-512 shuffle operations.
+     * Dequantizes partial dot products and computes final similarity scores in a vectorized manner.
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_dot_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
+     * @param shuffles memory segment containing shuffle indices for rearranging quantized values
+     * @param codebookCount number of codebooks used in the product quantization scheme
+     * @param quantizedPartials memory segment containing quantized partial dot product values
+     * @param delta quantization scale factor for converting quantized values to float
+     * @param minDistance minimum distance offset used during quantization
+     * @param results output memory segment where computed similarity scores will be written
      */
     public static void bulk_quantized_shuffle_dot_f32_512(MemorySegment shuffles, int codebookCount, MemorySegment quantizedPartials, float delta, float minDistance, MemorySegment results) {
         var mh$ = bulk_quantized_shuffle_dot_f32_512.HANDLE;
@@ -360,6 +414,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_euclidean_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
+     * @return the function descriptor for bulk_quantized_shuffle_euclidean_f32_512
      */
     public static FunctionDescriptor bulk_quantized_shuffle_euclidean_f32_512$descriptor() {
         return bulk_quantized_shuffle_euclidean_f32_512.DESC;
@@ -370,6 +425,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_euclidean_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
+     * @return the method handle for invoking bulk_quantized_shuffle_euclidean_f32_512
      */
     public static MethodHandle bulk_quantized_shuffle_euclidean_f32_512$handle() {
         return bulk_quantized_shuffle_euclidean_f32_512.HANDLE;
@@ -380,15 +436,24 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_euclidean_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
+     * @return the memory address of the bulk_quantized_shuffle_euclidean_f32_512 native function
      */
     public static MemorySegment bulk_quantized_shuffle_euclidean_f32_512$address() {
         return bulk_quantized_shuffle_euclidean_f32_512.ADDR;
     }
 
     /**
+     * Performs bulk computation of Euclidean distance scores for quantized vectors using AVX-512 shuffle operations.
+     * Dequantizes partial distances and computes final distance scores in a vectorized manner.
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_euclidean_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartials, float delta, float minDistance, float *results)
      * }
+     * @param shuffles memory segment containing shuffle indices for rearranging quantized values
+     * @param codebookCount number of codebooks used in the product quantization scheme
+     * @param quantizedPartials memory segment containing quantized partial distance values
+     * @param delta quantization scale factor for converting quantized values to float
+     * @param minDistance minimum distance offset used during quantization
+     * @param results output memory segment where computed distance scores will be written
      */
     public static void bulk_quantized_shuffle_euclidean_f32_512(MemorySegment shuffles, int codebookCount, MemorySegment quantizedPartials, float delta, float minDistance, MemorySegment results) {
         var mh$ = bulk_quantized_shuffle_euclidean_f32_512.HANDLE;
@@ -426,6 +491,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_cosine_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartialSums, float sumDelta, float minDistance, const char *quantizedPartialMagnitudes, float magnitudeDelta, float minMagnitude, float queryMagnitudeSquared, float *results)
      * }
+     * @return the function descriptor for bulk_quantized_shuffle_cosine_f32_512
      */
     public static FunctionDescriptor bulk_quantized_shuffle_cosine_f32_512$descriptor() {
         return bulk_quantized_shuffle_cosine_f32_512.DESC;
@@ -436,6 +502,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_cosine_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartialSums, float sumDelta, float minDistance, const char *quantizedPartialMagnitudes, float magnitudeDelta, float minMagnitude, float queryMagnitudeSquared, float *results)
      * }
+     * @return the method handle for invoking bulk_quantized_shuffle_cosine_f32_512
      */
     public static MethodHandle bulk_quantized_shuffle_cosine_f32_512$handle() {
         return bulk_quantized_shuffle_cosine_f32_512.HANDLE;
@@ -446,15 +513,28 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_cosine_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartialSums, float sumDelta, float minDistance, const char *quantizedPartialMagnitudes, float magnitudeDelta, float minMagnitude, float queryMagnitudeSquared, float *results)
      * }
+     * @return the memory address of the bulk_quantized_shuffle_cosine_f32_512 native function
      */
     public static MemorySegment bulk_quantized_shuffle_cosine_f32_512$address() {
         return bulk_quantized_shuffle_cosine_f32_512.ADDR;
     }
 
     /**
+     * Performs bulk computation of cosine similarity scores for quantized vectors using AVX-512 shuffle operations.
+     * Dequantizes both partial dot products and vector magnitudes to compute final cosine similarity scores.
      * {@snippet lang=c :
      * void bulk_quantized_shuffle_cosine_f32_512(const unsigned char *shuffles, int codebookCount, const char *quantizedPartialSums, float sumDelta, float minDistance, const char *quantizedPartialMagnitudes, float magnitudeDelta, float minMagnitude, float queryMagnitudeSquared, float *results)
      * }
+     * @param shuffles memory segment containing shuffle indices for rearranging quantized values
+     * @param codebookCount number of codebooks used in the product quantization scheme
+     * @param quantizedPartialSums memory segment containing quantized partial dot product sums
+     * @param sumDelta quantization scale factor for converting quantized sums to float
+     * @param minDistance minimum distance offset used during sum quantization
+     * @param quantizedPartialMagnitudes memory segment containing quantized partial vector magnitudes
+     * @param magnitudeDelta quantization scale factor for converting quantized magnitudes to float
+     * @param minMagnitude minimum magnitude offset used during magnitude quantization
+     * @param queryMagnitudeSquared squared magnitude of the query vector for normalization
+     * @param results output memory segment where computed cosine similarity scores will be written
      */
     public static void bulk_quantized_shuffle_cosine_f32_512(MemorySegment shuffles, int codebookCount, MemorySegment quantizedPartialSums, float sumDelta, float minDistance, MemorySegment quantizedPartialMagnitudes, float magnitudeDelta, float minMagnitude, float queryMagnitudeSquared, MemorySegment results) {
         var mh$ = bulk_quantized_shuffle_cosine_f32_512.HANDLE;
@@ -488,6 +568,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float assemble_and_sum_f32_512(const float *data, int dataBase, const unsigned char *baseOffsets, int baseOffsetsOffset, int baseOffsetsLength)
      * }
+     * @return the function descriptor for assemble_and_sum_f32_512
      */
     public static FunctionDescriptor assemble_and_sum_f32_512$descriptor() {
         return assemble_and_sum_f32_512.DESC;
@@ -498,6 +579,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float assemble_and_sum_f32_512(const float *data, int dataBase, const unsigned char *baseOffsets, int baseOffsetsOffset, int baseOffsetsLength)
      * }
+     * @return the method handle for invoking assemble_and_sum_f32_512
      */
     public static MethodHandle assemble_and_sum_f32_512$handle() {
         return assemble_and_sum_f32_512.HANDLE;
@@ -508,15 +590,24 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float assemble_and_sum_f32_512(const float *data, int dataBase, const unsigned char *baseOffsets, int baseOffsetsOffset, int baseOffsetsLength)
      * }
+     * @return the memory address of the assemble_and_sum_f32_512 native function
      */
     public static MemorySegment assemble_and_sum_f32_512$address() {
         return assemble_and_sum_f32_512.ADDR;
     }
 
     /**
+     * Assembles float values from scattered locations in memory using byte offsets and computes their sum using AVX-512 operations.
+     * Useful for gathering partial results indexed by offsets and combining them efficiently.
      * {@snippet lang=c :
      * float assemble_and_sum_f32_512(const float *data, int dataBase, const unsigned char *baseOffsets, int baseOffsetsOffset, int baseOffsetsLength)
      * }
+     * @param data memory segment containing the source float data array
+     * @param dataBase base index into the data array where lookups begin
+     * @param baseOffsets memory segment containing byte offsets for gathering values from data
+     * @param baseOffsetsOffset starting position in the baseOffsets array
+     * @param baseOffsetsLength number of offsets to process from baseOffsets
+     * @return the sum of all assembled float values
      */
     public static float assemble_and_sum_f32_512(MemorySegment data, int dataBase, MemorySegment baseOffsets, int baseOffsetsOffset, int baseOffsetsLength) {
         var mh$ = assemble_and_sum_f32_512.HANDLE;
@@ -552,6 +643,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float pq_decoded_cosine_similarity_f32_512(const unsigned char *baseOffsets, int baseOffsetsOffset, int baseOffsetsLength, int clusterCount, const float *partialSums, const float *aMagnitude, float bMagnitude)
      * }
+     * @return the function descriptor for pq_decoded_cosine_similarity_f32_512
      */
     public static FunctionDescriptor pq_decoded_cosine_similarity_f32_512$descriptor() {
         return pq_decoded_cosine_similarity_f32_512.DESC;
@@ -562,6 +654,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float pq_decoded_cosine_similarity_f32_512(const unsigned char *baseOffsets, int baseOffsetsOffset, int baseOffsetsLength, int clusterCount, const float *partialSums, const float *aMagnitude, float bMagnitude)
      * }
+     * @return the method handle for invoking pq_decoded_cosine_similarity_f32_512
      */
     public static MethodHandle pq_decoded_cosine_similarity_f32_512$handle() {
         return pq_decoded_cosine_similarity_f32_512.HANDLE;
@@ -572,15 +665,26 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * float pq_decoded_cosine_similarity_f32_512(const unsigned char *baseOffsets, int baseOffsetsOffset, int baseOffsetsLength, int clusterCount, const float *partialSums, const float *aMagnitude, float bMagnitude)
      * }
+     * @return the memory address of the pq_decoded_cosine_similarity_f32_512 native function
      */
     public static MemorySegment pq_decoded_cosine_similarity_f32_512$address() {
         return pq_decoded_cosine_similarity_f32_512.ADDR;
     }
 
     /**
+     * Computes cosine similarity between product-quantized vectors using AVX-512 operations.
+     * Gathers partial dot products and magnitudes using offsets, then calculates normalized similarity.
      * {@snippet lang=c :
      * float pq_decoded_cosine_similarity_f32_512(const unsigned char *baseOffsets, int baseOffsetsOffset, int baseOffsetsLength, int clusterCount, const float *partialSums, const float *aMagnitude, float bMagnitude)
      * }
+     * @param baseOffsets memory segment containing byte offsets for gathering partial results
+     * @param baseOffsetsOffset starting position in the baseOffsets array
+     * @param baseOffsetsLength number of offsets to process
+     * @param clusterCount number of clusters per subspace in the product quantization
+     * @param partialSums memory segment containing precomputed partial dot product sums
+     * @param aMagnitude memory segment containing magnitude values for vector a's subspaces
+     * @param bMagnitude magnitude of vector b for normalization
+     * @return the computed cosine similarity score between the two vectors
      */
     public static float pq_decoded_cosine_similarity_f32_512(MemorySegment baseOffsets, int baseOffsetsOffset, int baseOffsetsLength, int clusterCount, MemorySegment partialSums, MemorySegment aMagnitude, float bMagnitude) {
         var mh$ = pq_decoded_cosine_similarity_f32_512.HANDLE;
@@ -615,6 +719,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums)
      * }
+     * @return the function descriptor for calculate_partial_sums_dot_f32_512
      */
     public static FunctionDescriptor calculate_partial_sums_dot_f32_512$descriptor() {
         return calculate_partial_sums_dot_f32_512.DESC;
@@ -625,6 +730,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums)
      * }
+     * @return the method handle for invoking calculate_partial_sums_dot_f32_512
      */
     public static MethodHandle calculate_partial_sums_dot_f32_512$handle() {
         return calculate_partial_sums_dot_f32_512.HANDLE;
@@ -635,15 +741,25 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums)
      * }
+     * @return the memory address of the calculate_partial_sums_dot_f32_512 native function
      */
     public static MemorySegment calculate_partial_sums_dot_f32_512$address() {
         return calculate_partial_sums_dot_f32_512.ADDR;
     }
 
     /**
+     * Calculates partial dot product sums between a query vector and all centroids in a product quantization codebook using AVX-512.
+     * Computes dot products of query subvectors with corresponding codebook cluster centroids for later lookup.
      * {@snippet lang=c :
      * void calculate_partial_sums_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums)
      * }
+     * @param codebook memory segment containing the product quantization codebook centroids
+     * @param codebookBase starting index in the codebook array
+     * @param size dimension of each codebook subvector
+     * @param clusterCount number of clusters (centroids) per codebook subspace
+     * @param query memory segment containing the query vector to compare
+     * @param queryOffset starting offset in the query vector
+     * @param partialSums output memory segment where partial dot product sums will be written
      */
     public static void calculate_partial_sums_dot_f32_512(MemorySegment codebook, int codebookBase, int size, int clusterCount, MemorySegment query, int queryOffset, MemorySegment partialSums) {
         var mh$ = calculate_partial_sums_dot_f32_512.HANDLE;
@@ -678,6 +794,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums)
      * }
+     * @return the function descriptor for calculate_partial_sums_euclidean_f32_512
      */
     public static FunctionDescriptor calculate_partial_sums_euclidean_f32_512$descriptor() {
         return calculate_partial_sums_euclidean_f32_512.DESC;
@@ -688,6 +805,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums)
      * }
+     * @return the method handle for invoking calculate_partial_sums_euclidean_f32_512
      */
     public static MethodHandle calculate_partial_sums_euclidean_f32_512$handle() {
         return calculate_partial_sums_euclidean_f32_512.HANDLE;
@@ -698,15 +816,25 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums)
      * }
+     * @return the memory address of the calculate_partial_sums_euclidean_f32_512 native function
      */
     public static MemorySegment calculate_partial_sums_euclidean_f32_512$address() {
         return calculate_partial_sums_euclidean_f32_512.ADDR;
     }
 
     /**
+     * Calculates partial squared Euclidean distances between a query vector and all centroids in a product quantization codebook using AVX-512.
+     * Computes squared distances of query subvectors from corresponding codebook cluster centroids for later lookup.
      * {@snippet lang=c :
      * void calculate_partial_sums_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums)
      * }
+     * @param codebook memory segment containing the product quantization codebook centroids
+     * @param codebookBase starting index in the codebook array
+     * @param size dimension of each codebook subvector
+     * @param clusterCount number of clusters (centroids) per codebook subspace
+     * @param query memory segment containing the query vector to compare
+     * @param queryOffset starting offset in the query vector
+     * @param partialSums output memory segment where partial squared distance sums will be written
      */
     public static void calculate_partial_sums_euclidean_f32_512(MemorySegment codebook, int codebookBase, int size, int clusterCount, MemorySegment query, int queryOffset, MemorySegment partialSums) {
         var mh$ = calculate_partial_sums_euclidean_f32_512.HANDLE;
@@ -742,6 +870,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_best_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
      * }
+     * @return the function descriptor for calculate_partial_sums_best_dot_f32_512
      */
     public static FunctionDescriptor calculate_partial_sums_best_dot_f32_512$descriptor() {
         return calculate_partial_sums_best_dot_f32_512.DESC;
@@ -752,6 +881,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_best_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
      * }
+     * @return the method handle for invoking calculate_partial_sums_best_dot_f32_512
      */
     public static MethodHandle calculate_partial_sums_best_dot_f32_512$handle() {
         return calculate_partial_sums_best_dot_f32_512.HANDLE;
@@ -762,15 +892,26 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_best_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
      * }
+     * @return the memory address of the calculate_partial_sums_best_dot_f32_512 native function
      */
     public static MemorySegment calculate_partial_sums_best_dot_f32_512$address() {
         return calculate_partial_sums_best_dot_f32_512.ADDR;
     }
 
     /**
+     * Calculates partial dot product sums and tracks the best (highest) distance for each subspace during product quantization.
+     * Useful for computing both approximations and bounds for nearest neighbor search optimization.
      * {@snippet lang=c :
      * void calculate_partial_sums_best_dot_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
      * }
+     * @param codebook memory segment containing the product quantization codebook centroids
+     * @param codebookBase starting index in the codebook array
+     * @param size dimension of each codebook subvector
+     * @param clusterCount number of clusters (centroids) per codebook subspace
+     * @param query memory segment containing the query vector to compare
+     * @param queryOffset starting offset in the query vector
+     * @param partialSums output memory segment where partial dot product sums will be written
+     * @param partialBestDistances output memory segment where the best (highest) dot product for each subspace will be written
      */
     public static void calculate_partial_sums_best_dot_f32_512(MemorySegment codebook, int codebookBase, int size, int clusterCount, MemorySegment query, int queryOffset, MemorySegment partialSums, MemorySegment partialBestDistances) {
         var mh$ = calculate_partial_sums_best_dot_f32_512.HANDLE;
@@ -806,6 +947,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_best_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
      * }
+     * @return the function descriptor for calculate_partial_sums_best_euclidean_f32_512
      */
     public static FunctionDescriptor calculate_partial_sums_best_euclidean_f32_512$descriptor() {
         return calculate_partial_sums_best_euclidean_f32_512.DESC;
@@ -816,6 +958,7 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_best_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
      * }
+     * @return the method handle for invoking calculate_partial_sums_best_euclidean_f32_512
      */
     public static MethodHandle calculate_partial_sums_best_euclidean_f32_512$handle() {
         return calculate_partial_sums_best_euclidean_f32_512.HANDLE;
@@ -826,15 +969,26 @@ public class NativeSimdOps {
      * {@snippet lang=c :
      * void calculate_partial_sums_best_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
      * }
+     * @return the memory address of the calculate_partial_sums_best_euclidean_f32_512 native function
      */
     public static MemorySegment calculate_partial_sums_best_euclidean_f32_512$address() {
         return calculate_partial_sums_best_euclidean_f32_512.ADDR;
     }
 
     /**
+     * Calculates partial squared Euclidean distances and tracks the best (lowest) distance for each subspace during product quantization.
+     * Useful for computing both approximations and bounds for nearest neighbor search optimization.
      * {@snippet lang=c :
      * void calculate_partial_sums_best_euclidean_f32_512(const float *codebook, int codebookBase, int size, int clusterCount, const float *query, int queryOffset, float *partialSums, float *partialBestDistances)
      * }
+     * @param codebook memory segment containing the product quantization codebook centroids
+     * @param codebookBase starting index in the codebook array
+     * @param size dimension of each codebook subvector
+     * @param clusterCount number of clusters (centroids) per codebook subspace
+     * @param query memory segment containing the query vector to compare
+     * @param queryOffset starting offset in the query vector
+     * @param partialSums output memory segment where partial squared distance sums will be written
+     * @param partialBestDistances output memory segment where the best (lowest) squared distance for each subspace will be written
      */
     public static void calculate_partial_sums_best_euclidean_f32_512(MemorySegment codebook, int codebookBase, int size, int clusterCount, MemorySegment query, int queryOffset, MemorySegment partialSums, MemorySegment partialBestDistances) {
         var mh$ = calculate_partial_sums_best_euclidean_f32_512.HANDLE;

--- a/jvector-twenty/pom.xml
+++ b/jvector-twenty/pom.xml
@@ -39,6 +39,16 @@
                     </argLine>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalJOptions>
+                        <additionalJOption>--add-modules=jdk.incubator.vector</additionalJOption>
+                    </additionalJOptions>
+                    <release>22</release>
+                </configuration>
+            </plugin>
 
         </plugins>
 

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorizationProvider.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorizationProvider.java
@@ -31,6 +31,9 @@ public class PanamaVectorizationProvider extends VectorizationProvider
     private final VectorUtilSupport vectorUtilSupport;
     private final VectorTypeSupport vectorTypeSupport;
 
+    /**
+     * Constructs a PanamaVectorizationProvider with SIMD-optimized vector operations using the Panama Vector API.
+     */
     public PanamaVectorizationProvider() {
         this.vectorUtilSupport = new PanamaVectorUtilSupport();
         LOG.info("Preferred f32 species is " + FloatVector.SPECIES_PREFERRED.vectorBitSize());


### PR DESCRIPTION
This is the second example of backfilling javadocs to jvector. This one covers all modules and files, fixes some javadoc generation issues, and has a lighter touch. Generally, it only adds javadocs where they are wholly or partially missing.

This is for us to look at while we consider which of the two javadoc options to go with, if either.