### PR TITLE
turn off parallel writes in grid

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -308,8 +308,6 @@ public class Grid {
         var builder = new OnDiskGraphIndexWriter.Builder(onHeapGraph, outPath);
         builder.withMapper(identityMapper);
 
-        // Enable parallel writes for improved throughput
-        builder.withParallelWrites(true);
         Map<FeatureId, IntFunction<Feature.State>> suppliers = new EnumMap<>(FeatureId.class);
         for (var featureId : features) {
             switch (featureId) {


### PR DESCRIPTION
Turn off parallel writes in Grid until we finish evaluation of the new feature. Can be re-enabled in the future.