### PR TITLE
Avoid lambda allocation in AtomicInteger max update in MutablePQVectors

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/MutablePQVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/quantization/MutablePQVectors.java
@@ -53,7 +53,7 @@ public class MutablePQVectors extends PQVectors implements MutableCompressedVect
     public void encodeAndSet(int ordinal, VectorFloat<?> vector) {
         ensureChunkCapacity(ordinal);
         // increase count first so get() works
-        vectorCount.updateAndGet(current -> max(current, ordinal + 1));
+        vectorCount.accumulateAndGet(ordinal + 1, Math::max);
         pq.encodeTo(vector, get(ordinal));
     }
 
@@ -61,7 +61,7 @@ public class MutablePQVectors extends PQVectors implements MutableCompressedVect
     public void setZero(int ordinal) {
         ensureChunkCapacity(ordinal);
         // increase count first so get() works
-        vectorCount.updateAndGet(current -> max(current, ordinal + 1));
+        vectorCount.accumulateAndGet(ordinal + 1, Math::max);
         get(ordinal).zero();
     }
 


### PR DESCRIPTION
This is a minor optimization to reduce object allocations on the hot path when we're adding vectors to `MutablePQVectors`. The object allocation happens when we have a capturing lambda, which is different on every call to this method. Instead, we can use the `accumulateAndGet` method, which takes the value we want to offer and then takes a non-capturing lambda `Math::max`, which means we won't allocate an object per call.