### PR TITLE
Re-add OnDiskGraphIndex::getDimension

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -325,7 +325,7 @@ public class GraphIndexBuilder implements Closeable {
         this.simdExecutor = simdExecutor;
         this.parallelExecutor = parallelExecutor;
 
-        this.graph = new OnHeapGraphIndex(maxDegrees, neighborOverflow, new VamanaDiversityProvider(scoreProvider, alpha));
+        this.graph = new OnHeapGraphIndex(maxDegrees, dimension, neighborOverflow, new VamanaDiversityProvider(scoreProvider, alpha));
 
         this.searchers = ExplicitThreadLocal.withInitial(() -> {
             var gs = new GraphSearcher(graph);
@@ -1001,7 +1001,7 @@ public class GraphIndexBuilder implements Closeable {
 
         var diversityProvider = new VamanaDiversityProvider(buildScoreProvider, alpha);
 
-        try (MutableGraphIndex graph = OnHeapGraphIndex.load(in, overflowRatio, diversityProvider);) {
+        try (MutableGraphIndex graph = OnHeapGraphIndex.load(in, newVectors.dimension(), overflowRatio, diversityProvider);) {
 
             GraphIndexBuilder builder = new GraphIndexBuilder(
                     buildScoreProvider,

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ImmutableGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ImmutableGraphIndex.java
@@ -81,6 +81,11 @@ public interface ImmutableGraphIndex extends AutoCloseable, Accountable {
     List<Integer> maxDegrees();
 
     /**
+     * @return the dimension of the vectors in the graph
+     */
+    int getDimension();
+
+    /**
      * @return the first ordinal greater than all node ids in the graph.  Equal to size() in simple cases;
      * May be different from size() if nodes are being added concurrently, or if nodes have been
      * deleted (and cleaned up).

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/OnHeapGraphIndex.java
@@ -73,15 +73,17 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
 
     // Maximum number of neighbors (edges) per node per layer
     final List<Integer> maxDegrees;
+    private final int dimension;
     // The ratio by which we can overflow the neighborhood of a node during construction. Since it is a multiplicative
     // ratio, i.e., the maximum allowable degree if maxDegree * overflowRatio, it should be higher than 1.
     private final double overflowRatio;
 
     private volatile boolean allMutationsCompleted = false;
 
-    OnHeapGraphIndex(List<Integer> maxDegrees, double overflowRatio, DiversityProvider diversityProvider) {
+    OnHeapGraphIndex(List<Integer> maxDegrees, int dimension, double overflowRatio, DiversityProvider diversityProvider) {
         this.overflowRatio = overflowRatio;
         this.maxDegrees = new IntArrayList();
+        this.dimension = dimension;
         setDegrees(maxDegrees);
         entryPoint = new AtomicReference<>();
         this.completions = new CompletionTracker(1024);
@@ -370,6 +372,11 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
     }
 
     @Override
+    public int getDimension() {
+        return dimension;
+    }
+
+    @Override
     public void setAllMutationsCompleted() {
         allMutationsCompleted = true;
     }
@@ -541,7 +548,7 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
      */
     @Experimental
     @Deprecated
-    public static OnHeapGraphIndex load(RandomAccessReader in, double overflowRatio, DiversityProvider diversityProvider) throws IOException {
+    public static OnHeapGraphIndex load(RandomAccessReader in, int dimension, double overflowRatio, DiversityProvider diversityProvider) throws IOException {
         int magic = in.readInt(); // the magic number
         if (magic != OnHeapGraphIndex.MAGIC) {
             throw new IOException("Unsupported magic number: " + magic);
@@ -561,7 +568,7 @@ public class OnHeapGraphIndex implements MutableGraphIndex {
 
         int entryNode = in.readInt();
 
-        var graph = new OnHeapGraphIndex(layerDegrees, overflowRatio, diversityProvider);
+        var graph = new OnHeapGraphIndex(layerDegrees, dimension, overflowRatio, diversityProvider);
 
         Map<Integer, Integer> nodeLevelMap = new HashMap<>();
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -227,6 +227,7 @@ public class OnDiskGraphIndex implements ImmutableGraphIndex, AutoCloseable, Acc
         return features.keySet();
     }
 
+    @Override
     public int getDimension() {
         return dimension;
     }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/TestUtil.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/TestUtil.java
@@ -265,6 +265,11 @@ public class TestUtil {
         }
 
         @Override
+        public int getDimension() {
+            throw new NotImplementedException();
+        }
+
+        @Override
         public int getIdUpperBound() {
             return ImmutableGraphIndex.super.getIdUpperBound();
         }
@@ -421,6 +426,11 @@ public class TestUtil {
 
         @Override
         public List<Integer> maxDegrees() {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public int getDimension() {
             throw new NotImplementedException();
         }
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/OnHeapGraphIndexTest.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/OnHeapGraphIndexTest.java
@@ -151,7 +151,7 @@ public class OnHeapGraphIndexTest extends RandomizedTest  {
         log.info("Reading on-heap graph from {}", heapGraphOutputPath);
         MutableGraphIndex reconstructedOnHeapGraphIndex;
         try (var readerSupplier = new SimpleMappedReader.Supplier(heapGraphOutputPath.toAbsolutePath())) {
-            reconstructedOnHeapGraphIndex = OnHeapGraphIndex.load(readerSupplier.get(), NEIGHBOR_OVERFLOW, new VamanaDiversityProvider(baseBuildScoreProvider, ALPHA));
+            reconstructedOnHeapGraphIndex = OnHeapGraphIndex.load(readerSupplier.get(), baseVectorsRavv.dimension(), NEIGHBOR_OVERFLOW, new VamanaDiversityProvider(baseBuildScoreProvider, ALPHA));
         }
 
         try (var readerSupplier = new SimpleMappedReader.Supplier(graphOutputPath.toAbsolutePath());


### PR DESCRIPTION
This `getDimension` method was removed from the `OnDiskGraphIndex` class via https://github.com/datastax/jvector/pull/536. We use it in C*, so I propose adding it back in since it is a getter on a final field. 