### PR TITLE
Ensure extractTrainingVectors return a list of at most MAX_PQ_TRAINING_SET_SIZE

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/ProductQuantization.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/ProductQuantization.java
@@ -160,6 +160,7 @@ public class ProductQuantization implements VectorCompressor<ByteSequence<?>>, A
                 assert it.hasNext();
                 ordinalArray[i] = it.next();
             }
+            assert !it.hasNext();
             ordinalStream = IntStream.of(ordinalArray);
         }
 


### PR DESCRIPTION
Fixes #590 

Uses floyd's random sampling algorithm to select random training vectors from the `RandomAccessVectorValues`. The solution has two phases. The first is to select `MAX_PQ_TRAINING_SET_SIZE` random ordinals. Then, it maps those ordinals to vectors. Here is a reference to the algorithm: https://math.stackexchange.com/questions/178690/whats-the-proof-of-correctness-for-robert-floyds-algorithm-for-selecting-a-sin.

The algorithm is essentially constant time, which is an improvement on what we currently had. We will now only generate `MAX_PQ_TRAINING_SET_SIZE` random numbers instead of `ravv.size()` random numbers. The slight increase cost is checking a hash set for containment.

This change also handles the boundary case where the vector values object has at most `MAX_PQ_TRAINING_SET_SIZE`.