### PR TITLE
Disable TopK/filtered pruning, preserve legacy threshold behavior

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphSearcher.java
@@ -86,7 +86,7 @@ public class GraphSearcher implements Closeable {
         this.rerankedResults = new NodeQueue(new BoundedLongHeap(100), NodeQueue.Order.MIN_HEAP);
         this.visited = new IntHashSet();
 
-        this.pruneSearch = true;
+        this.pruneSearch = false;
         this.scoreTrackerFactory = new ScoreTracker.ScoreTrackerFactory();
     }
 
@@ -117,12 +117,16 @@ public class GraphSearcher implements Closeable {
     }
 
     /**
-     * When using pruning, we are using a heuristic to terminate the search earlier.
-     * In certain cases, it can lead to speedups. This is set to false by default.
-     * @param usage a boolean that determines whether we do early termination or not.
+     * @deprecated TopK and filtered graph-search pruning is disabled because the
+     * existing heuristic can reduce recall and has not shown reliable production
+     * value. This method is retained for API compatibility and has no effect.
+     *
+     * Threshold searches, where {@code threshold > 0}, continue to use their
+     * legacy threshold early-termination behavior.
      */
+    @Deprecated
     public void usePruning(boolean usage) {
-        pruneSearch = usage;
+        pruneSearch = false;
     }
 
     /**
@@ -339,14 +343,17 @@ public class GraphSearcher implements Closeable {
 
     private boolean stopSearch(NodeQueue localCandidates, ScoreTracker scoreTracker, int rerankK, float threshold) {
         float topCandidateScore = localCandidates.topScore();
+
         // we're done when we have K results and the best candidate is worse than the worst result so far
         if (approximateResults.size() >= rerankK && topCandidateScore < approximateResults.topScore()) {
             return true;
         }
-        // when querying by threshold, also stop when we are probabilistically unlikely to find more qualifying results
+
+        // preserve legacy threshold early termination
         if (threshold > 0 && scoreTracker.shouldStop()) {
             return true;
         }
+
         return false;
     }
 
@@ -394,8 +401,9 @@ public class GraphSearcher implements Closeable {
             assert approximateResults.size() == 0; // should be cleared by setEntryPointsFromPreviousLayer
             approximateResults.setMaxSize(rerankK);
 
-            // track scores to predict when we are done with threshold queries
-            var scoreTracker = scoreTrackerFactory.getScoreTracker(pruneSearch, rerankK, threshold);
+            // TopK and filtered pruning are disabled. Threshold searches retain their
+            // legacy threshold early-termination path inside ScoreTrackerFactory.
+            var scoreTracker = scoreTrackerFactory.getScoreTracker(false, rerankK, threshold);
 
             // the main search loop
             while (candidates.size() > 0) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ScoreTracker.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ScoreTracker.java
@@ -36,32 +36,23 @@ public interface ScoreTracker {
         }
 
         public ScoreTracker getScoreTracker(boolean pruneSearch, int rerankK, float threshold) {
-            // track scores to predict when we are done with threshold queries
-            final ScoreTracker scoreTracker;
-
+            // Preserve legacy threshold behavior. Threshold searches used TwoPhaseTracker
+            // independent of the pruning flag, and may still do so for compatibility.
             if (threshold > 0) {
                 if (twoPhaseTracker == null) {
                     twoPhaseTracker = new ScoreTracker.TwoPhaseTracker(threshold);
                 } else {
                     twoPhaseTracker.reset(threshold);
                 }
-                scoreTracker = twoPhaseTracker;
-            } else {
-                if (pruneSearch) {
-                    if (relaxedMonotonicityTracker == null) {
-                        relaxedMonotonicityTracker = new ScoreTracker.RelaxedMonotonicityTracker(rerankK);
-                    } else {
-                        relaxedMonotonicityTracker.reset(rerankK);
-                    }
-                    scoreTracker = relaxedMonotonicityTracker;
-                } else {
-                    if (noOpTracker == null) {
-                        noOpTracker = new ScoreTracker.NoOpTracker();
-                    }
-                    scoreTracker = noOpTracker;
-                }
+                return twoPhaseTracker;
             }
-            return scoreTracker;
+
+            // TopK and filtered pruning are disabled. Do not return
+            // RelaxedMonotonicityTracker, regardless of caller preference.
+            if (noOpTracker == null) {
+                noOpTracker = new ScoreTracker.NoOpTracker();
+            }
+            return noOpTracker;
         }
     }
 

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestLowCardinalityFiltering.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestLowCardinalityFiltering.java
@@ -51,8 +51,8 @@ public class TestLowCardinalityFiltering extends LuceneTestCase {
      */
     @Test
     public void testLowCardinalityFiltering() throws IOException {
-            testLowCardinalityFiltering(32, 0.044f, 0.91f, false);
-            testLowCardinalityFiltering(32, 0.048f, 0.93f, true);
+            testLowCardinalityFiltering(32, 0.055f, 0.95f, false);
+            testLowCardinalityFiltering(32, 0.055f, 0.95f, true);
     }
     public void testLowCardinalityFiltering(int maxDegree, float visitedRatioThreshold, float recallThreshold, boolean addHierarchy) throws IOException {
         var R = getRandom();

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestPruningCompatibility.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestPruningCompatibility.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import io.github.jbellis.jvector.LuceneTestCase;
+import io.github.jbellis.jvector.TestUtil;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
+import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.util.FixedBitSet;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class TestPruningCompatibility extends LuceneTestCase {
+    private static final int N_VECTORS = 10_000;
+    private static final int N_QUERIES = 10;
+    private static final int DIMENSIONS = 16;
+    private static final int TOP_K = 10;
+    private static final int RERANK_K = 100;
+    private static final int THRESHOLD_TOP_K_CAP = 1_000;
+    private static final int MAX_DEGREE = 32;
+    private static final VectorSimilarityFunction SIMILARITY = VectorSimilarityFunction.COSINE;
+
+    @Test
+    public void testScoreTrackerFactoryPolicy() {
+        var factory = new ScoreTracker.ScoreTrackerFactory();
+
+        assertTrue(factory.getScoreTracker(false, RERANK_K, 0.0f) instanceof ScoreTracker.NoOpTracker);
+        assertTrue(factory.getScoreTracker(true, RERANK_K, 0.0f) instanceof ScoreTracker.NoOpTracker);
+
+        // Preserve legacy threshold behavior: threshold searches still use TwoPhaseTracker.
+        assertTrue(factory.getScoreTracker(false, RERANK_K, 0.5f) instanceof ScoreTracker.TwoPhaseTracker);
+        assertTrue(factory.getScoreTracker(true, RERANK_K, 0.5f) instanceof ScoreTracker.TwoPhaseTracker);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testUsePruningIgnoredForTopKAndFilteredTopK() throws IOException {
+        for (boolean addHierarchy : List.of(false, true)) {
+            Fixture fixture = buildFixture(addHierarchy);
+
+            for (VectorFloat<?> query : fixture.queries) {
+                assertSameWithPruningOffAndOn(fixture, query, Bits.ALL, 0.0f, TOP_K, RERANK_K);
+                assertSameWithPruningOffAndOn(fixture, query, fixture.evenOrds, 0.0f, TOP_K, RERANK_K);
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testUsePruningIgnoredForThresholdSearch() throws IOException {
+        for (boolean addHierarchy : List.of(false, true)) {
+            Fixture fixture = buildFixture(addHierarchy);
+
+            for (VectorFloat<?> query : fixture.queries) {
+                float threshold = exactThreshold(fixture.ravv, query, 100);
+
+                assertSameWithPruningOffAndOn(
+                        fixture,
+                        query,
+                        Bits.ALL,
+                        threshold,
+                        THRESHOLD_TOP_K_CAP,
+                        THRESHOLD_TOP_K_CAP);
+            }
+        }
+    }
+
+    private void assertSameWithPruningOffAndOn(Fixture fixture,
+                                               VectorFloat<?> query,
+                                               Bits acceptOrds,
+                                               float threshold,
+                                               int topK,
+                                               int rerankK) {
+        SearchResult pruningOff = search(fixture, query, acceptOrds, threshold, topK, rerankK, false);
+        SearchResult pruningOn = search(fixture, query, acceptOrds, threshold, topK, rerankK, true);
+
+        assertEquals(pruningOff.getVisitedCount(), pruningOn.getVisitedCount());
+        assertEquals(pruningOff.getNodes().length, pruningOn.getNodes().length);
+        assertArrayEquals(sortedNodes(pruningOff), sortedNodes(pruningOn));
+
+        if (threshold > 0.0f) {
+            assertAllAtOrAboveThreshold(fixture, query, threshold, pruningOff);
+            assertAllAtOrAboveThreshold(fixture, query, threshold, pruningOn);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private SearchResult search(Fixture fixture,
+                                VectorFloat<?> query,
+                                Bits acceptOrds,
+                                float threshold,
+                                int topK,
+                                int rerankK,
+                                boolean usePruning) {
+        var searcher = new GraphSearcher(fixture.graph);
+        searcher.usePruning(usePruning);
+
+        var sf = fixture.ravv.rerankerFor(query, SIMILARITY);
+        return searcher.search(
+                new DefaultSearchScoreProvider(sf),
+                topK,
+                rerankK,
+                threshold,
+                0.0f,
+                acceptOrds);
+    }
+
+    private Fixture buildFixture(boolean addHierarchy) throws IOException {
+        var random = getRandom();
+
+        VectorFloat<?>[] vectors = TestVectorGraph.createRandomFloatVectors(N_VECTORS, DIMENSIONS, random);
+        var ravv = new ListRandomAccessVectorValues(List.of(vectors), DIMENSIONS);
+
+        var builder = new GraphIndexBuilder(
+                ravv,
+                SIMILARITY,
+                MAX_DEGREE,
+                2 * MAX_DEGREE,
+                1.2f,
+                1.2f,
+                addHierarchy);
+        var graph = builder.build(ravv);
+
+        FixedBitSet evenOrds = new FixedBitSet(N_VECTORS);
+        for (int i = 0; i < N_VECTORS; i += 2) {
+            evenOrds.set(i);
+        }
+
+        VectorFloat<?>[] queries = new VectorFloat<?>[N_QUERIES];
+        for (int i = 0; i < N_QUERIES; i++) {
+            queries[i] = TestUtil.randomVector(random, DIMENSIONS);
+        }
+
+        return new Fixture(ravv, graph, evenOrds, queries);
+    }
+
+    private float exactThreshold(RandomAccessVectorValues ravv,
+                                 VectorFloat<?> query,
+                                 int targetMatches) {
+        float[] scores = new float[ravv.size()];
+        for (int i = 0; i < ravv.size(); i++) {
+            scores[i] = SIMILARITY.compare(query, ravv.getVector(i));
+        }
+
+        Arrays.sort(scores);
+        return scores[scores.length - targetMatches];
+    }
+
+    private void assertAllAtOrAboveThreshold(Fixture fixture,
+                                             VectorFloat<?> query,
+                                             float threshold,
+                                             SearchResult result) {
+        for (var nodeScore : result.getNodes()) {
+            float score = SIMILARITY.compare(query, fixture.ravv.getVector(nodeScore.node));
+            assertTrue(
+                    "returned node below threshold: node=" + nodeScore.node
+                            + ", score=" + score
+                            + ", threshold=" + threshold,
+                    score + 1e-6f >= threshold);
+        }
+    }
+
+    private static int[] sortedNodes(SearchResult result) {
+        int[] nodes = Arrays.stream(result.getNodes())
+                .mapToInt(nodeScore -> nodeScore.node)
+                .toArray();
+        Arrays.sort(nodes);
+        return nodes;
+    }
+
+    private static class Fixture {
+        final RandomAccessVectorValues ravv;
+        final ImmutableGraphIndex graph;
+        final FixedBitSet evenOrds;
+        final VectorFloat<?>[] queries;
+
+        Fixture(RandomAccessVectorValues ravv,
+                ImmutableGraphIndex graph,
+                FixedBitSet evenOrds,
+                VectorFloat<?>[] queries) {
+            this.ravv = ravv;
+            this.graph = graph;
+            this.evenOrds = evenOrds;
+            this.queries = queries;
+        }
+    }
+}


### PR DESCRIPTION
This is a hotfix for JV 4.0.0-rc.8.  Resolves #678. 

## Summary

This hotfix disables the unsafe `threshold == 0` graph-search pruning path while preserving legacy threshold-search behavior for compatibility.

`GraphSearcher.usePruning(boolean)` is now deprecated and retained only for source and binary compatibility. Calls to this method no longer enable TopK or filtered-search pruning.

Threshold searches, where `threshold > 0`, continue to use the existing legacy threshold early-termination path. This is intentional because threshold search may already be used by customers, and changing that behavior in this hotfix could be a compatibility break.

In short:

```text
threshold == 0:
  RelaxedMonotonicityTracker is not used
  usePruning(true) is ignored
  plain and filtered TopK use standard graph-search termination

threshold > 0:
  legacy TwoPhaseTracker behavior is preserved
  threshold search behavior remains unchanged for compatibility
```

## Why This Change Is Needed

The existing TopK/filtered pruning implementation did not demonstrate reliable value and carried recall risk.

The original pruning design had several problems:

1. **Pruning was used to skip graph expansion.**  
   The search could pop a candidate and skip expanding its neighbors, then continue searching. In graph search, expansion is how better candidates are discovered, so this changes the traversal and can reduce recall.

2. **TopK pruning was redundant with standard graph-search termination.**  
   Plain TopK already has the standard frontier-vs-result-queue termination condition. Adding another relaxed-monotonicity signal can only terminate earlier than the normal search and therefore risks recall loss.

3. **Filtered TopK did not show useful benefit.**  
   This implementation already applies `acceptOrds` during traversal. In low-cardinality filtering tests, additional pruning saved almost no visits while sometimes reducing recall.

4. **Threshold pruning is imperfect but may be in use.**  
   Diagnostic threshold testing showed that the legacy threshold path can save substantial work for very selective thresholds, but it can lose recall for less-selective thresholds. Because this behavior existed previously, this hotfix preserves it rather than changing threshold semantics.

## Evidence From Filtering Tests

Filtered TopK was the primary case where pruning was expected to help. The observed benefit was negligible.

| Filter selectivity | Hierarchy | Visit reduction from pruning | Recall delta from pruning |
|---:|---:|---:|---:|
| 50% | off | 0.81% | -0.0082 |
| 10% | off | 0.05% | -0.0006 |
| 2% | off | 0.01% | -0.0003 |
| 50% | on | 0.06% | -0.0006 |
| 10% | on | 0.02% | -0.0001 |
| 2% | on | 0.00% | 0.0000 |

This indicates that the existing filtered-search implementation already gets the useful behavior from applying `acceptOrds` during traversal, and the additional relaxed pruning tracker does not provide meaningful value.

## Evidence From Threshold Diagnostics

Threshold pruning remains preserved for compatibility, but diagnostic testing showed why it should not be expanded or treated as a validated general pruning mechanism.

| Expected threshold matches | Visit reduction from legacy threshold pruning | Recall with pruning |
|---:|---:|---:|
| 25 | 79.05% | 1.000 |
| 100 | 79.05% | 0.932 |
| 500 | 68.50% | 0.618 |

## Implementation Notes

### `GraphSearcher.usePruning(boolean)`

The API is deprecated and retained for compatibility.

```java
/**
 * @deprecated TopK and filtered graph-search pruning is disabled because the
 * existing heuristic can reduce recall and has not shown reliable production
 * value. This method is retained for API compatibility and has no effect.
 *
 * Threshold searches, where {@code threshold > 0}, continue to use their
 * legacy threshold early-termination behavior.
 */
@Deprecated
public void usePruning(boolean usage) {
    pruneSearch = false;
}
```

## Compatibility Notes

- The public `usePruning(boolean)` method still exists.
- Existing callers will not get source or binary breakage from this change.
- Calls to `usePruning(true)` no longer enable TopK or filtered pruning.
- Threshold search behavior is preserved for compatibility.
- Callers that previously relied on TopK/filtered pruning may see slightly higher visited counts, but recall behavior should be safer and more predictable.

## Tests Added / Updated

### `TestPruningCompatibility`

Adds explicit coverage for the new compatibility contract.

#### `testScoreTrackerFactoryPolicy`

Verifies tracker selection:

```text
threshold == 0:
  pruneSearch=false -> NoOpTracker
  pruneSearch=true  -> NoOpTracker

threshold > 0:
  pruneSearch=false -> TwoPhaseTracker
  pruneSearch=true  -> TwoPhaseTracker
```

This confirms that `RelaxedMonotonicityTracker` is disabled for `threshold == 0`, while legacy threshold behavior is preserved.

#### `testUsePruningIgnoredForTopKAndFilteredTopK`

Verifies that `usePruning(true)` has no effect for:

```text
plain TopK
filtered TopK
hierarchy off
hierarchy on
```

The test compares pruning-on and pruning-off searches over the same graph, queries, and filters, and asserts:

```text
same returned nodes
same visited count
```

#### `testUsePruningIgnoredForThresholdSearch`

Verifies that `usePruning(true)` and `usePruning(false)` produce identical threshold-search behavior.

This confirms that the public pruning API is ignored, while the legacy threshold path remains unchanged.

### `TestLowCardinalityFiltering`

Keeps coverage for filtered TopK search behavior and filter correctness.

The test evaluates filtered search across multiple selectivities:

```text
50%
10%
2%
```

For each selectivity, the test compares pruning-off and pruning-on behavior over the same graph, queries, and filter set. It validates that returned nodes satisfy `acceptOrds` and records the visit/recall effect of pruning.

This test documents why filtered TopK pruning is being disabled: the measured visit reduction was negligible while recall could decrease slightly.

### `Test2DThreshold`

Continues to validate legacy threshold-search behavior.

This test is retained because threshold searches are intentionally preserved for compatibility. It checks that threshold queries continue to return sufficient matching nodes and meet the existing visited/recall expectations.

## Release Note Text

```markdown
Deprecated and disabled `GraphSearcher.usePruning(boolean)` for TopK and filtered searches.

The existing TopK/filter pruning heuristic could reduce recall and did not show reliable production value. The method remains available for source and binary compatibility, but enabling it no longer activates pruning for `threshold == 0` searches.

Legacy threshold-search behavior is preserved: searches with `threshold > 0` continue to use the existing threshold early-termination path.
```

## Future Work

Any future pruning implementation should be reintroduced only after a separate redesign and validation effort. A replacement should:

- never skip graph expansion for popped candidates;
- avoid upper-layer pruning;
- avoid redundant pruning for plain TopK;
- clearly separate TopK, filtered TopK, and threshold/range semantics;
- define the traversal signal it tracks;
- include representative recall and latency benchmarks across production-like datasets, dimensions, filter selectivities, and threshold selectivities. 