### PR TITLE
Save allocation of a large array in PQVectors.encodeAndBuild

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/PQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/PQVectors.java
@@ -95,21 +95,6 @@ public abstract class PQVectors implements CompressedVectors {
      * and split into chunks to avoid exceeding the maximum array size.
      *
      * @param pq           the ProductQuantization to use
-     * @param ordinalsMapping the graph ordinals to RAVV mapping
-     * @param ravv         the RandomAccessVectorValues to encode
-     * @param simdExecutor the ForkJoinPool to use for SIMD operations
-     * @return the PQVectors instance
-     */
-    public static ImmutablePQVectors encodeAndBuild(ProductQuantization pq, int[] ordinalsMapping, RandomAccessVectorValues ravv, ForkJoinPool simdExecutor) {
-        IntUnaryOperator mapper = (ordinal) -> ordinalsMapping[ordinal];
-        return encodeAndBuild(pq, ordinalsMapping.length, mapper, ravv, simdExecutor);
-    }
-
-    /**
-     * Build a PQVectors instance from the given RandomAccessVectorValues. The vectors are encoded in parallel
-     * and split into chunks to avoid exceeding the maximum array size.
-     *
-     * @param pq           the ProductQuantization to use
      * @param vectorCount  the number of vectors to encode
      * @param ordinalsMapping the graph ordinals to RAVV mapping, the function should be defined in [0, vectorCount)
      * @param ravv         the RandomAccessVectorValues to encode


### PR DESCRIPTION
When calling
```
public static ImmutablePQVectors encodeAndBuild(ProductQuantization pq, int vectorCount, RandomAccessVectorValues ravv, ForkJoinPool simdExecutor)
```
there was an allocation of a potentially large array, which was not acutally needed. This PR refactors that code to avoid that allocation.

Additionally, the function
```
public static ImmutablePQVectors encodeAndBuild(ProductQuantization pq, int vectorCount, int[] ordinalsMapping, RandomAccessVectorValues ravv, ForkJoinPool simdExecutor)
```
had a potential ambiguity in its parameters. It will fail if `ordinalsMapping.length > vectorCount`. Thus, it was replaced with
```
public static ImmutablePQVectors encodeAndBuild(ProductQuantization pq, int[] ordinalsMapping, RandomAccessVectorValues ravv, ForkJoinPool simdExecutor)
```
where the `vectorCount` is computed from `ordinalsMapping.length`.

Finally, the function
```
public static ImmutablePQVectors encodeAndBuild(ProductQuantization pq, int vectorCount, IntFunction<Integer> ordinalsMapping, RandomAccessVectorValues ravv, ForkJoinPool simdExecutor)
```
is added. It receives a remapper as an IntFunction<Integer> that should be defined in [0, vectorCount). Hopefully, it gives more flexibility to the caller.