### PR TITLE
fix for disk usage measurements

### DIFF
--- a/docs/release notes/4.1.0/692.testing.md
+++ b/docs/release notes/4.1.0/692.testing.md
@@ -1,0 +1,31 @@
+## This PR is a fix for an issue in how file sizes were calculated by the JVector test harness, i.e. BenchYAML and AutoBenchYAML.
+
+## Problem 1: The index cache directory accumulates across runs
+
+In Grid.runOneGraph (and runAllAndCollectResults), BenchmarkDiagnostics monitors two directories:
+diagnostics.startMonitoring("testDirectory", workDirectory);
+diagnostics.startMonitoring("indexCache", Paths.get(indexCacheDir));  // "index_cache/"
+getTotalBytes() sums both. The index_cache/ directory is persistent — it is never wiped between runs. So the reported disk figure grows monotonically across the run, regardless of which configuration is under test. The delta
+between a fused-PQ run and a non-fused-PQ run is invisible.
+
+## Problem 2: Even within a single run, the snapshot captures all feature sets, not just one
+
+When multiple feature sets are built in the same runOneGraph call, the directory total covers all of them. You can't attribute disk usage to a specific configuration from that number.
+
+There is even a TODO in the code acknowledging this at line 233:
+// TODO this does not capture disk usage for cached indexes. Need to update
+
+
+  ---
+## The fix
+
+Rather than directory-level monitoring, measure the specific graph file for each feature set directly after it is written. In buildOnDisk, the path for each feature set's graph file is already computed:
+
+if (handles.containsKey(features)) {
+graphPath = handles.get(features).writePath();
+} else {
+graphPath = outputDir.resolve("graph" + n++);
+}
+
+After the build completes, Files.size(graphPath) gives the exact on-disk size for that specific configuration. This value should be returned from buildOnDisk (as part of a result map keyed by feature set) and then included
+in the BenchResult params or metrics map alongside the other per-configuration numbers.

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -230,7 +230,6 @@ public class Grid {
         // Prepare to collect index construction metrics for reporting....
         var constructionMetrics = new ConstructionMetrics();
 
-        // TODO this does not capture disk usage for cached indexes.  Need to update
         // Capture initial memory and disk state
         try (var diagnostics = new BenchmarkDiagnostics(getDiagnosticLevel())) {
             diagnostics.startMonitoring("testDirectory", workDirectory);
@@ -253,6 +252,7 @@ public class Grid {
                     (buildCompressorObj == null) ? "None" : String.valueOf(buildCompressorObj);
 
             Map<Set<FeatureId>, ImmutableGraphIndex> indexes = new HashMap<>();
+            Map<Set<FeatureId>, Long> indexFileSizes = new HashMap<>();
             if (buildCompressorObj == null) {
                 indexes = buildInMemory(featureSets, M, efConstruction, neighborOverflow, addHierarchy, refineFinalGraph, ds, workDirectory);
             } else {
@@ -270,6 +270,7 @@ public class Grid {
                     if (cached.isPresent()) {
                         System.out.printf("%s: Using cached graph index for %s%n", key.datasetName, fs);
                         indexes.put(fs, cached.get());
+                        try { indexFileSizes.put(fs, Files.size(cache.resolve(key).finalPath)); } catch (IOException ignored) {}
                     } else {
                         missing.add(fs);
                         if (cache.isEnabled()) {
@@ -287,9 +288,10 @@ public class Grid {
                 if (!missing.isEmpty()) {
                     // At least one index needs to be built (b/c not in cache or cache is disabled)
                     // We pass the handles map so buildOnDisk knows exactly where to write
-                    var newIndexes = buildOnDisk(missing, M, efConstruction, neighborOverflow, addHierarchy, refineFinalGraph,
+                    var result = buildOnDisk(missing, M, efConstruction, neighborOverflow, addHierarchy, refineFinalGraph,
                             ds, outputDir, buildCompressorObj, handles, constructionMetrics);
-                    indexes.putAll(newIndexes);
+                    indexes.putAll(result.indexes);
+                    indexFileSizes.putAll(result.fileSizes);
                 }
             }
 
@@ -303,6 +305,7 @@ public class Grid {
             try {
                 for (var cpSupplier : compressionGrid) {
                     indexes.forEach((features, index) -> {
+                        constructionMetrics.indexFileSizeBytes = indexFileSizes.get(features);
                         final Set<FeatureId> featureSetForIndex = index instanceof OnDiskGraphIndex ? ((OnDiskGraphIndex) index).getFeatureSet() : Set.of();
 
                         CompressedVectors cv;
@@ -364,7 +367,7 @@ public class Grid {
         }
     }
 
-    private static Map<Set<FeatureId>, ImmutableGraphIndex> buildOnDisk(List<? extends Set<FeatureId>> featureSets,
+    private static BuildOnDiskResult buildOnDisk(List<? extends Set<FeatureId>> featureSets,
                                                                         int M,
                                                                         int efConstruction,
                                                                         float neighborOverflow,
@@ -464,8 +467,9 @@ public class Grid {
             entry.getValue().commit();
         }
 
-        // open indexes
+        // open indexes and capture per-feature-set file sizes
         Map<Set<FeatureId>, ImmutableGraphIndex> indexes = new HashMap<>();
+        Map<Set<FeatureId>, Long> fileSizes = new HashMap<>();
         n = 0;
         for (var features : featureSets) {
             Path loadPath = handles.containsKey(features)
@@ -473,9 +477,10 @@ public class Grid {
                     : outputDir.resolve("graph" + n++);
 
             indexes.put(features, OnDiskGraphIndex.load(ReaderSupplierFactory.open(loadPath)));
+            fileSizes.put(features, Files.size(loadPath));
         }
 
-        return indexes;
+        return new BuildOnDiskResult(indexes, fileSizes);
     }
 
     private static BuilderWithSuppliers builderWithSuppliers(Set<FeatureId> features,
@@ -845,6 +850,7 @@ public class Grid {
                                             diagnostics.startMonitoring("indexCache", Paths.get(indexCacheDir));
                                             diagnostics.capturePrePhaseSnapshot("Build");
                                             Map<Set<FeatureId>, ImmutableGraphIndex> indexes = new HashMap<>();
+                                            Map<Set<FeatureId>, Long> indexFileSizes = new HashMap<>();
 
                                             var compressor = getCompressor(buildCompressor, ds);
                                             var searchCompressorObj = getCompressor(searchCompressor, ds);
@@ -885,6 +891,7 @@ public class Grid {
                                                 if (cached.isPresent()) {
                                                     System.out.printf("%s: Using cached graph index for %s%n", key.datasetName, fs);
                                                     indexes.put(fs, cached.get());
+                                                    try { indexFileSizes.put(fs, Files.size(cache.resolve(key).finalPath)); } catch (IOException ignored) {}
                                                 } else {
                                                     missing.add(fs);
                                                     if (cache.isEnabled()) {
@@ -903,9 +910,10 @@ public class Grid {
                                             if (!missing.isEmpty()) {
                                                 // At least one index needs to be built (b/c not in cache or cache is disabled)
                                                 // We pass the handles map so buildOnDisk knows exactly where to write
-                                                var newIndexes = buildOnDisk(missing, m, ef, neighborOverflow, addHierarchy, refineFinalGraph,
+                                                var result = buildOnDisk(missing, m, ef, neighborOverflow, addHierarchy, refineFinalGraph,
                                                         ds, outputDir, compressor, handles, null);
-                                                indexes.putAll(newIndexes);
+                                                indexes.putAll(result.indexes);
+                                                indexFileSizes.putAll(result.fileSizes);
                                             }
 
                                             ImmutableGraphIndex index = indexes.get(features);
@@ -914,7 +922,6 @@ public class Grid {
                                             diagnostics.capturePostPhaseSnapshot("Build");
                                             diagnostics.printDiskStatistics("Graph Index Build");
                                             var buildSnapshot = diagnostics.getLatestSystemSnapshot();
-                                            DiskUsageMonitor.MultiDirectorySnapshot buildDiskSnapshot = diagnostics.getLatestDiskSnapshot();
 
                                             try (ConfiguredSystem cs = new ConfiguredSystem(ds, index, cvArg, features)) {
                                                 int queryRuns = 2;
@@ -966,10 +973,10 @@ public class Grid {
                                                                 allMetrics.put("Total Off-Heap (MB)", buildSnapshot.memoryStats.getTotalOffHeapMemory() / 1024.0 / 1024.0);
                                                             }
 
-                                                            // Add disk metrics if available
-                                                            if (buildDiskSnapshot != null) {
-                                                                allMetrics.put("Disk Usage (MB)", buildDiskSnapshot.getTotalBytes() / 1024.0 / 1024.0);
-                                                                allMetrics.put("File Count", buildDiskSnapshot.getTotalFileCount());
+                                                            // Add per-feature-set index file size
+                                                            Long fileSizeBytes = indexFileSizes.get(features);
+                                                            if (fileSizeBytes != null) {
+                                                                allMetrics.put("Disk Usage (MB)", fileSizeBytes / 1024.0 / 1024.0);
                                                             }
 
                                                             results.add(new BenchResult(ds.getName(), params, allMetrics));
@@ -1161,9 +1168,19 @@ public class Grid {
      * <p>Call {@link #appendTo(List)} to emit these as {@link Metric} entries so they can be selected for
      * console/CSV reporting.</p>
      */
+    private static final class BuildOnDiskResult {
+        final Map<Set<FeatureId>, ImmutableGraphIndex> indexes;
+        final Map<Set<FeatureId>, Long> fileSizes;
+        BuildOnDiskResult(Map<Set<FeatureId>, ImmutableGraphIndex> indexes, Map<Set<FeatureId>, Long> fileSizes) {
+            this.indexes = indexes;
+            this.fileSizes = fileSizes;
+        }
+    }
+
     static final class ConstructionMetrics {
         // null means “not applicable / not measured”
         public Double indexBuildTimeS;
+        public Long indexFileSizeBytes;
 
         // Index-construction phase (single pass per run)
         private final Map<String, QuantStats> indexByType = new HashMap<>();
@@ -1192,6 +1209,10 @@ public class Grid {
             if (indexBuildTimeS != null) {
                 out.add(Metric.of("construction.index_build_time_s",
                         "Index build time (s)", ".2f", indexBuildTimeS));
+            }
+            if (indexFileSizeBytes != null) {
+                out.add(Metric.of("construction.index_file_size_mb",
+                        "Index file size (MB)", ".2f", indexFileSizeBytes / 1024.0 / 1024.0));
             }
 
             // Index-construction quant timings

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -29,7 +29,6 @@ import io.github.jbellis.jvector.example.benchmarks.ThroughputBenchmark;
 import io.github.jbellis.jvector.example.benchmarks.diagnostics.BenchmarkDiagnostics;
 import io.github.jbellis.jvector.example.benchmarks.diagnostics.DiagnosticLevel;
 import io.github.jbellis.jvector.example.benchmarks.datasets.DataSet;
-import io.github.jbellis.jvector.example.benchmarks.diagnostics.DiskUsageMonitor;
 import io.github.jbellis.jvector.example.reporting.*;
 import io.github.jbellis.jvector.example.reporting.RunArtifacts;
 import io.github.jbellis.jvector.example.util.CompressorParameters;
@@ -364,6 +363,19 @@ public class Grid {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Result of {@link #buildOnDisk}: for each feature set built, the graph index re-opened
+     * from the written file and the size in bytes of that file on disk.
+     */
+    private static final class BuildOnDiskResult {
+        final Map<Set<FeatureId>, ImmutableGraphIndex> indexes;
+        final Map<Set<FeatureId>, Long> fileSizes;
+        BuildOnDiskResult(Map<Set<FeatureId>, ImmutableGraphIndex> indexes, Map<Set<FeatureId>, Long> fileSizes) {
+            this.indexes = indexes;
+            this.fileSizes = fileSizes;
         }
     }
 
@@ -1157,24 +1169,6 @@ public class Grid {
         if (cp instanceof CompressorParameters.BQParameters) return "BQ";
         // Unknown/unsupported type for quant timing purposes
         return null;
-    }
-
-    /**
-     * Construction/search quantization timing metrics captured while building an index and while encoding
-     * vectors for search-time evaluation.
-     *
-     * <p>Values may be {@code null} when not measured or not applicable (e.g., cache hit).</p>
-     *
-     * <p>Call {@link #appendTo(List)} to emit these as {@link Metric} entries so they can be selected for
-     * console/CSV reporting.</p>
-     */
-    private static final class BuildOnDiskResult {
-        final Map<Set<FeatureId>, ImmutableGraphIndex> indexes;
-        final Map<Set<FeatureId>, Long> fileSizes;
-        BuildOnDiskResult(Map<Set<FeatureId>, ImmutableGraphIndex> indexes, Map<Set<FeatureId>, Long> fileSizes) {
-            this.indexes = indexes;
-            this.fileSizes = fileSizes;
-        }
     }
 
     static final class ConstructionMetrics {

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/Grid.java
@@ -1171,6 +1171,15 @@ public class Grid {
         return null;
     }
 
+    /**
+     * Construction/search quantization timing metrics captured while building an index and while encoding
+     * vectors for search-time evaluation.
+     *
+     * <p>Values may be {@code null} when not measured or not applicable (e.g., cache hit).</p>
+     *
+     * <p>Call {@link #appendTo(List)} to emit these as {@link Metric} entries so they can be selected for
+     * console/CSV reporting.</p>
+     */
     static final class ConstructionMetrics {
         // null means “not applicable / not measured”
         public Double indexBuildTimeS;


### PR DESCRIPTION
### This PR is a fix for an issue in how file sizes were calculated by the JVector test harness, i.e. BenchYAML and AutoBenchYAML. 

## Problem 1: The index cache directory accumulates across runs

  In Grid.runOneGraph (and runAllAndCollectResults), BenchmarkDiagnostics monitors two directories:
  diagnostics.startMonitoring("testDirectory", workDirectory);
  diagnostics.startMonitoring("indexCache", Paths.get(indexCacheDir));  // "index_cache/"
  getTotalBytes() sums both. The index_cache/ directory is persistent — it is never wiped between runs. So the reported disk figure grows monotonically across the run, regardless of which configuration is under test. The delta
  between a fused-PQ run and a non-fused-PQ run is invisible.

## Problem 2: Even within a single run, the snapshot captures all feature sets, not just one

  When multiple feature sets are built in the same runOneGraph call, the directory total covers all of them. You can't attribute disk usage to a specific configuration from that number.

  There is even a TODO in the code acknowledging this at line 233:
  // TODO this does not capture disk usage for cached indexes. Need to update


  ---
 ## The fix

  Rather than directory-level monitoring, measure the specific graph file for each feature set directly after it is written. In buildOnDisk, the path for each feature set's graph file is already computed:

  if (handles.containsKey(features)) {
      graphPath = handles.get(features).writePath();
  } else {
      graphPath = outputDir.resolve("graph" + n++);
  }

  After the build completes, Files.size(graphPath) gives the exact on-disk size for that specific configuration. This value should be returned from buildOnDisk (as part of a result map keyed by feature set) and then included
  in the BenchResult params or metrics map alongside the other per-configuration numbers.
