### PR TITLE
fix for parallel write overwriting inline writes

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/ParallelGraphWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/ParallelGraphWriter.java
@@ -211,7 +211,8 @@ class ParallelGraphWriter implements AutoCloseable {
                         featureStateSuppliers,
                         recordSize,
                         baseOffset,               // Base offset (task calculates per-ordinal offsets)
-                        buffer
+                        buffer,
+                        filePath
                 );
 
                 return task.call();

--- a/jvector-examples/yaml-configs/autoDefault.yml
+++ b/jvector-examples/yaml-configs/autoDefault.yml
@@ -1,12 +1,12 @@
 version: 6
 
-dataset: cohere-english-v3-100k
+dataset: default
 
 construction:
   outDegree: [32]
   efConstruction: [100]
   neighborOverflow: [1.2f]
-  addHierarchy: [Yes]
+  addHierarchy: [Yes, No]
   refineFinalGraph: [Yes]
   fusedGraph: [No]
   compression:
@@ -18,12 +18,12 @@ construction:
         centerData: No
         anisotropicThreshold: -1.0 # optional parameter. By default, anisotropicThreshold=-1 (i.e., no anisotropy)
   reranking:
-    - NVQ
+    - FP
   useSavedIndexIfExists: Yes
 
 search:
   topKOverquery:
-    10: [1.0]
+    10: [1.0, 2.0, 5.0]
   useSearchPruning: [Yes]
   compression:
     - type: PQ

--- a/jvector-examples/yaml-configs/default.yml
+++ b/jvector-examples/yaml-configs/default.yml
@@ -8,7 +8,7 @@ construction:
   neighborOverflow: [1.2f]
   addHierarchy: [Yes]
   refineFinalGraph: [Yes]
-  fusedGraph: [No]
+  fusedGraph: [Yes, No]
   compression:
     - type: PQ
       parameters:
@@ -18,7 +18,7 @@ construction:
         centerData: No
         anisotropicThreshold: -1.0 # optional parameter. By default, anisotropicThreshold=-1 (i.e., no anisotropy)
   reranking:
-    - NVQ
+    - FP
   useSavedIndexIfExists: Yes
 
 search:


### PR DESCRIPTION
This PR fixes a bug that was introduced by PR542 - On Disk Graph Index Parallelization. In the original PR the new parallel writing implementation would overwrite anything that had been already written through calls to writeInline when the write() method of the OnDiskGraphIndexWriter was called. In this PR the logic has been updated to read the existing data into the buffer prior to flushing writes to disk, preserving the contents.