### PR TITLE
Allow bench workflow to run on PRs from forks

### DIFF
--- a/.github/workflows/checklist_comment_on_new_pr.yml
+++ b/.github/workflows/checklist_comment_on_new_pr.yml
@@ -1,6 +1,7 @@
 name: Comment on new Pull Request with checklist
 on:
-  pull_request:
+  # safe as long as this workflow doesn't access code from the PR branch
+  pull_request_target:
     types: opened
 
 jobs:

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -214,8 +214,7 @@ jobs:
             java ${{ matrix.jdk >= 20 && '--enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector' || '' }} \
               ${{ matrix.jdk >= 22 && '-Djvector.experimental.enable_native_vectorization=true' || '' }} \
               -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heap_dump/ -Xmx${HALF_MEM_GB}g \
-              -cp jvector-examples/target/jvector-examples-*-jar-with-dependencies.jar io.github.jbellis.jvector.example.AutoBenchYAML \
-              --match-all-datasets --output ${SAFE_BRANCH}-bench-results ${CONFIG_ARG} openai-1536-1m
+              -cp jvector-examples/target/jvector-examples-*-jar-with-dependencies.jar io.github.jbellis.jvector.example.AutoBenchYAML --output ${SAFE_BRANCH}-bench-results ${CONFIG_ARG} dpr-gemma-1m
           else
             java ${{ matrix.jdk >= 20 && '--enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector' || '' }} \
               ${{ matrix.jdk >= 22 && '-Djvector.experimental.enable_native_vectorization=true' || '' }} \

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -24,6 +24,7 @@ on:
       - '**/src/main/java/**'
       - 'pom.xml'
       - '**/pom.xml'
+      - '.github/workflows/run-bench.yml'
 
 jobs:
   # Job to generate the matrix configuration
@@ -41,8 +42,8 @@ jobs:
 
           # Default branches based on event type
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "Pull request detected. Using main and PR branch: ${{ github.head_ref }}"
-            BRANCHES='["main", "${{ github.head_ref }}"]'
+            echo "Pull request detected. Using main and PR ref: ${{ github.ref }}"
+            BRANCHES='["main", "${{ github.ref }}"]'
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.branches }}" ]]; then
             # Parse space-separated branches input into JSON array
             echo "Workflow dispatch with branches input detected"
@@ -213,7 +214,8 @@ jobs:
             java ${{ matrix.jdk >= 20 && '--enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector' || '' }} \
               ${{ matrix.jdk >= 22 && '-Djvector.experimental.enable_native_vectorization=true' || '' }} \
               -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heap_dump/ -Xmx${HALF_MEM_GB}g \
-              -cp jvector-examples/target/jvector-examples-*-jar-with-dependencies.jar io.github.jbellis.jvector.example.AutoBenchYAML --output ${SAFE_BRANCH}-bench-results ${CONFIG_ARG} dpr-gemma-1m
+              -cp jvector-examples/target/jvector-examples-*-jar-with-dependencies.jar io.github.jbellis.jvector.example.AutoBenchYAML \
+              --match-all-datasets --output ${SAFE_BRANCH}-bench-results ${CONFIG_ARG} openai-1536-1m
           else
             java ${{ matrix.jdk >= 20 && '--enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector' || '' }} \
               ${{ matrix.jdk >= 22 && '-Djvector.experimental.enable_native_vectorization=true' || '' }} \

--- a/.github/workflows/run-compaction.yml
+++ b/.github/workflows/run-compaction.yml
@@ -19,6 +19,7 @@ on:
       - '**/src/main/java/**'
       - 'pom.xml'
       - '**/pom.xml'
+      - '.github/workflows/run-compaction.yml'
 
 jobs:
   # Job to generate the matrix configuration

--- a/.github/workflows/run-compaction.yml
+++ b/.github/workflows/run-compaction.yml
@@ -31,7 +31,7 @@ jobs:
         id: set-matrix
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BRANCHES='["main", "${{ github.head_ref }}"]'
+            BRANCHES='["main", "${{ github.ref }}"]'
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.branches }}" ]]; then
             BRANCHES_INPUT="${{ github.event.inputs.branches }}"
             BRANCHES="["

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/AutoBenchYAML.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/AutoBenchYAML.java
@@ -76,20 +76,17 @@ public class AutoBenchYAML {
         String finalOutputPath = outputPath;
         String configPath = null;
         int diagnostic_level = 0;
-        boolean matchAllDatasets = false;
-        for (int i = 0; i < args.length; i++) {
-            if (i < args.length - 1 && args[i].equals("--config")) configPath = args[i+1];
-            if (i < args.length - 1 && args[i].equals("--diag")) diagnostic_level = Integer.parseInt(args[i+1]);
-            if (args[i].equals("--match-all-datasets")) matchAllDatasets = true;
+        for (int i = 0; i < args.length - 1; i++) {
+            if (args[i].equals("--config")) configPath = args[i+1];
+            if (args[i].equals("--diag")) diagnostic_level = Integer.parseInt(args[i+1]);
         }
         if (diagnostic_level > 0) {
             Grid.setDiagnosticLevel(diagnostic_level);
         }
         String finalConfigPath = configPath;
         String[] filteredArgs = Arrays.stream(args)
-                .filter(arg -> !arg.equals("--output") && !arg.equals(finalOutputPath) &&
-                               !arg.equals("--config") && !arg.equals(finalConfigPath) &&
-                               !arg.equals("--match-all-datasets"))
+                .filter(arg -> !arg.equals("--output") && !arg.equals(finalOutputPath) && 
+                               !arg.equals("--config") && !arg.equals(finalConfigPath))
                 .toArray(String[]::new);
 
         // Log the filtered arguments for debugging
@@ -103,12 +100,7 @@ public class AutoBenchYAML {
         var pattern = Pattern.compile(regex);
 
         var datasetCollection = DatasetCollection.load();
-        var candidateDatasets = matchAllDatasets ? datasetCollection.getAll() : datasetCollection.getSection(REGRESSION_TEST_KEY);
-        var datasetNames = candidateDatasets.stream().filter(dn -> pattern.matcher(dn).find()).collect(Collectors.toList());
-
-        if (datasetNames.size() == 0) {
-            throw new RuntimeException("No datasets matched the given patterns, nothing to do");
-        }
+        var datasetNames = datasetCollection.getSection(REGRESSION_TEST_KEY).stream().filter(dn -> pattern.matcher(dn).find()).collect(Collectors.toList());
 
         logger.info("Executing the following datasets: {}", datasetNames);
         List<BenchResult> results = new ArrayList<>();

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/AutoBenchYAML.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/AutoBenchYAML.java
@@ -76,17 +76,20 @@ public class AutoBenchYAML {
         String finalOutputPath = outputPath;
         String configPath = null;
         int diagnostic_level = 0;
-        for (int i = 0; i < args.length - 1; i++) {
-            if (args[i].equals("--config")) configPath = args[i+1];
-            if (args[i].equals("--diag")) diagnostic_level = Integer.parseInt(args[i+1]);
+        boolean matchAllDatasets = false;
+        for (int i = 0; i < args.length; i++) {
+            if (i < args.length - 1 && args[i].equals("--config")) configPath = args[i+1];
+            if (i < args.length - 1 && args[i].equals("--diag")) diagnostic_level = Integer.parseInt(args[i+1]);
+            if (args[i].equals("--match-all-datasets")) matchAllDatasets = true;
         }
         if (diagnostic_level > 0) {
             Grid.setDiagnosticLevel(diagnostic_level);
         }
         String finalConfigPath = configPath;
         String[] filteredArgs = Arrays.stream(args)
-                .filter(arg -> !arg.equals("--output") && !arg.equals(finalOutputPath) && 
-                               !arg.equals("--config") && !arg.equals(finalConfigPath))
+                .filter(arg -> !arg.equals("--output") && !arg.equals(finalOutputPath) &&
+                               !arg.equals("--config") && !arg.equals(finalConfigPath) &&
+                               !arg.equals("--match-all-datasets"))
                 .toArray(String[]::new);
 
         // Log the filtered arguments for debugging
@@ -100,7 +103,12 @@ public class AutoBenchYAML {
         var pattern = Pattern.compile(regex);
 
         var datasetCollection = DatasetCollection.load();
-        var datasetNames = datasetCollection.getSection(REGRESSION_TEST_KEY).stream().filter(dn -> pattern.matcher(dn).find()).collect(Collectors.toList());
+        var candidateDatasets = matchAllDatasets ? datasetCollection.getAll() : datasetCollection.getSection(REGRESSION_TEST_KEY);
+        var datasetNames = candidateDatasets.stream().filter(dn -> pattern.matcher(dn).find()).collect(Collectors.toList());
+
+        if (datasetNames.size() == 0) {
+            throw new RuntimeException("No datasets matched the given patterns, nothing to do");
+        }
 
         logger.info("Executing the following datasets: {}", datasetNames);
         List<BenchResult> results = new ArrayList<>();

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/AutoBenchYAML.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/AutoBenchYAML.java
@@ -102,6 +102,10 @@ public class AutoBenchYAML {
         var datasetCollection = DatasetCollection.load();
         var datasetNames = datasetCollection.getSection(REGRESSION_TEST_KEY).stream().filter(dn -> pattern.matcher(dn).find()).collect(Collectors.toList());
 
+        if (datasetNames.size() == 0) {
+            throw new RuntimeException("No datasets matched the given patterns, nothing to do");
+        }
+
         logger.info("Executing the following datasets: {}", datasetNames);
         List<BenchResult> results = new ArrayList<>();
         List<BenchResult> compactionResults = new ArrayList<>();


### PR DESCRIPTION
Allows all CI workflows to run correctly on PRs from forks. This mainly applies to the workflow which runs AutoBenchYAML.

- The workflow replaces `github.head.ref` (`fork-workflow-2`) with `github.ref` (`/refs/pull/688/merge`). The checkout action fails for the former if the branch is from a fork, but the latter works in both cases.
- The PR checklist commet workflow is updated to use the `pull_request_target` workflow rather the `pull_request` workflow. This allows the bot to add the PR checklist to PRs from forks. You'll notice that the bot did not comment on this PR, despite this change; this is because `pull_request_target` workflows are executed based on definitions in the main branch rather than the PR branch (for security reasons). This should work correctly on fork PRs raised _after_ this PR is merged.