### PR TITLE
Fix OnDiskGraphIndex#ramBytesUsed NPE

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -402,11 +402,20 @@ public class OnDiskGraphIndex implements ImmutableGraphIndex, AutoCloseable, Acc
         List<Int2ObjectHashMap<int[]>> inMemoryNeighborsLocal = inMemoryNeighbors.get();
 
         long inMemoryNeighborsBytes = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-        for (Int2ObjectHashMap<int[]> neighbors : inMemoryNeighborsLocal) {
-            inMemoryNeighborsBytes += neighbors.values().stream().mapToLong(is -> Integer.BYTES * (long) is.length).sum();
-            inMemoryNeighborsBytes += RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        if (inMemoryNeighborsLocal != null) {
+            for (Int2ObjectHashMap<int[]> neighbors : inMemoryNeighborsLocal) {
+                if (neighbors != null) {
+                    inMemoryNeighborsBytes += neighbors.values().stream().mapToLong(is -> Integer.BYTES * (long) is.length).sum();
+                }
+                inMemoryNeighborsBytes += RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+            }
         }
-        long inMemoryFeaturesBytes = inMemoryFeatures.get().values().stream().mapToLong(is -> Integer.BYTES * is.ramBytesUsed()).sum();
+
+        Int2ObjectHashMap<FusedFeature.InlineSource> inMemoryFeaturesLocal  = inMemoryFeatures.get();
+        long inMemoryFeaturesBytes = 0;
+        if (inMemoryFeaturesLocal != null) {
+            inMemoryFeaturesBytes = inMemoryFeaturesLocal.values().stream().mapToLong(is -> Integer.BYTES * is.ramBytesUsed()).sum();
+        }
         inMemoryFeaturesBytes += RamUsageEstimator.NUM_BYTES_OBJECT_REF;
 
         return Long.BYTES + 6 * Integer.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
@@ -337,6 +337,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
              var onDiskGraph = OnDiskGraphIndex.load(readerSupplier);
              var onDiskView = onDiskGraph.getView())
         {
+            assertEquals(88, onDiskGraph.ramBytesUsed()); // Current size of graph that hasn't been read from
             assertEquals(32, onDiskGraph.getDegree(0));
             assertEquals(2, onDiskGraph.version);
             assertEquals(100_000, onDiskGraph.size(0));


### PR DESCRIPTION
Fixes: https://github.com/datastax/jvector/issues/586

Now that we lazily load the `inMemoryNeighbors` and the `inMemoryFeatures`, we need to handle the case where they are `null` or have values that are `null`. The added test fails without the change.