### PR TITLE
Add toArray method to existing VectorFloat<?> to access underlying float[] vectors representation

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayVectorFloat.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ArrayVectorFloat.java
@@ -123,5 +123,10 @@ final public class ArrayVectorFloat implements VectorFloat<float[]>
     {
         return this.getHashCode();
     }
+
+    @Override
+    public float[] toArray() {
+        return get();
+    }
 }
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/VectorFloat.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/types/VectorFloat.java
@@ -55,4 +55,12 @@ public interface VectorFloat<T> extends Accountable
         }
         return result;
     }
+    
+    default float[] toArray() {
+        final float[] arr = new float[length()];
+        for (int i = 0; i < length(); ++i) {
+            arr[i] = get(i);
+        }
+        return arr;
+    }
 }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentVectorFloat.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/MemorySegmentVectorFloat.java
@@ -141,4 +141,9 @@ final public class MemorySegmentVectorFloat implements VectorFloat<MemorySegment
     public int hashCode() {
         return this.getHashCode();
     }
+
+    @Override
+    public float[] toArray() {
+        return (float[])segment.heapBase().get();
+    }
 }


### PR DESCRIPTION
Add `toArray `method to existing `VectorFloat<?>`API. This is simpler change (since we could provide the default implementation using `length()` + `get(index)` but we cannot guarantee that every `toArray` implementation is going to be zero copy, although we could document that.

Closes https://github.com/datastax/jvector/issues/696