### PR TITLE
Compaction pr updates

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexCompactor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndexCompactor.java
@@ -81,7 +81,6 @@ public final class OnDiskGraphIndexCompactor implements Accountable {
     private final int dimension;
     private int maxOrdinal = -1;
     private int numTotalNodes = 0;
-    private boolean ownsExecutor = false;
     private final ForkJoinPool executor;
     private final int taskWindowSize;
     private final VectorSimilarityFunction similarityFunction;
@@ -120,14 +119,19 @@ public final class OnDiskGraphIndexCompactor implements Accountable {
             ForkJoinPool executor) {
         checkBeforeCompact(sources, sourceCompressed, liveNodes, remappers);
 
-        int threads = Runtime.getRuntime().availableProcessors();
         if (executor != null) {
             this.executor = executor;
         } else {
-            this.executor = new ForkJoinPool(threads);
-            this.ownsExecutor = true;
+            // Default to the shared physical-core pool. Compaction (PQ encode + parallel record
+            // flush + refinement) is compute- and memory-bandwidth-bound, so sizing to logical
+            // cores oversubscribes hyperthreaded hosts and costs throughput. This pool is
+            // process-wide and shared with index construction and quantization; the compactor
+            // never owns or shuts it down.
+            this.executor = PhysicalCoreExecutor.pool();
         }
-        this.taskWindowSize = threads;
+        // Track the pool's real parallelism so task-window / backpressure sizing stays correct
+        // whether the executor is the shared default or a caller-injected pool.
+        this.taskWindowSize = this.executor.getParallelism();
 
         this.sources = sources;
         this.sourceCompressed = (sourceCompressed == null || sourceCompressed.isEmpty()) ? null : sourceCompressed;
@@ -299,7 +303,6 @@ public final class OnDiskGraphIndexCompactor implements Accountable {
             // Delayed until after refinement so refineCompactedGraph can read from the pre-encoded
             // code cache appended past the projected EOF; onAfterClose unmaps it and truncates.
             strategy.onAfterClose(outputPath);
-            if (ownsExecutor) executor.shutdown();
         }
     }
 
@@ -333,7 +336,6 @@ public final class OnDiskGraphIndexCompactor implements Accountable {
             throw new RuntimeException("Sidecar compaction failed", e);
         } finally {
             inlineStrategy.onAfterClose(graphPath);
-            if (ownsExecutor) executor.shutdown();
         }
     }
 
@@ -1408,8 +1410,8 @@ public final class OnDiskGraphIndexCompactor implements Accountable {
         // Shallow size of this object (header + fields)
         // Current fields: sources, liveNodes, numLiveNodesPerSource, remappers, maxDegrees,
         //                dimension(int), maxOrdinal(int), numTotalNodes(int),
-        //                ownsExecutor(boolean), executor, taskWindowSize(int), similarityFunction
-        long size = OH + 8L * REF + Integer.BYTES * 4 + 1;
+        //                executor, taskWindowSize(int), similarityFunction
+        long size = OH + 8L * REF + Integer.BYTES * 4;
 
         // liveNodes: FixedBitSet per source. May be null after releaseSourcesBeforeRefine().
         if (liveNodes != null) {
@@ -1437,12 +1439,9 @@ public final class OnDiskGraphIndexCompactor implements Accountable {
         // maxDegrees: small list of integers
         size += OH + REF + (long) maxDegrees.size() * (OH + Integer.BYTES);
 
-        // executor: ForkJoinPool overhead (if owned)
-        // Estimate based on number of threads
-        int numThreads = ownsExecutor ? Runtime.getRuntime().availableProcessors() : taskWindowSize;
-        if (ownsExecutor) {
-            size += OH + REF;
-        }
+        // executor: a shared pool (default) or caller-injected — not owned by the compactor, so it
+        // contributes no pool allocation here. Scratch space still scales with its parallelism.
+        int numThreads = taskWindowSize;
 
         // Scratch space: ThreadLocal instances (one per active thread)
         // Each Scratch contains:

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskParallelGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskParallelGraphIndexWriter.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.function.IntFunction;
 
 /**
@@ -68,6 +69,7 @@ public class OnDiskParallelGraphIndexWriter extends RandomAccessOnDiskGraphIndex
     private final Path filePath;
     private final int parallelWorkerThreads;
     private final boolean parallelUseDirectBuffers;
+    private final ExecutorService parallelExecutor;
 
     /**
      * Constructs an OnDiskParallelGraphIndexWriter with all parameters including file path
@@ -95,6 +97,28 @@ public class OnDiskParallelGraphIndexWriter extends RandomAccessOnDiskGraphIndex
                                    int parallelWorkerThreads,
                                    boolean parallelUseDirectBuffers)
     {
+        this(randomAccessWriter, version, startOffset, graph, oldToNewOrdinals, dimension, features,
+                filePath, parallelWorkerThreads, parallelUseDirectBuffers, null);
+    }
+
+    /**
+     * @param parallelExecutor an externally-owned executor to run parallel L0 writes on, or
+     *        {@code null} to use a dedicated pool sized to {@code parallelWorkerThreads}. The
+     *        executor must outlive this writer and is the caller's to shut down. Because the write
+     *        tasks block on file I/O, prefer an I/O-sized pool rather than a compute pool.
+     */
+    OnDiskParallelGraphIndexWriter(RandomAccessWriter randomAccessWriter,
+                                   int version,
+                                   long startOffset,
+                                   ImmutableGraphIndex graph,
+                                   OrdinalMapper oldToNewOrdinals,
+                                   int dimension,
+                                   EnumMap<FeatureId, Feature> features,
+                                   Path filePath,
+                                   int parallelWorkerThreads,
+                                   boolean parallelUseDirectBuffers,
+                                   ExecutorService parallelExecutor)
+    {
         super(randomAccessWriter, version, startOffset, graph, oldToNewOrdinals, dimension, features);
         if (filePath == null) {
             throw new IllegalStateException("Parallel writes require a file path");
@@ -102,6 +126,7 @@ public class OnDiskParallelGraphIndexWriter extends RandomAccessOnDiskGraphIndex
         this.filePath = filePath;
         this.parallelWorkerThreads = parallelWorkerThreads;
         this.parallelUseDirectBuffers = parallelUseDirectBuffers;
+        this.parallelExecutor = parallelExecutor;
     }
 
     /**
@@ -136,7 +161,8 @@ public class OnDiskParallelGraphIndexWriter extends RandomAccessOnDiskGraphIndex
                 graph,
                 inlineFeatures,
                 config,
-                filePath)) {
+                filePath,
+                parallelExecutor)) {
 
             parallelWriter.writeL0Records(
                 ordinalMapper,
@@ -173,6 +199,7 @@ public class OnDiskParallelGraphIndexWriter extends RandomAccessOnDiskGraphIndex
         private final Path filePath;
         private int parallelWorkerThreads = 0;
         private boolean parallelUseDirectBuffers = false;
+        private ExecutorService parallelExecutor = null;
 
         public Builder(ImmutableGraphIndex graphIndex, Path outPath) throws FileNotFoundException {
             super(graphIndex, new BufferedRandomAccessWriter(outPath));
@@ -211,11 +238,27 @@ public class OnDiskParallelGraphIndexWriter extends RandomAccessOnDiskGraphIndex
             return this;
         }
 
+        /**
+         * Run parallel L0 writes on a caller-supplied executor instead of a dedicated per-write
+         * pool. The executor is the caller's to shut down and must outlive the writer. When set,
+         * {@link #withParallelWorkerThreads(int)} only affects task batching, not pool size.
+         * <p>
+         * The write tasks block on file I/O, so supply an I/O-sized pool (typically &gt;= logical
+         * cores); a small compute pool (e.g. a physical-core ForkJoinPool) will throttle writes.
+         *
+         * @param executor the shared executor, or {@code null} to keep the dedicated-pool default
+         * @return this builder
+         */
+        public Builder withExecutor(ExecutorService executor) {
+            this.parallelExecutor = executor;
+            return this;
+        }
+
         @Override
         protected OnDiskParallelGraphIndexWriter reallyBuild(int dimension) {
             return new OnDiskParallelGraphIndexWriter(
                 out, version, startOffset, graphIndex, ordinalMapper, dimension, features, filePath,
-                parallelWorkerThreads, parallelUseDirectBuffers
+                parallelWorkerThreads, parallelUseDirectBuffers, parallelExecutor
             );
         }
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/ParallelGraphWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/ParallelGraphWriter.java
@@ -65,6 +65,7 @@ class ParallelGraphWriter implements AutoCloseable {
     private final RandomAccessWriter writer;
     private final ImmutableGraphIndex graph;
     private final ExecutorService executor;
+    private final boolean ownsExecutor;
     private final ThreadLocal<ImmutableGraphIndex.View> viewPerThread;
     private final ThreadLocal<ByteBuffer> bufferPerThread;
     private final CopyOnWriteArrayList<ImmutableGraphIndex.View> allViews = new CopyOnWriteArrayList<>();
@@ -118,17 +119,43 @@ class ParallelGraphWriter implements AutoCloseable {
                                List<Feature> inlineFeatures,
                                Config config,
                                Path filePath) {
+        this(writer, graph, inlineFeatures, config, filePath, null);
+    }
+
+    /**
+     * Creates a parallel writer that runs its record-building/write tasks on a caller-supplied
+     * executor instead of a dedicated pool.
+     *
+     * @param externalExecutor an externally-owned executor to run tasks on, or {@code null} to
+     *        create (and own) a dedicated fixed thread pool sized to {@code config.workerThreads}.
+     *        An external executor must outlive this writer and is the caller's to shut down;
+     *        {@link #close()} will not shut it down. Note these tasks block on file I/O, so an
+     *        executor sized for I/O concurrency (typically &gt;= logical cores) is appropriate; a
+     *        small compute-sized pool (e.g. a physical-core ForkJoinPool) will throttle writes.
+     */
+    public ParallelGraphWriter(RandomAccessWriter writer,
+                               ImmutableGraphIndex graph,
+                               List<Feature> inlineFeatures,
+                               Config config,
+                               Path filePath,
+                               ExecutorService externalExecutor) {
         this.writer = writer;
         this.graph = graph;
         this.filePath = Objects.requireNonNull(filePath);
         this.taskMultiplier = config.taskMultiplier;
-        this.executor = Executors.newFixedThreadPool(config.workerThreads,
-            r -> {
-                Thread t = new Thread(r);
-                t.setName("ParallelGraphWriter-Worker-" + threadCounter.getAndIncrement());
-                t.setDaemon(false);
-                return t;
-            });
+        if (externalExecutor != null) {
+            this.executor = externalExecutor;
+            this.ownsExecutor = false;
+        } else {
+            this.executor = Executors.newFixedThreadPool(config.workerThreads,
+                r -> {
+                    Thread t = new Thread(r);
+                    t.setName("ParallelGraphWriter-Worker-" + threadCounter.getAndIncrement());
+                    t.setDaemon(false);
+                    return t;
+                });
+            this.ownsExecutor = true;
+        }
 
         // Compute fixed record size for L0
         this.recordSize = Integer.BYTES // node ordinal
@@ -285,15 +312,17 @@ class ParallelGraphWriter implements AutoCloseable {
     @Override
     public void close() throws IOException {
         try {
-            // Shutdown executor
-            executor.shutdown();
-            try {
-                if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+            // Shut down the executor only if we created it; an injected executor is the caller's.
+            if (ownsExecutor) {
+                executor.shutdown();
+                try {
+                    if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+                        executor.shutdownNow();
+                    }
+                } catch (InterruptedException e) {
                     executor.shutdownNow();
+                    Thread.currentThread().interrupt();
                 }
-            } catch (InterruptedException e) {
-                executor.shutdownNow();
-                Thread.currentThread().interrupt();
             }
 
             // Close all views (CopyOnWriteArrayList is safe for concurrent iteration)

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,8 +52,16 @@ import java.util.regex.Pattern;
  * </ol>
  * Neither the pool nor the probe is created until {@link #pool()}, {@link #instance()} or
  * {@link #getPhysicalCoreCount()} is first called.
+ *
+ * <p>On first resolution the chosen count and the method that produced it are logged at
+ * {@code INFO}. When no {@code jvector.physical_core_count} property is set and topology-aware
+ * sizing yields a different count than the legacy {@code availableProcessors() / 2} heuristic, a
+ * {@code WARNING} is also logged so the change in worker-thread count (and the throughput that
+ * tracks it) is visible to an operator who expected the old value.
  */
 public class PhysicalCoreExecutor implements Closeable {
+    private static final Logger LOG = Logger.getLogger(PhysicalCoreExecutor.class.getName());
+
     /** How long to wait on a best-effort OS probe subprocess before giving up.
      * An early exit (failed probe) won't take this long, but we keep a longer window to avoid spurrious
      * race conditions on systems which are potentially busy during start-up. */
@@ -135,6 +145,12 @@ public class PhysicalCoreExecutor implements Closeable {
     // ---------------------------------------------------------------------------------------------
 
     private static int resolvePhysicalCoreCount() {
+        final int logical = Runtime.getRuntime().availableProcessors();
+        // The pre-probe default (this class's historical sizing): assume 2-way hyper-threading.
+        // Serves both as the last-resort fallback and as the baseline we warn against when
+        // topology-aware sizing now selects a different number.
+        final int legacyHeuristic = Math.max(1, logical / 2);
+
         Integer override = Integer.getInteger("jvector.physical_core_count");
         if (override != null) {
             if (override < 1) {
@@ -142,18 +158,44 @@ public class PhysicalCoreExecutor implements Closeable {
                         "jvector.physical_core_count must be >= 1, got: " + override);
             }
             // Trust the operator: the property exists precisely to correct a wrong availableProcessors().
+            LOG.log(Level.INFO,
+                    "PhysicalCoreExecutor: using {0} worker threads, set explicitly via the "
+                            + "jvector.physical_core_count system property (availableProcessors={1}).",
+                    new Object[]{override, logical});
             return override;
         }
 
-        int logical = Runtime.getRuntime().availableProcessors();
         int detected = detectPhysicalCores();
+        final int selected;
+        final String method;
         if (detected >= 1) {
             // Physical cannot exceed logical; clamping also respects cgroup CPU limits, since
             // availableProcessors() reflects the quota while /proc/cpuinfo shows all host cores.
-            return Math.min(detected, logical);
+            selected = Math.min(detected, logical);
+            method = "OS topology probe on \"" + System.getProperty("os.name", "?")
+                    + "\" (detected " + detected + " physical cores, clamped to availableProcessors=" + logical + ")";
+        } else {
+            // Unknown topology: assume 2-way hyper-threading (the historical default).
+            selected = legacyHeuristic;
+            method = "fallback heuristic availableProcessors()/2 (availableProcessors=" + logical
+                    + "; OS topology probe unavailable)";
         }
-        // Unknown topology: assume 2-way hyper-threading (the historical default).
-        return Math.max(1, logical / 2);
+
+        LOG.log(Level.INFO,
+                "PhysicalCoreExecutor: using {0} worker threads, determined by {1}.",
+                new Object[]{selected, method});
+
+        // Auto-sizing now diverges from the pre-probe default; make that loud so an operator who
+        // expected the old thread count (and the throughput that came with it) can pin it deliberately.
+        if (selected != legacyHeuristic) {
+            LOG.log(Level.WARNING,
+                    "PhysicalCoreExecutor: previous auto-sized worker threads on this node would have been {0}, "
+                            + "but aligning to cores now sets them to {1}. "
+                            + "Set the jvector.physical_core_count system property to override.",
+                    new Object[]{legacyHeuristic, selected});
+        }
+
+        return selected;
     }
 
     /** Best-effort physical-core probe. Returns {@code -1} when the topology can't be determined. */

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/util/PhysicalCoreExecutor.java
@@ -19,8 +19,19 @@ import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 
 import java.io.Closeable;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A fork join pool which is sized to match the number of physical cores on the machine (avoiding hyper-thread count)
@@ -30,21 +41,73 @@ import java.util.function.Supplier;
  * @see ProductQuantization
  * @see GraphIndexBuilder
  *
- * Knowing how many physical cores a machine has is left to the operator (however the default of 1/2 cores is today often correct).
+ * <p>The physical core count is resolved lazily on first use, in this order:
+ * <ol>
+ *   <li>the {@code jvector.physical_core_count} system property, if set (trusted as-is);</li>
+ *   <li>a best-effort OS probe ({@code /proc/cpuinfo} on Linux, {@code sysctl} on macOS,
+ *       {@code wmic} on Windows);</li>
+ *   <li>a fallback of {@code availableProcessors() / 2}, which assumes 2-way hyper-threading.</li>
+ * </ol>
+ * Neither the pool nor the probe is created until {@link #pool()}, {@link #instance()} or
+ * {@link #getPhysicalCoreCount()} is first called.
  */
 public class PhysicalCoreExecutor implements Closeable {
-    private static final int physicalCoreCount = Integer.getInteger("jvector.physical_core_count", Math.max(1, Runtime.getRuntime().availableProcessors()/2));
+    /** How long to wait on a best-effort OS probe subprocess before giving up.
+     * An early exit (failed probe) won't take this long, but we keep a longer window to avoid spurrious
+     * race conditions on systems which are potentially busy during start-up. */
+    private static final long PROBE_TIMEOUT_SECONDS = 15;
 
-    public static final PhysicalCoreExecutor instance = new PhysicalCoreExecutor(physicalCoreCount);
+    /** Lazily resolved; {@code -1} means "not yet resolved". Guarded by the class monitor for writes. */
+    private static volatile int physicalCoreCount = -1;
+
+    /** Lazily constructed shared instance. Guarded by the class monitor for writes. */
+    private static volatile PhysicalCoreExecutor instance;
+
+    /**
+     * Returns the resolved physical core count, computing it (including any OS probe) on first call
+     * and caching the result. Does not create the pool.
+     */
+    public static int getPhysicalCoreCount() {
+        int c = physicalCoreCount;
+        if (c < 0) {
+            synchronized (PhysicalCoreExecutor.class) {
+                c = physicalCoreCount;
+                if (c < 0) {
+                    c = resolvePhysicalCoreCount();
+                    physicalCoreCount = c;
+                }
+            }
+        }
+        return c;
+    }
+
+    /**
+     * Returns the lazily-created shared instance, constructing the backing pool on first call.
+     */
+    public static PhysicalCoreExecutor instance() {
+        PhysicalCoreExecutor i = instance;
+        if (i == null) {
+            synchronized (PhysicalCoreExecutor.class) {
+                i = instance;
+                if (i == null) {
+                    i = new PhysicalCoreExecutor(getPhysicalCoreCount());
+                    instance = i;
+                }
+            }
+        }
+        return i;
+    }
 
     public static ForkJoinPool pool() {
-        return instance.pool;
+        return instance().pool;
     }
-    
+
     private final ForkJoinPool pool;
 
     private PhysicalCoreExecutor(int cores) {
-        assert cores > 0 && cores <= Runtime.getRuntime().availableProcessors() : "Invalid core count: " + cores;
+        if (cores < 1) {
+            throw new IllegalArgumentException("Physical core count must be >= 1, got: " + cores);
+        }
         this.pool = new ForkJoinPool(cores);
     }
 
@@ -56,12 +119,158 @@ public class PhysicalCoreExecutor implements Closeable {
         return pool.submit(run::get).join();
     }
 
-    public static int getPhysicalCoreCount() {
-        return physicalCoreCount;
-    }
-
     @Override
     public void close() {
-        pool.shutdownNow();
+        synchronized (PhysicalCoreExecutor.class) {
+            pool.shutdownNow();
+            // Release the singleton so a later pool()/instance() lazily creates a fresh pool.
+            if (instance == this) {
+                instance = null;
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Core-count resolution
+    // ---------------------------------------------------------------------------------------------
+
+    private static int resolvePhysicalCoreCount() {
+        Integer override = Integer.getInteger("jvector.physical_core_count");
+        if (override != null) {
+            if (override < 1) {
+                throw new IllegalArgumentException(
+                        "jvector.physical_core_count must be >= 1, got: " + override);
+            }
+            // Trust the operator: the property exists precisely to correct a wrong availableProcessors().
+            return override;
+        }
+
+        int logical = Runtime.getRuntime().availableProcessors();
+        int detected = detectPhysicalCores();
+        if (detected >= 1) {
+            // Physical cannot exceed logical; clamping also respects cgroup CPU limits, since
+            // availableProcessors() reflects the quota while /proc/cpuinfo shows all host cores.
+            return Math.min(detected, logical);
+        }
+        // Unknown topology: assume 2-way hyper-threading (the historical default).
+        return Math.max(1, logical / 2);
+    }
+
+    /** Best-effort physical-core probe. Returns {@code -1} when the topology can't be determined. */
+    private static int detectPhysicalCores() {
+        try {
+            String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+            if (os.contains("linux")) {
+                return detectLinuxPhysicalCores();
+            }
+            if (os.contains("mac") || os.contains("darwin")) {
+                return parseFirstInt(runCommand("/usr/sbin/sysctl", "-n", "hw.physicalcpu"));
+            }
+            if (os.contains("windows")) {
+                // wmic is deprecated but widely present; sum NumberOfCores across CPU packages.
+                return sumInts(runCommand("wmic", "cpu", "get", "NumberOfCores"));
+            }
+        } catch (Throwable t) {
+            // Best-effort only; fall through to the caller's heuristic default.
+        }
+        return -1;
+    }
+
+    /** Linux: count distinct (physical id, core id) pairs in {@code /proc/cpuinfo}. */
+    private static int detectLinuxPhysicalCores() throws Exception {
+        Path cpuinfo = Paths.get("/proc/cpuinfo");
+        if (!Files.isReadable(cpuinfo)) {
+            return -1;
+        }
+        Set<String> cores = new HashSet<>();
+        String physicalId = null;
+        String coreId = null;
+        for (String line : Files.readAllLines(cpuinfo)) {
+            line = line.trim();
+            if (line.isEmpty()) {
+                if (physicalId != null && coreId != null) {
+                    cores.add(physicalId + ':' + coreId);
+                }
+                physicalId = null;
+                coreId = null;
+            } else if (line.startsWith("physical id")) {
+                physicalId = valueAfterColon(line);
+            } else if (line.startsWith("core id")) {
+                coreId = valueAfterColon(line);
+            }
+        }
+        // Handle a trailing block not terminated by a blank line.
+        if (physicalId != null && coreId != null) {
+            cores.add(physicalId + ':' + coreId);
+        }
+        // Topology fields are absent on many non-x86 CPUs (e.g. ARM); report unknown so the caller
+        // falls back to its heuristic rather than trusting a bogus count.
+        return cores.isEmpty() ? -1 : cores.size();
+    }
+
+    private static String valueAfterColon(String line) {
+        int idx = line.indexOf(':');
+        return idx >= 0 ? line.substring(idx + 1).trim() : "";
+    }
+
+    /** Runs a short-lived command, returning its stdout, or {@code null} on any failure/timeout. */
+    private static String runCommand(String... cmd) {
+        Process p = null;
+        try {
+            p = new ProcessBuilder(cmd).redirectErrorStream(false).start();
+            // Close stdin so the child never blocks waiting for input.
+            p.getOutputStream().close();
+            if (!p.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                return null;
+            }
+            if (p.exitValue() != 0) {
+                return null;
+            }
+            try (InputStream in = p.getInputStream()) {
+                return new String(readAll(in), StandardCharsets.UTF_8);
+            }
+        } catch (Throwable t) {
+            return null;
+        } finally {
+            if (p != null && p.isAlive()) {
+                p.destroyForcibly();
+            }
+        }
+    }
+
+    private static byte[] readAll(InputStream in) throws Exception {
+        // Probe outputs are tiny; a single bounded read is plenty.
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        byte[] buf = new byte[1024];
+        int n;
+        while ((n = in.read(buf)) != -1) {
+            out.write(buf, 0, n);
+            if (out.size() > 1 << 16) {
+                break;
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private static int parseFirstInt(String s) {
+        if (s == null) {
+            return -1;
+        }
+        Matcher m = Pattern.compile("\\d+").matcher(s);
+        return m.find() ? Integer.parseInt(m.group()) : -1;
+    }
+
+    private static int sumInts(String s) {
+        if (s == null) {
+            return -1;
+        }
+        Matcher m = Pattern.compile("\\d+").matcher(s);
+        int sum = 0;
+        boolean any = false;
+        while (m.find()) {
+            sum += Integer.parseInt(m.group());
+            any = true;
+        }
+        return any ? sum : -1;
     }
 }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/util/TestPhysicalCoreExecutor.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/util/TestPhysicalCoreExecutor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jbellis.jvector.util;
+
+import io.github.jbellis.jvector.LuceneTestCase;
+import org.junit.Test;
+
+import java.util.concurrent.ForkJoinPool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class TestPhysicalCoreExecutor extends LuceneTestCase {
+
+    @Test
+    public void resolvedCountIsSaneAndCached() {
+        int logical = Runtime.getRuntime().availableProcessors();
+        int count = PhysicalCoreExecutor.getPhysicalCoreCount();
+        // Whether resolved from the property, an OS probe, or the heuristic fallback, the count
+        // must be a positive value that never exceeds the logical processors visible to the JVM.
+        assertTrue("count must be >= 1, got " + count, count >= 1);
+        assertTrue("count (" + count + ") must be <= availableProcessors (" + logical + ")",
+                count <= logical);
+        // Repeated calls return the cached value.
+        assertEquals(count, PhysicalCoreExecutor.getPhysicalCoreCount());
+    }
+
+    @Test
+    public void poolMatchesResolvedCountAndIsShared() {
+        ForkJoinPool pool = PhysicalCoreExecutor.pool();
+        assertNotNull(pool);
+        assertEquals(PhysicalCoreExecutor.getPhysicalCoreCount(), pool.getParallelism());
+        // pool()/instance() hand back the same lazily-created singleton.
+        assertSame(pool, PhysicalCoreExecutor.pool());
+        assertSame(PhysicalCoreExecutor.instance(), PhysicalCoreExecutor.instance());
+    }
+
+    @Test
+    public void explicitPropertyOverrideIsHonored() {
+        // The property is resolved once per JVM and cached; only assert against it when it is set,
+        // so this test is meaningful under -Djvector.physical_core_count and inert otherwise.
+        Integer override = Integer.getInteger("jvector.physical_core_count");
+        if (override != null) {
+            assertEquals(override.intValue(), PhysicalCoreExecutor.getPhysicalCoreCount());
+        }
+    }
+}


### PR DESCRIPTION
This branch PR makes two key changes:

* Cherry-picks [robust physical core count](https://github.com/datastax/jvector/pull/679), also PRed to main separately
* Makes compaction worker pools simply re-use the core thread pool used by nearly all other jvector internal tasks, as controlled by the parameter `jvector.physical_core_count`.

Given the thread resource changes here, this is likely impacting in a couple key areas:

1) Compaction will take fewer resources, and will not saturate a system as much as it did, protecting front-end serving resources in a typical embedding scenario.
2) If results from a couple comprehensive tests are accurate, this is a net improvement as well to compaction wall-clock and CPU efficiency (work done/cycle) due to less contention from the previous multi-pool setup which effectively allocated 1.5x or higher (not counting the core thread pool) threads vs system availability.

These previously run tests also indicated robust recall results across several scenarios including different datasets and sizes up to 10M, so recall was effectively unchanged compared to previous results with this compaction branch. What did change was the operational envelope (as described above)

Nonetheless, given that this is a relatively non-trivial adjustment to the operational profile near a release, we need to have sufficient testing on it.

I feel very strongly that we *should not* merge the upstream compaction-pr without this pr merged into it first, as the system saturation which would occur with the current thread pool configuration would certainly impact front-end operations.
