### PR TITLE
adding average nodes visited to benchmark tests

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/AutoBenchYAML.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/AutoBenchYAML.java
@@ -193,7 +193,7 @@ public class AutoBenchYAML {
             // Write CSV data
             try (FileWriter writer = new FileWriter(outputFile)) {
                 // Write CSV header
-                writer.write("dataset,QPS,QPS StdDev,Mean Latency,Recall@10,Index Construction Time\n");
+                writer.write("dataset,QPS,QPS StdDev,Mean Latency,Recall@10,Index Construction Time,Avg Nodes Visited\n");
 
                 // Write one row per dataset with average metrics
                 for (Map.Entry<String, SummaryStats> entry : statsByDataset.entrySet()) {
@@ -205,7 +205,8 @@ public class AutoBenchYAML {
                     writer.write(datasetStats.getQpsStdDev() + ",");
                     writer.write(datasetStats.getAvgLatency() + ",");
                     writer.write(datasetStats.getAvgRecall() + ",");
-                    writer.write(datasetStats.getIndexConstruction() + "\n");
+                    writer.write(datasetStats.getIndexConstruction() + ",");
+                    writer.write(datasetStats.getAvgNodesVisited() + "\n");
                 }
             }
 

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -568,7 +568,8 @@ public class Grid {
                                                             ThroughputBenchmark.createDefault()),
                                                     LatencyBenchmark.createDefault(),
                                                     CountBenchmark.createDefault(),
-                                                    AccuracyBenchmark.createDefault()
+                                                    AccuracyBenchmark.createDefault(),
+                                                    CountBenchmark.createDefault()
                                             );
                                             QueryTester tester = new QueryTester(benchmarks);
                                             for (int topK : topKGrid.keySet()) {

--- a/jvector-examples/src/test/java/io/github/jbellis/jvector/example/util/BenchmarkSummarizerTest.java
+++ b/jvector-examples/src/test/java/io/github/jbellis/jvector/example/util/BenchmarkSummarizerTest.java
@@ -115,8 +115,8 @@ public class BenchmarkSummarizerTest {
     @Test
     public void testSummaryStatsToString() {
         // Create a SummaryStats instance
-        SummaryStats stats = new SummaryStats(0.85, 1200.0, 5.2, 1000000, 4);
-        
+        SummaryStats stats = new SummaryStats(0.85, 1200.0, 5.2, 1000000, 4, 0.2, 100)
+;
         // Verify toString output
         String expected = String.format(
             "Benchmark Summary (across %d configurations):%n" +

--- a/jvector-examples/src/test/java/io/github/jbellis/jvector/example/util/SummarizerTest.java
+++ b/jvector-examples/src/test/java/io/github/jbellis/jvector/example/util/SummarizerTest.java
@@ -121,7 +121,7 @@ public class SummarizerTest {
         System.out.println("\nTest: SummaryStats toString method");
         
         // Create a SummaryStats instance
-        SummaryStats stats = new SummaryStats(0.85, 1200.0, 5.2, 1000000, 4);
+        SummaryStats stats = new SummaryStats(0.85, 1200.0, 5.2, 1000000, 4, 0.2, 100);
         
         // Verify toString output
         String expected = String.format(

--- a/visualize_benchmarks.py
+++ b/visualize_benchmarks.py
@@ -30,7 +30,7 @@ from matplotlib.ticker import MaxNLocator
 # Define metrics where higher values are better and lower values are better
 
 HIGHER_IS_BETTER = ["QPS", "Recall@10"]
-LOWER_IS_BETTER = ["Mean Latency", "Index Build Time"]
+LOWER_IS_BETTER = ["Mean Latency", "Index Build Time", "Average Nodes Visited"]
 
 
 class BenchmarkData:


### PR DESCRIPTION
This PR is to add the value of average nodes visited to the metrics tested by the regression tests defined in AutoBenchYAML, which are used by the automated regression testing GitHub action.

Includes changes to the post-hoc script for visualization of regression test results.