### PR TITLE
Expose the NVQ getter

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/NVQ.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/NVQ.java
@@ -88,6 +88,10 @@ public class NVQ extends AbstractFeature {
         }
     }
 
+    public NVQuantization getNVQuantization() {
+        return nvq;
+    }
+
     public ScoreFunction.ExactScoreFunction rerankerFor(VectorFloat<?> queryVector,
                                                         VectorSimilarityFunction vsf,
                                                         FeatureSource source) {


### PR DESCRIPTION
In OpenSearch, we plan to make use of the NVQ Feature presence, if NVQ vectors need to be dequantized back to float. The current technique is using reflection, but it would be better to expose the getter which will make the implementation cleaner. 

https://github.com/opensearch-project/opensearch-jvector/pull/539/changes/BASE..1122f0d283d441efa697e72d2d0a9311b09e3820#diff-76d766440abecf3c20679bf1b8eb51eead85a9363a60478703aedcadf4d4f73dR417