### PR TITLE
CNDB-15469: Add NVQunatization::create method that takes global mean

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/NVQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/NVQuantization.java
@@ -150,16 +150,17 @@ public class NVQuantization implements VectorCompressor<NVQuantization.Quantized
             VectorUtil.addInPlace(globalMean, ravvCopy.getVector(i));
         }
         VectorUtil.scale(globalMean, 1.0f / ravvCopy.size());
-        return compute(globalMean, nSubVectors);
+        return create(globalMean, nSubVectors);
     }
 
     /**
-     * Computes the global mean vector and the data structures used to divide each vector into subvectors.
+     * Creates a NVQuantization instance by using the global mean and computing the data structures used to divide each
+     * vector into subvectors.
      *
      * @param scaledGlobalMean the mean of the graph (its average vector)
      * @param nSubVectors number of subvectors
      */
-    public static NVQuantization compute(VectorFloat<?> scaledGlobalMean, int nSubVectors) {
+    public static NVQuantization create(VectorFloat<?> scaledGlobalMean, int nSubVectors) {
         var subvectorSizesAndOffsets = getSubvectorSizesAndOffsets(scaledGlobalMean.length(), nSubVectors);
         return new NVQuantization(subvectorSizesAndOffsets, scaledGlobalMean);
     }


### PR DESCRIPTION
In some applications, it will be better to compute the global mean iteratively at the time of insertion into the graph instead of when creating the `NVQuantization` object. Therefore, I propose adding a new `create` method that takes an already computed scaled global mean vector.

Because we update the existing `compute` method to call this new `create` method, the existing tests fully cover the new method.

This work is part of https://github.com/riptano/cndb/issues/15469.