### PR TITLE
Make the thresholds in TestLowCardinalityFiltering tighter

### DIFF
--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestLowCardinalityFiltering.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestLowCardinalityFiltering.java
@@ -45,6 +45,10 @@ import static org.junit.Assert.assertEquals;
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class TestLowCardinalityFiltering extends LuceneTestCase {
+    /*
+    This test replicates https://github.com/jbellis/pwtest/tree/master natively in JVector.
+    It splits the vectors in two classes (with probability 0.5) and tests that the filtering works when the query belongs to one of them.
+     */
     @Test
     public void testLowCardinalityFiltering() throws IOException {
             testLowCardinalityFiltering(32, 0.044f, 0.91f, false);


### PR DESCRIPTION
This PR makes the thresholds tighter in the newly introduced test TestLowCardinalityFiltering (#551). The previous thresholds were too loose. It also reduces the number of vectors as it is enough to monitor the number of visited nodes.