### PR TITLE
add openai_datasets

### DIFF
--- a/jvector-examples/yaml-configs/dataset-metadata.yml
+++ b/jvector-examples/yaml-configs/dataset-metadata.yml
@@ -103,3 +103,9 @@ nytimes-256-angular:
 sift-128-euclidean:
   similarity_function: EUCLIDEAN
   load_behavior: NO_SCRUB
+openai-3072-1m:
+  similarity_function: DOT_PRODUCT
+  load_behavior: NO_SCRUB
+openai-1536-1m:
+  similarity_function: DOT_PRODUCT
+  load_behavior: NO_SCRUB

--- a/jvector-examples/yaml-configs/datasets.yml
+++ b/jvector-examples/yaml-configs/datasets.yml
@@ -26,6 +26,9 @@ regression-tests:
   - cohere-english-v3-10M
   - dpr-gemma-1m
   - dpr-gemma-10m
+openai-unconfigured:
+  - openai-3072-1m
+  - openai-1536-1m
 #other-datasets:
 #  - dpr-1M
 #  - dpr-10M


### PR DESCRIPTION
This adds the name entries for the openai datasets in our shared config.
They still need to have some reasonable per-dataset defaults added, but they are testable now with default settings.