### PR TITLE
Add offheap memory tracking to Bench YAML reports

### DIFF
--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/benchmarks/QueryTester.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/benchmarks/QueryTester.java
@@ -98,17 +98,23 @@ public class QueryTester {
             diagnostics.capturePostPhaseSnapshot("Query");
 
             // Add memory and disk metrics to results
-            var systemSnapshot = diagnostics.getLatestSystemSnapshot();
+            // Get both pre and post snapshots to calculate maximum memory usage
+            var preSnapshot = diagnostics.getPrePhaseSystemSnapshot();
+            var postSnapshot = diagnostics.getLatestSystemSnapshot();
             var diskSnapshot = diagnostics.getLatestDiskSnapshot();
 
-            if (systemSnapshot != null) {
-                // Max heap usage in MB
+            if (preSnapshot != null && postSnapshot != null) {
+                // Calculate max heap usage across pre and post snapshots
+                long maxHeapUsed = Math.max(preSnapshot.memoryStats.heapUsed,
+                                           postSnapshot.memoryStats.heapUsed);
                 results.add(Metric.of("search.system.max_heap_mb", "Max heap usage (MB)", ".1f",
-                        systemSnapshot.memoryStats.heapUsed / (1024.0 * 1024.0)));
+                        maxHeapUsed / (1024.0 * 1024.0)));
 
-                // Max off-heap usage (direct + mapped) in MB
+                // Calculate max off-heap usage (direct + mapped) across pre and post snapshots
+                long maxOffHeapUsed = Math.max(preSnapshot.memoryStats.getTotalOffHeapMemory(),
+                                               postSnapshot.memoryStats.getTotalOffHeapMemory());
                 results.add(Metric.of("search.system.max_offheap_mb", "Max offheap usage (MB)", ".1f",
-                        systemSnapshot.memoryStats.getTotalOffHeapMemory() / (1024.0 * 1024.0)));
+                        maxOffHeapUsed / (1024.0 * 1024.0)));
             }
 
             if (diskSnapshot != null) {

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/benchmarks/diagnostics/BenchmarkDiagnostics.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/benchmarks/diagnostics/BenchmarkDiagnostics.java
@@ -237,7 +237,14 @@ public class BenchmarkDiagnostics implements AutoCloseable {
      * Gets the pre-phase system snapshot (second to last), or null if not available
      */
     public SystemMonitor.SystemSnapshot getPrePhaseSystemSnapshot() {
-        return snapshots.size() < 2 ? null : snapshots.get(snapshots.size() - 2);
+        // The pre-phase snapshot is the second to last entry in the snapshots list, since the last one is the post-phase snapshot
+        var numSnapshots = snapshots.size();
+        if (numSnapshots < 2) {
+            return null;
+        } else {
+            SystemMonitor.SystemSnapshot prePhaseSnapshot = snapshots.get(numSnapshots - 2);
+            return prePhaseSnapshot;
+        }
     }
 
     /**

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/benchmarks/diagnostics/BenchmarkDiagnostics.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/benchmarks/diagnostics/BenchmarkDiagnostics.java
@@ -234,6 +234,13 @@ public class BenchmarkDiagnostics implements AutoCloseable {
     }
 
     /**
+     * Gets the pre-phase system snapshot (second to last), or null if not available
+     */
+    public SystemMonitor.SystemSnapshot getPrePhaseSystemSnapshot() {
+        return snapshots.size() < 2 ? null : snapshots.get(snapshots.size() - 2);
+    }
+
+    /**
      * Gets the latest disk usage snapshot, or null if none captured
      */
     public DiskUsageMonitor.MultiDirectorySnapshot getLatestDiskSnapshot() {

--- a/jvector-examples/yaml-configs/run-config.yml
+++ b/jvector-examples/yaml-configs/run-config.yml
@@ -17,7 +17,7 @@ console:
     count:      [ visited ]  # [visited, expanded, expanded base layer]
     accuracy:   [ recall ]   # [recall, MAP]
   metrics:
-    system: [ max_heap_mb ] # [ max_heap_mb, max_offheap_mb ]
+    system: [ max_heap_mb, max_offheap_mb ] # [ max_heap_mb, max_offheap_mb ]
 #    disk: total_file_size_mb # [ total_file_size_mb, file_count ]
 #    construction: index_build_time_s # [ index_build_time_s, index_quant_time_s, search_quant_time_s ]
 


### PR DESCRIPTION
This PR updates the tracking of offheap memory usage by calculating max usage comparing the pre and post phase snapshots instead of just using the final snapshot, and adds offheap memory usage to the tabular results generated by BenchYAML. 

Note that the reported offheap usage will appear static across configurations for a given dataset in this test. This is because off-heap memory is allocated during index loading (once per dataset). It includes memory-mapped index files and Direct ByteBuffers for vector storage. All query configurations reuse the same loaded index, so off-heap usage remains constant but different datasets have different index sizes, hence different off-heap usage.

Example output:
```
Disk Usage Summary Graph Index Build:
  [testDirectory]:
    Total Disk Used: 115.99 MB
    Total Files: 1
    Net Change: 115.99 MB, +1 files
  [indexCache]:
    Total Disk Used: 0 B
    Total Files: 0
    Net Change: 0 B, +0 files
  [Overall Total]:
    Total Disk Used: 115.99 MB
    Total Files: 1
    Net Change: 115.99 MB, +1 files
Index build time: 26.442781 seconds

cohere-english-v3-100k: ProductQuantization(M=128, clusters=256, centered=false) codebooks loaded from PQ_cohere-english-v3-100k_128_256_false_-1.0
cohere-english-v3-100k: ProductQuantization(M=128, clusters=256, centered=false) encoded 99685 vectors [13.17 MB] in 1.75s
cohere-english-v3-100k: Using OnDiskGraphIndex(layers=[LayerInfo{size=99685, degree=32}, LayerInfo{size=3224, degree=32}, LayerInfo{size=95, degree=32}, LayerInfo{size=2, degree=32}], entryPoint=NodeAtLevel(level=3, node=75059), features=NVQ_VECTORS):

Index configuration:
  featureSetForIndex   [NVQ_VECTORS]
  M                    32
  efConstruction       100
  neighborOverflow     1.2
  addHierarchy         true
  refineFinalGraph     true

Query configuration:
  usePruning           true

Overquery    Avg QPS         ± Std Dev    CV %        Mean Latency    Avg Visited    Recall@10    Max heap        Max offheap    
             (of 3)                                   (ms)                                        usage (MB)      usage (MB)     
---------------------------------------------------------------------------------------------------------------------------------
1.00         52315.1         378.7        0.7         0.163           355.3          0.78         755.2           116.4          
2.00         44155.5         619.7        1.4         0.201           515.2          0.92         834.3           116.4          
5.00         28832.6         264.1        0.9         0.306           951.1          0.98         834.3           116.4          
10.00        17835.6         1134.1       6.4         0.504           1536.7         0.99         786.6           116.4          


Overquery    Avg QPS         ± Std Dev    CV %        Mean Latency    Avg Visited    Recall@100    Max heap        Max offheap    
             (of 3)                                   (ms)                                         usage (MB)      usage (MB)     
----------------------------------------------------------------------------------------------------------------------------------
1.00         18204.6         119.4        0.7         0.522           1536.7         0.85          803.5           116.4          
2.00         11269.1         83.9         0.7         0.846           2495.2         0.97          803.5           116.4          
```
