### PR TITLE
Speed up ivec reads by buffering

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/SiftLoader.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/util/SiftLoader.java
@@ -56,7 +56,7 @@ public class SiftLoader {
     public static List<List<Integer>> readIvecs(String filename) {
         var groundTruthTopK = new ArrayList<List<Integer>>();
 
-        try (var dis = new DataInputStream(new FileInputStream(filename))) {
+        try (var dis = new DataInputStream(new BufferedInputStream(new FileInputStream(filename)))) {
             while (dis.available() > 0) {
                 var numNeighbors = Integer.reverseBytes(dis.readInt());
                 var neighbors = new ArrayList<Integer>(numNeighbors);


### PR DESCRIPTION
`MultiFileDataSource` makes use of `SiftLoader.readFvecs` to read base and query vectors, and `SiftLoader.readIvecs` to read the provided ground truth. The `readIvecs` function is currently quite inefficient due to lack of buffering, disproportionately slowing down the time taken to load the Dataset.

This is not so important for `Bench`, where the time taken to load the dataset is insignificant compared to the time taken to build the index. However, this becomes quite important when running short-lived programs with pre-created graphs, especially during rapid prototyping.

This PR addresses this by adding a `BufferedInputStream`, similar to the current implementation of `readFvecs`.

Some numbers from my machine based on a dataset with ~2M base vectors and ~50K query vectors illustrates the difference:

| File        | Size   | Contents          | Time               |
| ---         | ---    | ---               | ---                |
| base.fvecs  | 964M   | ~2M 128D fvecs    | 2.6s               |
| query.fvecs | 25M    | ~50K 128D fvecs   | 0.12s              |
| gt.ivecs    | 58M    | ~50K 300D ivecs   | 10.3s (unbuffered)<br>0.34s (buffered) |

Without buffering, reading the ground truth is ~4x slower than the actual base vectors. With buffering, the ground truth is no longer the bottleneck.
