### PR TITLE
adding regression test datasets

### DIFF
--- a/jvector-examples/yaml-configs/dataset_metadata.yml
+++ b/jvector-examples/yaml-configs/dataset_metadata.yml
@@ -37,3 +37,15 @@ ada002-1M:
   similarity_function: COSINE
 colbert-1M:
   similarity_function: COSINE
+cap-1M:
+  similarity_function: COSINE
+cap-6M:
+  similarity_function: COSINE
+dpr-1M:
+  similarity_function: COSINE
+dpr-10M:
+  similarity_function: COSINE
+cohere-english-v3-1M:
+  similarity_function: COSINE
+cohere-english-v3-10M:
+  similarity_function: COSINE


### PR DESCRIPTION
regression tests are not producing information. Even though the files are correctly downloaded, without specifying similarity metadata the "download" fails. This PR adds the datasets used by the regression tests to the metadata file.