### PR TITLE
Fix BuildScoreProvider::randomAccessScoreProvider bug

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/DefaultSearchScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/DefaultSearchScoreProvider.java
@@ -17,6 +17,7 @@
 package io.github.jbellis.jvector.graph.similarity;
 
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
@@ -82,14 +83,15 @@ public final class DefaultSearchScoreProvider implements SearchScoreProvider {
     /**
      * A SearchScoreProvider for a single-pass search based on exact similarity.
      * Generally only suitable when your RandomAccessVectorValues is entirely in-memory,
-     * e.g. during construction.
+     * e.g. during construction. The ordinal mapper is used to map between the graph's ordinals
+     * and the ordinals used by the RandomAccessVectorValues.
      */
-    public static DefaultSearchScoreProvider exact(VectorFloat<?> v, int[] graphToRavvOrdMap ,VectorSimilarityFunction vsf, RandomAccessVectorValues ravv) {
+    public static DefaultSearchScoreProvider exact(VectorFloat<?> v, OrdinalMapper ordinalMapper, VectorSimilarityFunction vsf, RandomAccessVectorValues ravv) {
         // don't use ESF.reranker, we need thread safety here
         var sf = new ScoreFunction.ExactScoreFunction() {
             @Override
             public float similarityTo(int node2) {
-                return vsf.compare(v, ravv.getVector(graphToRavvOrdMap[node2]));
+                return vsf.compare(v, ravv.getVector(ordinalMapper.oldToNew(node2)));
             }
         };
         return new DefaultSearchScoreProvider(sf);

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/GraphIndexBuilderTest.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/GraphIndexBuilderTest.java
@@ -156,4 +156,19 @@ public class GraphIndexBuilderTest extends LuceneTestCase {
         }
         assertGraphEquals(graph, builder.graph);
     }
+
+    // Because RandomAccessVectorValues is exposed in such a way that it allows for subsequent additions to the
+    // vector source, we need to ensure that GraphIndexBuilder can handle this.
+    @Test
+    public void testAddNodesToVectorValuesIteratively() throws IOException {
+        int dimension = randomIntBetween(2, 32);
+        var mutableVectors = new ArrayList<VectorFloat<?>>();
+        RandomAccessVectorValues ravv = new ListRandomAccessVectorValues(mutableVectors, dimension);
+        try (var builder = new GraphIndexBuilder(ravv, VectorSimilarityFunction.COSINE, 2, 10, 1.0f, 1.0f, true)) {
+            for (int i = 0; i < 10; i++) {
+                mutableVectors.add(TestUtil.randomVector(random(), dimension));
+                builder.addGraphNode(i, ravv.getVector(i));
+            }
+        }
+    }
 }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProviderTest.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProviderTest.java
@@ -17,6 +17,7 @@
 package io.github.jbellis.jvector.graph.similarity;
 
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
@@ -24,6 +25,7 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -46,9 +48,13 @@ public class BuildScoreProviderTest {
         var ravv = new ListRandomAccessVectorValues(vectors, 2);
 
         // Create non-identity mapping: graph node 0 -> ravv ordinal 2, graph node 1 -> ravv ordinal 0, graph node 2 -> ravv ordinal 1
-        int[] graphToRavvOrdMap = {2, 0, 1};
+        var oldToNew = new HashMap<Integer, Integer>();
+        oldToNew.put(0, 2);
+        oldToNew.put(1, 0);
+        oldToNew.put(2, 1);
+        var ordinalMapper = new OrdinalMapper.MapMapper(oldToNew);
         
-        var bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, graphToRavvOrdMap, vsf);
+        var bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, ordinalMapper, vsf);
         
         // Test that searchProviderFor(graphNode) uses the correct RAVV ordinal
         var ssp0 = bsp.searchProviderFor(0); // should use ravv ordinal 2 (vector [-1, 0])


### PR DESCRIPTION
See comment: https://github.com/datastax/jvector/pull/536/files#r2453090826

In #536, there was an addition that prevented concurrent addition of vectors to the `RandomAccessVectorValues` object. This behavior has been allowed in downstream projects, so I propose we return to it. Further, I replaced an identity map array with a simple `OrdinalMapper` identity function. It might be confusing to use the `OrdinalMapper`, but in reading it's javadoc, I think it applies here.

The added test fails without this change.