### PR TITLE
Record index build time in buildInMemory path

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -574,12 +574,13 @@ public class Grid {
                                                           FilteredForkJoinPool.createFilteredPool());
         start = System.nanoTime();
         var onHeapGraph = builder.build(floatVectors);
+        double buildTimeS = (System.nanoTime() - start) / 1_000_000_000.0;
         System.out.format("Build (%s) M=%d overflow=%.2f ef=%d in %.2fs%n",
                           "full res",
                           M,
                           neighborOverflow,
                           efConstruction,
-                          (System.nanoTime() - start) / 1_000_000_000.0);
+                          buildTimeS);
         for (int i = 0; i <= onHeapGraph.getMaxLevel(); i++) {
             System.out.format("  L%d: %d nodes, %.2f avg degree%n",
                               i,
@@ -603,6 +604,7 @@ public class Grid {
             var index = OnDiskGraphIndex.load(ReaderSupplierFactory.open(graphPath));
             indexes.put(features, index);
         }
+        indexBuildTimes.put(ds.getName(), buildTimeS);
         return indexes;
     }
 


### PR DESCRIPTION
`buildInMemory `(the no-build-compressor path) never recorded the index build time into indexBuildTimes, so getIndexBuildTimeSeconds() always returned null for it. This caused construction.index_build_time_s to be omitted from benchmark results, triggering a warning whenever the metric was selected in the logging config:

`WARNING: selected logging output not available; skipping metrics.construction.index_build_time_s (construction.index_build_time_s)`

Fix: capture the duration of builder.build() in buildInMemory and store it in indexBuildTimes, consistent with how buildOnDisk already does it. Write time is intentionally excluded — only graph construction is measured.

Before: 
```
Index build time: null seconds
```

After: 
```
Index build time: 32.192336 seconds
```