### PR TITLE
Add int8 / byte-vector similarity support

### DIFF
--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/GraphIndexBuilder.java
@@ -23,6 +23,7 @@ import io.github.jbellis.jvector.graph.ImmutableGraphIndex.NodeAtLevel;
 import io.github.jbellis.jvector.graph.SearchResult.NodeScore;
 import io.github.jbellis.jvector.graph.diversity.VamanaDiversityProvider;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.graph.VectorValues;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.management.CompressionType;
@@ -32,7 +33,9 @@ import io.github.jbellis.jvector.quantization.BQVectors;
 import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.util.*;
+import io.github.jbellis.jvector.vector.ByteVectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,6 +115,11 @@ public class GraphIndexBuilder implements Closeable, Accountable {
             default:
                 throw new IllegalArgumentException("Unsupported build compression type: " + type);
         }
+    }
+
+    private static BuildScoreProvider getBuildScoreProvider(RandomAccessByteVectorValues vectorValues, ByteVectorSimilarityFunction similarityFunction) {
+        // Byte vectors do not support PQ/BQ build-time compression; always use the direct provider.
+        return BuildScoreProvider.byteVectorScoreProvider(vectorValues, similarityFunction);
     }
 
     /**
@@ -408,6 +416,31 @@ public class GraphIndexBuilder implements Closeable, Accountable {
     }
 
     /**
+     * Entry point for the fluent builder for int8 byte vectors, resolving the {@link BuildScoreProvider}
+     * from raw byte vectors via {@link BuildScoreProvider#byteVectorScoreProvider}.
+     *
+     * @param vectorValues       the int8 byte vectors whose relations are represented by the graph
+     * @param similarityFunction the byte-vector similarity function to score vectors with
+     * @param maxDegrees         the maximum number of connections a node can have in each layer; if fewer entries
+     *                           are specified than the number of layers, the last entry is used for all remaining layers.
+     */
+    public static Builder builder(RandomAccessByteVectorValues vectorValues, ByteVectorSimilarityFunction similarityFunction, List<Integer> maxDegrees) {
+        return new Builder(getBuildScoreProvider(vectorValues, similarityFunction), vectorValues.dimension(), maxDegrees);
+    }
+
+    /**
+     * Entry point for the fluent builder for int8 byte vectors, for the common case of a single
+     * (non-hierarchical) max degree.
+     *
+     * @param vectorValues       the int8 byte vectors whose relations are represented by the graph
+     * @param similarityFunction the byte-vector similarity function to score vectors with
+     * @param M                  the maximum number of connections a node can have
+     */
+    public static Builder builder(RandomAccessByteVectorValues vectorValues, ByteVectorSimilarityFunction similarityFunction, int M) {
+        return builder(vectorValues, similarityFunction, List.of(M));
+    }
+
+    /**
      * Entry point for the fluent builder, building from an existing {@link MutableGraphIndex} (e.g. one just
      * loaded from disk) rather than constructing a fresh {@link OnHeapGraphIndex}. {@code addHierarchy} is not
      * settable here — it is structural and is always derived from {@code mutableGraphIndex}'s own topology.
@@ -689,13 +722,17 @@ public class GraphIndexBuilder implements Closeable, Accountable {
         return newBuilder;
     }
 
-    public ImmutableGraphIndex build(RandomAccessVectorValues ravv) {
-        var vv = ravv.threadLocalSupplier();
+    /**
+     * Builds the graph from any {@link VectorValues} source — works for both
+     * {@link RandomAccessVectorValues} (float32) and {@link RandomAccessByteVectorValues} (int8).
+     * The score provider supplied at construction time determines how vectors are compared.
+     */
+    public ImmutableGraphIndex build(VectorValues<?> ravv) {
         int size = ravv.size();
 
         simdExecutor.submit(() -> {
             IntStream.range(0, size).parallel().forEach(node -> {
-                addGraphNode(node, vv.get().getVector(node));
+                addGraphNode(node, scoreProvider.searchProviderFor(node));
             });
         }).join();
 
@@ -842,6 +879,19 @@ public class GraphIndexBuilder implements Closeable, Accountable {
      * @return an estimate of the number of extra bytes used by the graph after adding the given node
      */
     public long addGraphNode(int node, VectorFloat<?> vector) {
+        var ssp = scoreProvider.searchProviderFor(vector);
+        return addGraphNode(node, ssp);
+    }
+
+    /**
+     * Inserts a node with the given int8 byte vector into the graph.
+     *
+     * @param node   the node ID to add
+     * @param vector the byte vector to add
+     * @return an estimate of the number of extra bytes used by the graph after adding the given node
+     * @throws UnsupportedOperationException if this builder was not constructed with a byte-vector score provider
+     */
+    public long addGraphNode(int node, ByteSequence<?> vector) {
         var ssp = scoreProvider.searchProviderFor(vector);
         return addGraphNode(node, ssp);
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ListRandomAccessByteVectorValues.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/ListRandomAccessByteVectorValues.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph;
+
+import io.github.jbellis.jvector.vector.types.ByteSequence;
+
+import java.util.List;
+
+/**
+ * A List-backed implementation of the {@link RandomAccessByteVectorValues} interface.
+ * <p>
+ * It is acceptable to provide this class to a GraphBuilder, and then continue
+ * to add vectors to the backing List as you add to the graph.
+ * <p>
+ * This will be as threadsafe as the provided List.
+ */
+public class ListRandomAccessByteVectorValues implements RandomAccessByteVectorValues {
+    private final List<ByteSequence<?>> vectors;
+    private final int dimension;
+
+    /**
+     * Construct a new instance of {@link ListRandomAccessByteVectorValues}.
+     *
+     * @param vectors   a (potentially mutable) list of byte vectors.
+     * @param dimension the dimension of the vectors.
+     */
+    public ListRandomAccessByteVectorValues(List<ByteSequence<?>> vectors, int dimension) {
+        this.vectors = vectors;
+        this.dimension = dimension;
+    }
+
+    @Override
+    public int size() {
+        return vectors.size();
+    }
+
+    @Override
+    public int dimension() {
+        return dimension;
+    }
+
+    @Override
+    public ByteSequence<?> getVector(int nodeId) {
+        return vectors.get(nodeId);
+    }
+
+    @Override
+    public boolean isValueShared() {
+        return false;
+    }
+
+    @Override
+    public ListRandomAccessByteVectorValues copy() {
+        return this;
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/RandomAccessByteVectorValues.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/RandomAccessByteVectorValues.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph;
+
+import io.github.jbellis.jvector.vector.types.ByteSequence;
+
+/**
+ * Provides random access to byte (int8) vectors by dense ordinal.
+ * <p>
+ * This is the byte-vector parallel to {@link RandomAccessVectorValues}.
+ * Both extend the common super-interface {@link VectorValues}.
+ * It is used by graph-based index builders and searchers that operate natively
+ * on int8 vectors without a float32 round-trip.
+ */
+public interface RandomAccessByteVectorValues extends VectorValues<ByteSequence<?>> {
+
+    /**
+     * Creates a new copy of this {@link RandomAccessByteVectorValues}.
+     * Un-shared implementations may simply return {@code this}.
+     */
+    @Override
+    RandomAccessByteVectorValues copy();
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/RandomAccessVectorValues.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/RandomAccessVectorValues.java
@@ -30,14 +30,15 @@ import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 /**
- * Provides random access to vectors by dense ordinal. This interface is used by graph-based
+ * Provides random access to float32 vectors by dense ordinal. This interface is used by graph-based
  * implementations of KNN search.
+ * <p>
+ * For int8 vectors see {@link RandomAccessByteVectorValues}.
+ * Both extend the common super-interface {@link VectorValues}.
  */
-public interface RandomAccessVectorValues {
-    Logger LOG = Logger.getLogger(RandomAccessVectorValues.class.getName());
+public interface RandomAccessVectorValues extends VectorValues<VectorFloat<?>> {
 
     /**
      * Return the number of vector values.
@@ -46,22 +47,8 @@ public interface RandomAccessVectorValues {
      * (1) implementing a threadsafe, un-shared RAVV, where `copy` returns `this`, or
      * (2) implementing a fixed-size RAVV.
      */
+    @Override
     int size();
-
-    /** Return the dimension of the returned vector values */
-    int dimension();
-
-    /**
-     * Return the vector value indexed at the given ordinal.
-     *
-     * <p>For performance, implementations are free to re-use the same object across invocations.
-     * That is, you will get back the same VectorFloat&lt;?&gt;
-     * reference (for instance) for every requested ordinal. If you want to use those values across
-     * calls, you should make a copy.
-     *
-     * @param nodeId a valid ordinal, &ge; 0 and &lt; {@link #size()}.
-     */
-    VectorFloat<?> getVector(int nodeId);
 
     @Deprecated
     default VectorFloat<?> vectorValue(int targetOrd) {
@@ -79,34 +66,14 @@ public interface RandomAccessVectorValues {
     }
 
     /**
-     * @return true iff the vector returned by `getVector` is shared.  A shared vector will
-     * only be valid until the next call to getVector overwrites it.
-     */
-    boolean isValueShared();
-
-    /**
      * Creates a new copy of this {@link RandomAccessVectorValues}. This is helpful when you need to
      * access different values at once, to avoid overwriting the underlying float vector returned by
      * a shared {@link RandomAccessVectorValues#getVector}.
      * <p>
      * Un-shared implementations may simply return `this`.
      */
+    @Override
     RandomAccessVectorValues copy();
-
-    /**
-     * Returns a supplier of thread-local copies of the RAVV.
-     */
-    default Supplier<RandomAccessVectorValues> threadLocalSupplier() {
-        if (!isValueShared()) {
-            return () -> this;
-        }
-
-        if (this instanceof AutoCloseable) {
-            LOG.warning("RAVV is shared and implements AutoCloseable; threadLocalSupplier() may lead to leaks");
-        }
-        var tl = ExplicitThreadLocal.withInitial(this::copy);
-        return tl::get;
-    }
 
     /**
      * Convenience method to create an ExactScoreFunction for reranking.  The resulting function is NOT thread-safe.

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/VectorValues.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/VectorValues.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph;
+
+import io.github.jbellis.jvector.util.ExplicitThreadLocal;
+
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+/**
+ * Common super-interface for random access to vectors by dense ordinal.
+ * <p>
+ * {@code V} is the vector element type — {@code VectorFloat<?>} for float32 vectors
+ * (see {@link RandomAccessVectorValues}) and {@code ByteSequence<?>} for int8 vectors
+ * (see {@link RandomAccessByteVectorValues}).
+ */
+public interface VectorValues<V> {
+    Logger LOG = Logger.getLogger(VectorValues.class.getName());
+
+    /** Return the number of vector values. */
+    int size();
+
+    /** Return the dimension of the returned vector values. */
+    int dimension();
+
+    /**
+     * Return the vector value indexed at the given ordinal.
+     * <p>
+     * For performance, implementations are free to re-use the same object across invocations.
+     * If you need to retain the value across calls, make a copy.
+     *
+     * @param nodeId a valid ordinal, &ge; 0 and &lt; {@link #size()}.
+     */
+    V getVector(int nodeId);
+
+    /**
+     * @return true iff the vector returned by {@link #getVector} is shared across calls.
+     * A shared vector is only valid until the next call to {@link #getVector} overwrites it.
+     */
+    boolean isValueShared();
+
+    /**
+     * Creates a new copy of this instance.
+     * Un-shared implementations may simply return {@code this}.
+     */
+    VectorValues<V> copy();
+
+    /**
+     * Returns a supplier of thread-local copies of this instance.
+     */
+    @SuppressWarnings("unchecked")
+    default Supplier<VectorValues<V>> threadLocalSupplier() {
+        if (!isValueShared()) {
+            return () -> this;
+        }
+
+        if (this instanceof AutoCloseable) {
+            LOG.warning("VectorValues is shared and implements AutoCloseable; threadLocalSupplier() may lead to leaks");
+        }
+        var tl = ExplicitThreadLocal.withInitial(this::copy);
+        return tl::get;
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/AbstractGraphIndexWriter.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/AbstractGraphIndexWriter.java
@@ -21,6 +21,7 @@ import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.FusedFeature;
+import io.github.jbellis.jvector.graph.disk.feature.InlineByteVectors;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.disk.feature.SeparatedFeature;
@@ -386,6 +387,8 @@ public abstract class AbstractGraphIndexWriter<T extends IndexWriter> implements
             int dimension;
             if (features.containsKey(FeatureId.INLINE_VECTORS)) {
                 dimension = ((InlineVectors) features.get(FeatureId.INLINE_VECTORS)).dimension();
+            } else if (features.containsKey(FeatureId.INLINE_BYTE_VECTORS)) {
+                dimension = ((InlineByteVectors) features.get(FeatureId.INLINE_BYTE_VECTORS)).dimension();
             } else if (features.containsKey(FeatureId.NVQ_VECTORS)) {
                 dimension = ((NVQ) features.get(FeatureId.NVQ_VECTORS)).dimension();
             } else if (features.containsKey(FeatureId.SEPARATED_VECTORS)) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/OnDiskGraphIndex.java
@@ -27,6 +27,7 @@ import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureSource;
 import io.github.jbellis.jvector.graph.disk.feature.FusedPQ;
 import io.github.jbellis.jvector.graph.disk.feature.FusedFeature;
+import io.github.jbellis.jvector.graph.disk.feature.InlineByteVectors;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.disk.feature.SeparatedFeature;
@@ -36,8 +37,10 @@ import org.agrona.collections.Int2ObjectHashMap;
 import java.util.ArrayList;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.util.RamUsageEstimator;
+import io.github.jbellis.jvector.vector.ByteVectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 
@@ -578,6 +581,41 @@ public class OnDiskGraphIndex implements ImmutableGraphIndex, AutoCloseable, Acc
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+        }
+
+        /**
+         * Returns the signed int8 vector stored for {@code node} via the
+         * {@link FeatureId#INLINE_BYTE_VECTORS} feature.
+         *
+         * @throws UnsupportedOperationException if the graph was not written with
+         *         {@link InlineByteVectors}
+         */
+        public ByteSequence<?> getByteVector(int node) {
+            if (!features.containsKey(FeatureId.INLINE_BYTE_VECTORS)) {
+                throw new UnsupportedOperationException("No inline byte vectors in this graph");
+            }
+            try {
+                long diskOffset = offsetFor(node, FeatureId.INLINE_BYTE_VECTORS);
+                reader.seek(diskOffset);
+                return vectorTypeSupport.readByteSequence(reader, dimension);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        /**
+         * Returns a {@link ScoreFunction.ExactScoreFunction} that scores candidates by reading
+         * their int8 vectors from disk and comparing them byte×byte against {@code queryBytes}.
+         *
+         * @throws UnsupportedOperationException if the graph was not written with
+         *         {@link InlineByteVectors}
+         */
+        public ScoreFunction.ExactScoreFunction byteVectorRerankerFor(ByteSequence<?> queryBytes,
+                                                                       ByteVectorSimilarityFunction bvsf) {
+            if (!features.containsKey(FeatureId.INLINE_BYTE_VECTORS)) {
+                throw new UnsupportedOperationException("No inline byte vectors in this graph");
+            }
+            return node -> bvsf.compare(queryBytes, getByteVector(node));
         }
 
         public NodesIterator getNeighborsIterator(int level, int node) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FeatureId.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/FeatureId.java
@@ -33,7 +33,8 @@ public enum FeatureId {
     FUSED_PQ(FusedPQ::load),
     NVQ_VECTORS(NVQ::load),
     SEPARATED_VECTORS(SeparatedVectors::load),
-    SEPARATED_NVQ(SeparatedNVQ::load);
+    SEPARATED_NVQ(SeparatedNVQ::load),
+    INLINE_BYTE_VECTORS(InlineByteVectors::load);
 
     private final BiFunction<CommonHeader, RandomAccessReader, Feature> loader;
 

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/InlineByteVectors.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/disk/feature/InlineByteVectors.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph.disk.feature;
+
+import io.github.jbellis.jvector.disk.IndexWriter;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.graph.disk.CommonHeader;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+
+import java.io.IOException;
+
+/**
+ * Stores signed int8 (byte) vectors inline in an {@link io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex}.
+ * <p>
+ * Each vector occupies exactly {@code dimension} bytes on disk — 4× smaller than
+ * the float32 {@link InlineVectors} representation.  The on-disk layout is otherwise
+ * identical: one contiguous byte block per node record, written and read via
+ * {@link VectorTypeSupport#writeByteSequence} and {@link VectorTypeSupport#readByteSequence}.
+ * <p>
+ * Use {@link io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex.View#getByteVector(int)}
+ * to retrieve a stored vector at search time.
+ */
+public class InlineByteVectors extends AbstractFeature {
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private final int dimension;
+
+    public InlineByteVectors(int dimension) {
+        this.dimension = dimension;
+    }
+
+    @Override
+    public FeatureId id() {
+        return FeatureId.INLINE_BYTE_VECTORS;
+    }
+
+    /** No extra header bytes — dimension is already in the {@link CommonHeader}. */
+    @Override
+    public int headerSize() {
+        return 0;
+    }
+
+    /** One byte per component. */
+    @Override
+    public int featureSize() {
+        return dimension;
+    }
+
+    public int dimension() {
+        return dimension;
+    }
+
+    static InlineByteVectors load(CommonHeader header, RandomAccessReader reader) {
+        return new InlineByteVectors(header.dimension);
+    }
+
+    @Override
+    public void writeHeader(IndexWriter out) {
+        // common header carries dimension; nothing extra needed
+    }
+
+    @Override
+    public void writeInline(IndexWriter out, Feature.State state) throws IOException {
+        vts.writeByteSequence(out, ((State) state).vector);
+    }
+
+    public static class State implements Feature.State {
+        public final ByteSequence<?> vector;
+
+        public State(ByteSequence<?> vector) {
+            this.vector = vector;
+        }
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
@@ -25,6 +25,7 @@ import io.github.jbellis.jvector.vector.VectorUtil;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.util.function.Supplier;
 
 /**
  * Encapsulates comparing node distances for GraphIndexBuilder.
@@ -106,8 +107,10 @@ public interface BuildScoreProvider {
     static BuildScoreProvider randomAccessScoreProvider(RandomAccessVectorValues ravv, VectorSimilarityFunction similarityFunction) {
         // We need two sources of vectors in order to perform diversity check comparisons without
         // colliding.  ThreadLocalSupplier makes this a no-op if the RAVV is actually un-shared.
-        var vectors = ravv.threadLocalSupplier();
-        var vectorsCopy = ravv.threadLocalSupplier();
+        var vectorsRaw = ravv.threadLocalSupplier();
+        var vectorsCopyRaw = ravv.threadLocalSupplier();
+        Supplier<RandomAccessVectorValues> vectors = () -> (RandomAccessVectorValues) vectorsRaw.get();
+        Supplier<RandomAccessVectorValues> vectorsCopy = () -> (RandomAccessVectorValues) vectorsCopyRaw.get();
 
         return new BuildScoreProvider() {
             @Override

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProvider.java
@@ -16,13 +16,16 @@
 
 package io.github.jbellis.jvector.graph.similarity;
 
+import io.github.jbellis.jvector.graph.RandomAccessByteVectorValues;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.RemappedRandomAccessVectorValues;
+import io.github.jbellis.jvector.vector.ByteVectorSimilarityFunction;
 import io.github.jbellis.jvector.quantization.BQVectors;
 import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorUtil;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import java.util.function.Supplier;
@@ -59,6 +62,20 @@ public interface BuildScoreProvider {
      * @param vector the query vector to provide similarity scores against
      */
     SearchScoreProvider searchProviderFor(VectorFloat<?> vector);
+
+    /**
+     * Create a search score provider to use *internally* during construction, for a byte (int8) query vector.
+     * <p>
+     * The default implementation throws {@link UnsupportedOperationException}; only
+     * {@link #byteVectorScoreProvider} overrides it.
+     *
+     * @param vector the int8 query vector to provide similarity scores against
+     */
+    default SearchScoreProvider searchProviderFor(ByteSequence<?> vector) {
+        throw new UnsupportedOperationException(
+                "This BuildScoreProvider does not support byte-vector queries; " +
+                "use byteVectorScoreProvider() to construct a byte-vector builder");
+    }
 
     /**
      * Create a search score provider to use *internally* during construction.
@@ -210,6 +227,68 @@ public interface BuildScoreProvider {
             @Override
             public VectorFloat<?> approximateCentroid() {
                 return pqv.getCompressor().getOrComputeCentroid();
+            }
+        };
+    }
+
+    /**
+     * Returns a BSP that performs exact score comparisons using the given
+     * {@link RandomAccessByteVectorValues} and {@link ByteVectorSimilarityFunction}.
+     * All scoring is byte×byte with no float32 round-trip.
+     */
+    static BuildScoreProvider byteVectorScoreProvider(RandomAccessByteVectorValues ravv, ByteVectorSimilarityFunction bvsf) {
+        var vectors     = ravv.threadLocalSupplier();
+        var vectorsCopy = ravv.threadLocalSupplier();
+
+        return new BuildScoreProvider() {
+            @Override
+            public boolean isExact() {
+                return true;
+            }
+
+            @Override
+            public VectorFloat<?> approximateCentroid() {
+                var vv = vectors.get();
+                var centroid = vts.createFloatVector(vv.dimension());
+                for (int i = 0; i < vv.size(); i++) {
+                    var v = vv.getVector(i);
+                    for (int d = 0; d < vv.dimension(); d++) {
+                        centroid.set(d, centroid.get(d) + v.get(d));
+                    }
+                }
+                VectorUtil.scale(centroid, 1.0f / vv.size());
+                return centroid;
+            }
+
+            @Override
+            public SearchScoreProvider searchProviderFor(VectorFloat<?> vector) {
+                throw new UnsupportedOperationException(
+                        "byteVectorScoreProvider does not support float query vectors; use searchProviderFor(int node)");
+            }
+
+            @Override
+            public SearchScoreProvider searchProviderFor(ByteSequence<?> vector) {
+                var vc = vectorsCopy.get();
+                var sf = (ScoreFunction.ExactScoreFunction) node2 -> bvsf.compare(vector, vc.getVector(node2));
+                return new DefaultSearchScoreProvider(sf);
+            }
+
+            @Override
+            public SearchScoreProvider searchProviderFor(int node1) {
+                var v  = vectors.get().getVector(node1);
+                return searchProviderFor(v);
+            }
+
+            @Override
+            public SearchScoreProvider diversityProviderFor(int node1) {
+                return searchProviderFor(node1);
+            }
+
+            @Override
+            public ScoreFunction diversityScoreFunctionFor(int node1) {
+                var v  = vectors.get().getVector(node1);
+                var vc = vectorsCopy.get();
+                return (ScoreFunction.ExactScoreFunction) node2 -> bvsf.compare(v, vc.getVector(node2));
             }
         };
     }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ByteVectorSimilarityFunction.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/ByteVectorSimilarityFunction.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.vector;
+
+import io.github.jbellis.jvector.vector.types.ByteSequence;
+
+/**
+ * Vector similarity function for signed int8 (byte) vectors; parallel to
+ * {@link VectorSimilarityFunction} but operating on {@link ByteSequence}.
+ * <p>
+ * Bytes are treated as signed int8 values (Java's {@code byte} is already signed, range −128..127).
+ * Return-value conventions match {@link VectorSimilarityFunction}: higher is more similar.
+ */
+public enum ByteVectorSimilarityFunction {
+
+    /**
+     * Euclidean similarity normalised to {@code (0, 1]}.
+     * Raw squared L2 is divided by {@code n * 255^2} (the maximum possible squared distance
+     * between two signed int8 vectors) before the {@code 1 / (1 + x)} mapping, so the result
+     * is always in (0, 1] regardless of dimension.
+     */
+    EUCLIDEAN {
+        @Override
+        public float compare(ByteSequence<?> v1, ByteSequence<?> v2) {
+            float maxSquaredDist = v1.length() * (255.0f * 255.0f);
+            return 1.0f / (1.0f + VectorUtil.squareL2Distance(v1, v2) / maxSquaredDist);
+        }
+    },
+
+    /**
+     * Dot product normalised to {@code [0, 1]}.
+     * Raw int8 dot product is divided by {@code n * 127^2} (the maximum possible magnitude)
+     * before applying the {@code (1 + x) / 2} mapping, so the result is always in [0, 1]
+     * regardless of dimension or whether the vectors are unit-norm.
+     * For already unit-norm int8 vectors (e.g. Cohere, OpenAI reduced-precision) prefer {@link #COSINE}.
+     */
+    DOT_PRODUCT {
+        @Override
+        public float compare(ByteSequence<?> v1, ByteSequence<?> v2) {
+            float maxMagnitude = v1.length() * (127.0f * 127.0f);
+            return (1.0f + VectorUtil.dotProduct(v1, v2) / maxMagnitude) / 2.0f;
+        }
+    },
+
+    /** Cosine similarity: {@code (1 + cosine(v1, v2)) / 2} */
+    COSINE {
+        @Override
+        public float compare(ByteSequence<?> v1, ByteSequence<?> v2) {
+            return (1.0f + VectorUtil.cosine(v1, v2)) / 2.0f;
+        }
+    };
+
+    /**
+     * Calculates a similarity score between the two int8 vectors.
+     * Higher values correspond to closer vectors.
+     *
+     * @param v1 a byte vector
+     * @param v2 another byte vector, of the same dimension
+     * @return the similarity score
+     */
+    public abstract float compare(ByteSequence<?> v1, ByteSequence<?> v2);
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/DefaultVectorUtilSupport.java
@@ -339,6 +339,37 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public float dotProduct(ByteSequence<?> a, ByteSequence<?> b) {
+    float sum = 0;
+    for (int i = 0; i < a.length(); i++) {
+      sum += (int) a.get(i) * (int) b.get(i);
+    }
+    return sum;
+  }
+
+  @Override
+  public float squareDistance(ByteSequence<?> a, ByteSequence<?> b) {
+    float sum = 0;
+    for (int i = 0; i < a.length(); i++) {
+      float diff = a.get(i) - b.get(i);
+      sum += diff * diff;
+    }
+    return sum;
+  }
+
+  @Override
+  public float cosine(ByteSequence<?> a, ByteSequence<?> b) {
+    float dot = 0, normA = 0, normB = 0;
+    for (int i = 0; i < a.length(); i++) {
+      float ai = a.get(i), bi = b.get(i);
+      dot   += ai * bi;
+      normA += ai * ai;
+      normB += bi * bi;
+    }
+    return (float) (dot / Math.sqrt(normA * normB));
+  }
+
+  @Override
   public int hammingDistance(long[] v1, long[] v2) {
     int hd = 0;
     for (int i = 0; i < v1.length; i++) {

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtil.java
@@ -174,6 +174,21 @@ public final class VectorUtil {
     return impl.assembleAndSumPQ(data, subspaceCount, dataOffsets1, dataOffsetsOffset1, dataOffsets2, dataOffsetsOffset2, clusterCount);
   }
 
+  /** Returns the dot product of two signed int8 byte vectors. */
+  public static float dotProduct(ByteSequence<?> a, ByteSequence<?> b) {
+    return impl.dotProduct(a, b);
+  }
+
+  /** Returns the sum of squared differences of two signed int8 byte vectors. */
+  public static float squareL2Distance(ByteSequence<?> a, ByteSequence<?> b) {
+    return impl.squareDistance(a, b);
+  }
+
+  /** Returns the cosine similarity of two signed int8 byte vectors. */
+  public static float cosine(ByteSequence<?> a, ByteSequence<?> b) {
+    return impl.cosine(a, b);
+  }
+
   public static int hammingDistance(long[] v1, long[] v2) {
     return impl.hammingDistance(v1, v2);
   }

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/vector/VectorUtilSupport.java
@@ -130,6 +130,15 @@ public interface VectorUtilSupport {
    */
   float assembleAndSumPQ(VectorFloat<?> codebookPartialSums, int subspaceCount, ByteSequence<?> vector1Ordinals, int vector1OrdinalOffset, ByteSequence<?> node2Ordinals, int node2OrdinalOffset, int clusterCount);
 
+  /** Calculates the dot product of two signed int8 byte vectors. */
+  float dotProduct(ByteSequence<?> a, ByteSequence<?> b);
+
+  /** Returns the sum of squared differences of two signed int8 byte vectors. */
+  float squareDistance(ByteSequence<?> a, ByteSequence<?> b);
+
+  /** Returns the cosine similarity of two signed int8 byte vectors. */
+  float cosine(ByteSequence<?> a, ByteSequence<?> b);
+
   int hammingDistance(long[] v1, long[] v2);
 
   void calculatePartialSums(VectorFloat<?> codebook, int codebookIndex, int size, int clusterCount, VectorFloat<?> query, int offset, VectorSimilarityFunction vsf, VectorFloat<?> partialSums);

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/tutorial/Int8Example.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/tutorial/Int8Example.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.example.tutorial;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import io.github.jbellis.jvector.disk.ReaderSupplierFactory;
+import io.github.jbellis.jvector.example.util.SiftLoader;
+import io.github.jbellis.jvector.graph.GraphIndexBuilder;
+import io.github.jbellis.jvector.graph.GraphSearcher;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
+import io.github.jbellis.jvector.graph.ListRandomAccessByteVectorValues;
+import io.github.jbellis.jvector.graph.RandomAccessByteVectorValues;
+import io.github.jbellis.jvector.graph.SearchResult;
+import io.github.jbellis.jvector.graph.disk.GraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.GraphIndexWriterTypes;
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.InlineByteVectors;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
+import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.vector.ByteVectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+
+/**
+ * Demonstrates end-to-end INT8 (signed byte) vector support in JVector:
+ *
+ * <p><b>How to run:</b>
+ * <pre>
+ *   # 1. Download the siftsmall dataset from http://corpus-texmex.irisa.fr/
+ *   #    and unzip it so that siftsmall/siftsmall_base.fvecs is present
+ *   #    in the directory you run the command from.
+ *
+ *   # 2. Build and run — jdk22 is the default profile (active when no -P flag is given):
+ *   ./mvnw compile -pl jvector-examples -am
+ *   ./mvnw exec:exec@tutorial -pl jvector-examples -Dtutorial=int8
+ *
+ *   # Use -Pjdk20 or -Pjdk11 if you are on an older JDK:
+ *   ./mvnw exec:exec@tutorial -pl jvector-examples -Pjdk20 -Dtutorial=int8
+ * </pre>
+ *
+ * <ol>
+ *   <li>Read the siftsmall dataset from .fvecs files (float32).</li>
+ *   <li>Convert each float32 vector to a signed int8 {@link ByteSequence}.</li>
+ *   <li>Build a graph index using only byte×byte distance calculations.</li>
+ *   <li>Save the graph to disk with {@link InlineByteVectors} — 1 byte per component on disk.</li>
+ *   <li>Load the index back from disk.</li>
+ *   <li>Generate random int8 query vectors and search, scoring directly from disk byte vectors.</li>
+ * </ol>
+ *
+ * <p>The siftsmall dataset must be present at {@code siftsmall/siftsmall_base.fvecs}
+ * relative to the working directory. Download it from
+ * <a href="http://corpus-texmex.irisa.fr/">http://corpus-texmex.irisa.fr/</a>.
+ */
+public class Int8Example {
+
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    public static void main(String[] args) throws IOException {
+        String siftDir = args.length > 0 ? args[0] : "siftsmall";
+
+        // ── Step 1: Read siftsmall base vectors (.fvecs) ─────────────────────────────
+        System.out.println("Loading siftsmall base vectors...");
+        List<VectorFloat<?>> floatVectors = SiftLoader.readFvecs(siftDir + "/siftsmall_base.fvecs");
+        int dimension = floatVectors.get(0).length();
+        System.out.printf("Loaded %d vectors of dimension %d%n", floatVectors.size(), dimension);
+
+        // ── Step 2: Convert float32 vectors to signed int8 (ByteSequence) ────────────
+        // SIFT base vectors store gradient histogram bins as unsigned bytes in [0, 255].
+        // We subtract 128 to shift them into the signed range [-128, 127] that
+        // ByteVectorSimilarityFunction and the underlying SIMD routines expect.
+        // For other float32 datasets you would typically scale by a dataset-specific
+        // factor and then clamp before casting.
+        System.out.println("Converting float32 vectors to int8...");
+        List<ByteSequence<?>> byteVectors = new ArrayList<>(floatVectors.size());
+        for (VectorFloat<?> fv : floatVectors) {
+            ByteSequence<?> bv = vts.createByteSequence(dimension);
+            for (int i = 0; i < dimension; i++) {
+                // SIFT component in [0,255] → shift to signed [-128, 127]
+                bv.set(i, (byte) ((int) fv.get(i) - 128));
+            }
+            byteVectors.add(bv);
+        }
+
+        // Wrap the list in a RandomAccessByteVectorValues (RABVV) —
+        // the byte-vector analogue of RandomAccessVectorValues.
+        RandomAccessByteVectorValues rabvv = new ListRandomAccessByteVectorValues(byteVectors, dimension);
+
+        // ── Step 3: Build the graph index using int8 vectors ─────────────────────────
+        // Use the fluent builder API. addHierarchy and refineFinalGraph are controlled
+        // via GraphIndexBuilderConfig (JMX/system property); no need to pass them here.
+        // The BuildScoreProvider wires up byte×byte scoring — no float32 round-trip
+        // occurs during construction.
+        int M = 32;
+        int efConstruction = 100;
+        float neighborOverflow = 1.2f;
+        float alpha = 1.2f;
+
+        System.out.println("Building graph index from int8 vectors...");
+        ImmutableGraphIndex heapGraph;
+        try (GraphIndexBuilder builder = GraphIndexBuilder.builder(rabvv, ByteVectorSimilarityFunction.EUCLIDEAN, M)
+                .withBeamWidth(efConstruction)
+                .withNeighborOverflow(neighborOverflow)
+                .withAlpha(alpha)
+                .build())
+        {
+            heapGraph = builder.build(rabvv);
+        }
+        System.out.printf("Graph built with %d nodes%n", heapGraph.size(0));
+
+        // ── Step 4: Save the graph to disk with native int8 storage ──────────────────
+        // InlineByteVectors stores each vector as `dimension` raw bytes on disk —
+        // 4× more compact than the float32 InlineVectors alternative.
+        Path graphPath = Files.createTempFile("jvector-int8-example", null);
+        System.out.printf("Writing graph to disk (%d bytes/vector): %s%n", dimension, graphPath);
+        try (GraphIndexWriter writer = GraphIndexWriter
+                .getBuilderFor(GraphIndexWriterTypes.RANDOM_ACCESS_PARALLEL, heapGraph, graphPath)
+                .with(new InlineByteVectors(dimension))
+                .build())
+        {
+            writer.write(Map.of(
+                FeatureId.INLINE_BYTE_VECTORS,
+                nodeId -> new InlineByteVectors.State(rabvv.getVector(nodeId))
+            ));
+        }
+
+        // ── Step 5: Load the index from disk ─────────────────────────────────────────
+        System.out.println("Loading graph from disk...");
+        ReaderSupplier readerSupplier = ReaderSupplierFactory.open(graphPath);
+        OnDiskGraphIndex diskGraph = OnDiskGraphIndex.load(readerSupplier);
+
+        // ── Step 6: Search with random int8 query vectors ────────────────────────────
+        // The score function reads each candidate's byte vector directly from disk —
+        // true int8 end-to-end, no float conversion anywhere in the search path.
+        int numQueries = 10;
+        int topK = 5;
+        Random rng = new Random(42);
+
+        System.out.printf("%nSearching with %d random int8 query vectors (top-%d):%n", numQueries, topK);
+
+        try (GraphSearcher searcher = new GraphSearcher(diskGraph)) {
+            OnDiskGraphIndex.View view = (OnDiskGraphIndex.View) searcher.getView();
+
+            for (int q = 0; q < numQueries; q++) {
+                ByteSequence<?> queryBytes = randomInt8Vector(dimension, rng);
+
+                // byteVectorRerankerFor reads each candidate's int8 vector from disk
+                // and scores it byte×byte — no float32 anywhere in the hot path.
+                SearchScoreProvider ssp = new DefaultSearchScoreProvider(
+                        view.byteVectorRerankerFor(queryBytes, ByteVectorSimilarityFunction.EUCLIDEAN));
+
+                SearchResult result = searcher.search(ssp, topK, Bits.ALL);
+
+                System.out.printf("Query %2d → top neighbors: ", q);
+                for (SearchResult.NodeScore ns : result.getNodes()) {
+                    System.out.printf("(id=%d, score=%.4f) ", ns.node, ns.score);
+                }
+                System.out.println();
+            }
+        }
+
+        // cleanup
+        readerSupplier.close();
+        Files.deleteIfExists(graphPath);
+    }
+
+    /**
+     * Returns a random signed-byte vector as a {@link ByteSequence}.
+     * Each component is independently and uniformly drawn from [-128, 127].
+     */
+    private static ByteSequence<?> randomInt8Vector(int dimension, Random rng) {
+        ByteSequence<?> v = vts.createByteSequence(dimension);
+        for (int i = 0; i < dimension; i++) {
+            // nextInt(256) gives [0, 255]; subtract 128 → [-128, 127]
+            v.set(i, (byte) (rng.nextInt(256) - 128));
+        }
+        return v;
+    }
+}

--- a/jvector-examples/src/main/java/io/github/jbellis/jvector/example/tutorial/TutorialRunner.java
+++ b/jvector-examples/src/main/java/io/github/jbellis/jvector/example/tutorial/TutorialRunner.java
@@ -41,6 +41,9 @@ public class TutorialRunner {
             case "nvq":
                 NvqExample.main(forwardArgs);
                 break;
+            case "int8":
+                Int8Example.main(forwardArgs);
+                break;
             default:
                 throw new IllegalArgumentException("Unknown example" + args[0]);
         }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/NativeVectorUtilSupport.java
@@ -62,6 +62,30 @@ final class NativeVectorUtilSupport extends PanamaVectorUtilSupport
     }
 
     @Override
+    public float dotProduct(ByteSequence<?> a, ByteSequence<?> b) {
+        return NativeSimdOps.dot_product_i8(
+                ((MemorySegmentByteSequence) a).get(), (long) a.offset(),
+                ((MemorySegmentByteSequence) b).get(), (long) b.offset(),
+                (long) a.length());
+    }
+
+    @Override
+    public float squareDistance(ByteSequence<?> a, ByteSequence<?> b) {
+        return NativeSimdOps.euclidean_i8(
+                ((MemorySegmentByteSequence) a).get(), (long) a.offset(),
+                ((MemorySegmentByteSequence) b).get(), (long) b.offset(),
+                (long) a.length());
+    }
+
+    @Override
+    public float cosine(ByteSequence<?> a, ByteSequence<?> b) {
+        return NativeSimdOps.cosine_i8(
+                ((MemorySegmentByteSequence) a).get(), (long) a.offset(),
+                ((MemorySegmentByteSequence) b).get(), (long) b.offset(),
+                (long) a.length());
+    }
+
+    @Override
     protected FloatVector fromVectorFloat(VectorSpecies<Float> SPEC, VectorFloat<?> vector, int offset) {
         return FloatVector.fromMemorySegment(SPEC, ((MemorySegmentVectorFloat) vector).get(), vector.offset(offset), ByteOrder.LITTLE_ENDIAN);
     }

--- a/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/NativeSimdOps.java
+++ b/jvector-native/src/main/java/io/github/jbellis/jvector/vector/cnative/NativeSimdOps.java
@@ -2506,6 +2506,192 @@ public class NativeSimdOps {
         }
     }
 
+    private static class dot_product_i8 {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            NativeSimdOps.C_FLOAT,
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_LONG,
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_LONG,
+            NativeSimdOps.C_LONG
+        );
+
+        public static final MemorySegment ADDR = NativeSimdOps.findOrThrow("dot_product_i8");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC, Linker.Option.critical(true));
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * float dot_product_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static FunctionDescriptor dot_product_i8$descriptor() {
+        return dot_product_i8.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * float dot_product_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static MethodHandle dot_product_i8$handle() {
+        return dot_product_i8.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * float dot_product_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static MemorySegment dot_product_i8$address() {
+        return dot_product_i8.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * float dot_product_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static float dot_product_i8(MemorySegment a, long aoffset, MemorySegment b, long boffset, long length) {
+        var mh$ = dot_product_i8.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("dot_product_i8", a, aoffset, b, boffset, length);
+            }
+            return (float)mh$.invokeExact(a, aoffset, b, boffset, length);
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class euclidean_i8 {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            NativeSimdOps.C_FLOAT,
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_LONG,
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_LONG,
+            NativeSimdOps.C_LONG
+        );
+
+        public static final MemorySegment ADDR = NativeSimdOps.findOrThrow("euclidean_i8");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC, Linker.Option.critical(true));
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * float euclidean_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static FunctionDescriptor euclidean_i8$descriptor() {
+        return euclidean_i8.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * float euclidean_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static MethodHandle euclidean_i8$handle() {
+        return euclidean_i8.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * float euclidean_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static MemorySegment euclidean_i8$address() {
+        return euclidean_i8.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * float euclidean_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static float euclidean_i8(MemorySegment a, long aoffset, MemorySegment b, long boffset, long length) {
+        var mh$ = euclidean_i8.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("euclidean_i8", a, aoffset, b, boffset, length);
+            }
+            return (float)mh$.invokeExact(a, aoffset, b, boffset, length);
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class cosine_i8 {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            NativeSimdOps.C_FLOAT,
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_LONG,
+            NativeSimdOps.C_POINTER,
+            NativeSimdOps.C_LONG,
+            NativeSimdOps.C_LONG
+        );
+
+        public static final MemorySegment ADDR = NativeSimdOps.findOrThrow("cosine_i8");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC, Linker.Option.critical(true));
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * float cosine_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static FunctionDescriptor cosine_i8$descriptor() {
+        return cosine_i8.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * float cosine_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static MethodHandle cosine_i8$handle() {
+        return cosine_i8.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * float cosine_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static MemorySegment cosine_i8$address() {
+        return cosine_i8.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * float cosine_i8(const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length)
+     * }
+     */
+    public static float cosine_i8(MemorySegment a, long aoffset, MemorySegment b, long boffset, long length) {
+        var mh$ = cosine_i8.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("cosine_i8", a, aoffset, b, boffset, length);
+            }
+            return (float)mh$.invokeExact(a, aoffset, b, boffset, length);
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
     private static class jvector_simd_get_active_isa {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             NativeSimdOps.C_POINTER    );

--- a/jvector-native/src/main/native/benchmarks/bench_similarity_i8.cpp
+++ b/jvector-native/src/main/native/benchmarks/bench_similarity_i8.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Google Benchmark micro-benchmarks for the int8 vector similarity kernels:
+//   dot_product_i8, euclidean_i8, cosine_i8
+//
+// Parameterised over the realistic embedding dimensions used in production:
+//   128, 256, 512, 1024, 1536, 3072
+//
+// Build (requires google-benchmark installed or available via pkg-config):
+//   meson setup build && ninja -C build bench_simd_kernels
+//
+// Run:
+//   ./build/bench_simd_kernels [--benchmark_filter=<pattern>]
+
+#include <benchmark/benchmark.h>
+#include <cstdint>
+#include <vector>
+
+#include "jvector_simd.h"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Deterministic, non-zero int8 vector: values cycle through a signed range to
+// avoid degenerate all-zero inputs while staying within [-128, 127].
+static std::vector<int8_t> make_i8_vec(size_t n, int8_t seed)
+{
+    std::vector<int8_t> v(n);
+    for (size_t i = 0; i < n; ++i) {
+        int val = seed + static_cast<int>(i % 127);
+        if (i % 3 == 0) val = -val;
+        // clamp to [-127, 127] to keep vectors non-degenerate for cosine
+        if (val >  127) val =  127;
+        if (val < -127) val = -127;
+        v[i] = static_cast<int8_t>(val);
+    }
+    return v;
+}
+
+// Benchmark sizes matching production embedding dimensions.
+static const std::vector<int64_t> kBenchSizes = {128, 256, 512, 1024, 1536, 3072};
+
+// ---------------------------------------------------------------------------
+// dot_product_i8
+// ---------------------------------------------------------------------------
+
+static void BM_dot_product_i8(benchmark::State& state)
+{
+    const size_t n = static_cast<size_t>(state.range(0));
+    auto a = make_i8_vec(n, 7);
+    auto b = make_i8_vec(n, 13);
+
+    for (auto _ : state) {
+        float result = dot_product_i8(a.data(), 0, b.data(), 0, n);
+        benchmark::DoNotOptimize(result);
+    }
+
+    state.SetItemsProcessed(state.iterations() * static_cast<int64_t>(n));
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(n) * 2 * sizeof(int8_t));
+}
+BENCHMARK(BM_dot_product_i8)->ArgsProduct({kBenchSizes});
+
+// ---------------------------------------------------------------------------
+// euclidean_i8
+// ---------------------------------------------------------------------------
+
+static void BM_euclidean_i8(benchmark::State& state)
+{
+    const size_t n = static_cast<size_t>(state.range(0));
+    auto a = make_i8_vec(n, 7);
+    auto b = make_i8_vec(n, 13);
+
+    for (auto _ : state) {
+        float result = euclidean_i8(a.data(), 0, b.data(), 0, n);
+        benchmark::DoNotOptimize(result);
+    }
+
+    state.SetItemsProcessed(state.iterations() * static_cast<int64_t>(n));
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(n) * 2 * sizeof(int8_t));
+}
+BENCHMARK(BM_euclidean_i8)->ArgsProduct({kBenchSizes});
+
+// ---------------------------------------------------------------------------
+// cosine_i8
+// ---------------------------------------------------------------------------
+
+static void BM_cosine_i8(benchmark::State& state)
+{
+    const size_t n = static_cast<size_t>(state.range(0));
+    auto a = make_i8_vec(n, 7);
+    auto b = make_i8_vec(n, 13);
+
+    for (auto _ : state) {
+        float result = cosine_i8(a.data(), 0, b.data(), 0, n);
+        benchmark::DoNotOptimize(result);
+    }
+
+    state.SetItemsProcessed(state.iterations() * static_cast<int64_t>(n));
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(n) * 2 * sizeof(int8_t));
+}
+BENCHMARK(BM_cosine_i8)->ArgsProduct({kBenchSizes});
+

--- a/jvector-native/src/main/native/meson.build
+++ b/jvector-native/src/main/native/meson.build
@@ -131,6 +131,7 @@ if gtest_dep.found()
     sources     : [
       'tests/test_helpers.cpp',
       'tests/test_similarity.cpp',
+      'tests/test_similarity_i8.cpp',
       'tests/test_elementwise.cpp',
       'tests/test_cpu_features.cpp',
     ],
@@ -154,7 +155,10 @@ gbench_dep = dependency('benchmark', required: false)
 if gbench_dep.found()
   executable(
     'bench_simd_kernels',
-    sources     : 'benchmarks/bench_similarity_f32.cpp',
+    sources     : [
+      'benchmarks/bench_similarity_f32.cpp',
+      'benchmarks/bench_similarity_i8.cpp',
+    ],
     dependencies: [vectorutil_dep, gbench_dep],
     cpp_args    : ['-O3'],
   )

--- a/jvector-native/src/main/native/src/jvector_avx3_dl_kernels.cpp
+++ b/jvector-native/src/main/native/src/jvector_avx3_dl_kernels.cpp
@@ -25,13 +25,358 @@
 //   VNNI, VBMI, VBMI2, IFMA, BITALG, VPOPCNTDQ, GFNI, VAES, VPCLMULQDQ
 //
 // Compiled with -march=icelake-server.
-// Highway will select HWY_AVX3_DL as the static target.
-#include "jvector_simd.h"
-#include "hwy/highway.h"
-#include "assert_hwy_targets.h"
+//
+// This file uses raw Intel AVX-512 intrinsics directly — NO Google Highway —
+// so we get exactly the instructions we intend with zero abstraction overhead.
 
-namespace hn = hwy::HWY_NAMESPACE;
+#include <cmath>
+#include <cstdint>
+#include <cstddef>
+#include <immintrin.h>        // AVX-512 + VNNI intrinsics
+#include "jvector_simd.h"
+
+// =============================================================================
+// Register naming convention
+//   zmm  = 512-bit  (16 × int32, 32 × int16, 64 × int8)
+//   ymm  = 256-bit  (32 × int8,  16 × int16)
+//   xmm  = 128-bit  (16 × int8,  8 × int16)
+//
+// VNNI instructions used
+// ─────────────────────────────────────────────────────────────────────────────
+// VPDPBUSD  zmm_acc, zmm_a, zmm_b
+//   For each group of 4 adjacent lanes (i×4 .. i×4+3):
+//     acc[i] += (u8)a[i×4+0] * (i8)b[i×4+0]
+//             + (u8)a[i×4+1] * (i8)b[i×4+1]
+//             + (u8)a[i×4+2] * (i8)b[i×4+2]
+//             + (u8)a[i×4+3] * (i8)b[i×4+3]
+//   → 16 i32 accumulations, 64 int8 products per zmm register per cycle.
+//   Latency: 3 cycles.  Throughput: 1/cycle (two ports on Ice Lake).
+//
+// VPDPWSSD  zmm_acc, zmm_a, zmm_b
+//   For each group of 2 adjacent i16 lanes (i×2, i×2+1):
+//     acc[i] += (i16)a[i×2+0] * (i16)b[i×2+0]
+//             + (i16)a[i×2+1] * (i16)b[i×2+1]
+//   → 16 i32 accumulations, 32 int16 products per zmm per cycle.
+//   Latency: 3 cycles.  Throughput: 1/cycle.
+//
+// Signed i8 × signed i8 using VPDPBUSD
+// ─────────────────────────────────────────────────────────────────────────────
+// VPDPBUSD requires operand A to be unsigned.  For signed inputs we apply the
+// standard bias trick:
+//   (a + 128) is always non-negative, so we use it as the unsigned operand.
+//   (a+128) * b = a*b + 128*b  →  a*b = VPDPBUSD(a+128, b) - 128 * sum(b)
+//
+// The bias (128*sum(b)) is constant per zmm load of b, computed as:
+//   _mm512_dpwssd_epi32(zero, b, set1_epi16(128))   [reuse VPDPWSSD]
+// and subtracted once per iteration from the accumulator.
+//
+// This adds one VPDPWSSD + one VPADDD per iteration, which is negligible
+// compared to the main VPDPBUSD throughput.
+//
+// Unrolling strategy
+// ─────────────────────────────────────────────────────────────────────────────
+// With 3-cycle VPDPBUSD latency and 1/cycle throughput (ports 0+5), we need
+// at least 4 independent accumulator chains to keep the ports saturated:
+//   issued cycle 0: port 0 ← acc0
+//   issued cycle 1: port 5 ← acc1
+//   issued cycle 2: port 0 ← acc2
+//   issued cycle 3: port 5 ← acc3   (acc0 writeback done, cycle 3)
+// 4× unrolling fully hides the 3-cycle latency.
+// =============================================================================
 
 namespace AVX3_DL {
+
+// ---------------------------------------------------------------------------
+// Horizontal reduce: sum all 16 int32 lanes of a zmm register.
+// _mm512_reduce_add_epi32 emits the optimal fold-down sequence; the compiler
+// schedules it across surrounding instructions better than manual shuffles.
+// ---------------------------------------------------------------------------
+static inline int32_t hsum_epi32(__m512i v)
+{
+    return _mm512_reduce_add_epi32(v);
+}
+
+// ---------------------------------------------------------------------------
+// dot_product_i8  —  VPDPBUSD with bias correction for signed i8 × signed i8
+// ---------------------------------------------------------------------------
+//
+// Algorithm
+//   acc  = VPDPBUSD(acc,  a_u8, b_i8)   where a_u8 = a + 128
+//   bias = VPDPWSSD(bias, b_i8, 128)    accumulates 128 * sum(b)
+//   result = hsum(acc) - hsum(bias)
+//
+// 4× unrolled (256 bytes/iteration) to saturate both ICX VNNI ports and
+// fully hide the 3-cycle VPDPBUSD latency.
+float dot_product_i8(const int8_t * __restrict__ a, size_t aoffset,
+                     const int8_t * __restrict__ b, size_t boffset,
+                     size_t length)
+{
+    a += aoffset;
+    b += boffset;
+
+    const __m512i bias128 = _mm512_set1_epi16(128);
+
+    __m512i acc0  = _mm512_setzero_si512(), acc1  = _mm512_setzero_si512();
+    __m512i acc2  = _mm512_setzero_si512(), acc3  = _mm512_setzero_si512();
+    __m512i bias0 = _mm512_setzero_si512(), bias1 = _mm512_setzero_si512();
+    __m512i bias2 = _mm512_setzero_si512(), bias3 = _mm512_setzero_si512();
+
+    size_t i = 0;
+    for (; i + 256 <= length; i += 256) {
+        __m512i va0 = _mm512_loadu_si512(a + i +   0);
+        __m512i va1 = _mm512_loadu_si512(a + i +  64);
+        __m512i va2 = _mm512_loadu_si512(a + i + 128);
+        __m512i va3 = _mm512_loadu_si512(a + i + 192);
+        __m512i vb0 = _mm512_loadu_si512(b + i +   0);
+        __m512i vb1 = _mm512_loadu_si512(b + i +  64);
+        __m512i vb2 = _mm512_loadu_si512(b + i + 128);
+        __m512i vb3 = _mm512_loadu_si512(b + i + 192);
+
+        // Flip sign bit: maps signed [-128,127] → unsigned [0,255].
+        const __m512i flip = _mm512_set1_epi8(-128);
+        __m512i au0 = _mm512_add_epi8(va0, flip);
+        __m512i au1 = _mm512_add_epi8(va1, flip);
+        __m512i au2 = _mm512_add_epi8(va2, flip);
+        __m512i au3 = _mm512_add_epi8(va3, flip);
+
+        // VPDPBUSD: acc[i] += (u8)au[4i+k] * (i8)vb[4i+k], k=0..3
+        acc0 = _mm512_dpbusd_epi32(acc0, au0, vb0);
+        acc1 = _mm512_dpbusd_epi32(acc1, au1, vb1);
+        acc2 = _mm512_dpbusd_epi32(acc2, au2, vb2);
+        acc3 = _mm512_dpbusd_epi32(acc3, au3, vb3);
+
+        // Bias: promote vb to i16 then compute 128 * sum(vb) using VPDPWSSD.
+        // Each 64-byte zmm of int8 is split into two 512-bit i16 vectors.
+        __m512i vb0_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i +   0)));
+        __m512i vb0_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i +  32)));
+        __m512i vb1_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i +  64)));
+        __m512i vb1_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i +  96)));
+        __m512i vb2_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i + 128)));
+        __m512i vb2_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i + 160)));
+        __m512i vb3_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i + 192)));
+        __m512i vb3_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i + 224)));
+
+        bias0 = _mm512_dpwssd_epi32(bias0, vb0_lo, bias128);
+        bias0 = _mm512_dpwssd_epi32(bias0, vb0_hi, bias128);
+        bias1 = _mm512_dpwssd_epi32(bias1, vb1_lo, bias128);
+        bias1 = _mm512_dpwssd_epi32(bias1, vb1_hi, bias128);
+        bias2 = _mm512_dpwssd_epi32(bias2, vb2_lo, bias128);
+        bias2 = _mm512_dpwssd_epi32(bias2, vb2_hi, bias128);
+        bias3 = _mm512_dpwssd_epi32(bias3, vb3_lo, bias128);
+        bias3 = _mm512_dpwssd_epi32(bias3, vb3_hi, bias128);
+    }
+    __m512i acc  = _mm512_add_epi32(_mm512_add_epi32(acc0,  acc1),
+                                    _mm512_add_epi32(acc2,  acc3));
+    __m512i bias = _mm512_add_epi32(_mm512_add_epi32(bias0, bias1),
+                                    _mm512_add_epi32(bias2, bias3));
+
+    // Single-zmm tail (residual 64-byte blocks).
+    for (; i + 64 <= length; i += 64) {
+        __m512i va = _mm512_loadu_si512(a + i);
+        __m512i vb = _mm512_loadu_si512(b + i);
+        __m512i au = _mm512_add_epi8(va, _mm512_set1_epi8(-128));
+        acc  = _mm512_dpbusd_epi32(acc,  au, vb);
+        
+        // Promote vb to i16 for bias calculation
+        __m512i vb_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i)));
+        __m512i vb_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i + 32)));
+        bias = _mm512_dpwssd_epi32(bias, vb_lo, bias128);
+        bias = _mm512_dpwssd_epi32(bias, vb_hi, bias128);
+    }
+
+    int32_t result = hsum_epi32(acc) - hsum_epi32(bias);
+
+    // Scalar tail.
+    for (; i < length; i++)
+        result += (int32_t)a[i] * (int32_t)b[i];
+
+    return (float)result;
+}
+
+// ---------------------------------------------------------------------------
+// euclidean_i8  —  VPMOVSXBW sign-extend + VPDPWSSD squared differences
+// ---------------------------------------------------------------------------
+//
+// Each 64-byte zmm block is processed as two 32-byte halves:
+//   _mm512_cvtepi8_epi16(__m256i) = VPMOVSXBW: sign-extends 32×i8 → 32×i16
+//   diff = da - db  (i16 subtraction, no overflow since range is [-255,255])
+//   acc  = VPDPWSSD(acc, diff, diff)
+//
+// 4× unrolled (256 bytes/iteration).
+float euclidean_i8(const int8_t * __restrict__ a, size_t aoffset,
+                   const int8_t * __restrict__ b, size_t boffset,
+                   size_t length)
+{
+    a += aoffset;
+    b += boffset;
+
+    __m512i acc0 = _mm512_setzero_si512(), acc1 = _mm512_setzero_si512();
+    __m512i acc2 = _mm512_setzero_si512(), acc3 = _mm512_setzero_si512();
+
+    size_t i = 0;
+    for (; i + 256 <= length; i += 256) {
+#define EUCL_BLOCK(off, acc_var)                                                          \
+        {                                                                                 \
+            const int8_t *ap = a + i + (off), *bp = b + i + (off);                      \
+            __m512i da_lo = _mm512_cvtepi8_epi16(                                        \
+                                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ap)));       \
+            __m512i db_lo = _mm512_cvtepi8_epi16(                                        \
+                                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(bp)));       \
+            __m512i da_hi = _mm512_cvtepi8_epi16(                                        \
+                                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ap + 32)));  \
+            __m512i db_hi = _mm512_cvtepi8_epi16(                                        \
+                                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(bp + 32)));  \
+            __m512i diff_lo = _mm512_sub_epi16(da_lo, db_lo);                            \
+            __m512i diff_hi = _mm512_sub_epi16(da_hi, db_hi);                            \
+            acc_var = _mm512_dpwssd_epi32(acc_var, diff_lo, diff_lo);                    \
+            acc_var = _mm512_dpwssd_epi32(acc_var, diff_hi, diff_hi);                    \
+        }
+        EUCL_BLOCK(  0, acc0)
+        EUCL_BLOCK( 64, acc1)
+        EUCL_BLOCK(128, acc2)
+        EUCL_BLOCK(192, acc3)
+#undef EUCL_BLOCK
+    }
+    __m512i acc = _mm512_add_epi32(_mm512_add_epi32(acc0, acc1),
+                                   _mm512_add_epi32(acc2, acc3));
+
+    // Single 64-byte tail blocks.
+    for (; i + 64 <= length; i += 64) {
+        __m512i da_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(a + i)));
+        __m512i db_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i)));
+        __m512i da_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(a + i + 32)));
+        __m512i db_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i + 32)));
+        acc = _mm512_dpwssd_epi32(acc, _mm512_sub_epi16(da_lo, db_lo), _mm512_sub_epi16(da_lo, db_lo));
+        acc = _mm512_dpwssd_epi32(acc, _mm512_sub_epi16(da_hi, db_hi), _mm512_sub_epi16(da_hi, db_hi));
+    }
+
+    // 32-byte tail (one ymm → one 512-bit i16 vector).
+    if (i + 32 <= length) {
+        __m512i da = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(a + i)));
+        __m512i db = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i)));
+        __m512i diff = _mm512_sub_epi16(da, db);
+        acc = _mm512_dpwssd_epi32(acc, diff, diff);
+        i += 32;
+    }
+
+    int32_t result = hsum_epi32(acc);
+
+    // Scalar tail.
+    for (; i < length; i++) {
+        int32_t d = (int32_t)a[i] - (int32_t)b[i];
+        result += d * d;
+    }
+    return (float)result;
+}
+
+// ---------------------------------------------------------------------------
+// cosine_i8  —  three parallel VPDPBUSD chains with bias correction
+// ---------------------------------------------------------------------------
+//
+// Computes dot(a,b), ||a||², ||b||² in a single pass using VPDPBUSD.
+// Bias trick: a_u = a+128 (unsigned), then subtract 128*sum(b) and 128*sum(a).
+//
+//   dot(a,b)  = hsum(VPDPBUSD(acc_dot,  a_u, b))  - 128*sum(b)
+//   ||a||²    = hsum(VPDPBUSD(acc_normA, a_u, a))  - 128*sum(a)
+//   ||b||²    = hsum(VPDPBUSD(acc_normB, b_u, b))  - 128*sum(b)
+//
+// normB reuses the same biasAB accumulator as dot (both need 128*sum(b)).
+// 2× unrolled (128 bytes/iteration) with 6 VPDPBUSD + 4 VPDPWSSD per iter.
+float cosine_i8(const int8_t * __restrict__ a, size_t aoffset,
+                const int8_t * __restrict__ b, size_t boffset,
+                size_t length)
+{
+    a += aoffset;
+    b += boffset;
+
+    const __m512i bias128 = _mm512_set1_epi16(128);
+    const __m512i flip    = _mm512_set1_epi8(-128);
+
+    __m512i dot0  = _mm512_setzero_si512(), dot1  = _mm512_setzero_si512();
+    __m512i normA0 = _mm512_setzero_si512(), normA1 = _mm512_setzero_si512();
+    __m512i normB0 = _mm512_setzero_si512(), normB1 = _mm512_setzero_si512();
+    __m512i biasAB0 = _mm512_setzero_si512(), biasAB1 = _mm512_setzero_si512();
+    __m512i biasA0  = _mm512_setzero_si512(), biasA1  = _mm512_setzero_si512();
+
+    size_t i = 0;
+    for (; i + 128 <= length; i += 128) {
+        __m512i va0 = _mm512_loadu_si512(a + i);
+        __m512i vb0 = _mm512_loadu_si512(b + i);
+        __m512i va1 = _mm512_loadu_si512(a + i + 64);
+        __m512i vb1 = _mm512_loadu_si512(b + i + 64);
+        __m512i au0 = _mm512_add_epi8(va0, flip);
+        __m512i bu0 = _mm512_add_epi8(vb0, flip);
+        __m512i au1 = _mm512_add_epi8(va1, flip);
+        __m512i bu1 = _mm512_add_epi8(vb1, flip);
+
+        dot0  = _mm512_dpbusd_epi32(dot0,  au0, vb0);
+        dot1  = _mm512_dpbusd_epi32(dot1,  au1, vb1);
+        normA0 = _mm512_dpbusd_epi32(normA0, au0, va0);
+        normA1 = _mm512_dpbusd_epi32(normA1, au1, va1);
+        normB0 = _mm512_dpbusd_epi32(normB0, bu0, vb0);
+        normB1 = _mm512_dpbusd_epi32(normB1, bu1, vb1);
+        
+        // Promote to i16 for bias calculations
+        __m512i va0_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(a + i)));
+        __m512i va0_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(a + i + 32)));
+        __m512i vb0_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i)));
+        __m512i vb0_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i + 32)));
+        __m512i va1_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(a + i + 64)));
+        __m512i va1_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(a + i + 96)));
+        __m512i vb1_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i + 64)));
+        __m512i vb1_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i + 96)));
+        
+        biasAB0 = _mm512_dpwssd_epi32(biasAB0, vb0_lo, bias128);
+        biasAB0 = _mm512_dpwssd_epi32(biasAB0, vb0_hi, bias128);
+        biasAB1 = _mm512_dpwssd_epi32(biasAB1, vb1_lo, bias128);
+        biasAB1 = _mm512_dpwssd_epi32(biasAB1, vb1_hi, bias128);
+        biasA0  = _mm512_dpwssd_epi32(biasA0,  va0_lo, bias128);
+        biasA0  = _mm512_dpwssd_epi32(biasA0,  va0_hi, bias128);
+        biasA1  = _mm512_dpwssd_epi32(biasA1,  va1_lo, bias128);
+        biasA1  = _mm512_dpwssd_epi32(biasA1,  va1_hi, bias128);
+    }
+    __m512i dot    = _mm512_add_epi32(dot0,    dot1);
+    __m512i normA  = _mm512_add_epi32(normA0,  normA1);
+    __m512i normB  = _mm512_add_epi32(normB0,  normB1);
+    __m512i biasAB = _mm512_add_epi32(biasAB0, biasAB1);
+    __m512i biasA  = _mm512_add_epi32(biasA0,  biasA1);
+
+    // Single-zmm tail.
+    for (; i + 64 <= length; i += 64) {
+        __m512i va = _mm512_loadu_si512(a + i);
+        __m512i vb = _mm512_loadu_si512(b + i);
+        __m512i au = _mm512_add_epi8(va, flip);
+        __m512i bu = _mm512_add_epi8(vb, flip);
+        dot    = _mm512_dpbusd_epi32(dot,   au, vb);
+        normA  = _mm512_dpbusd_epi32(normA, au, va);
+        normB  = _mm512_dpbusd_epi32(normB, bu, vb);
+        
+        // Promote to i16 for bias calculations
+        __m512i va_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(a + i)));
+        __m512i va_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(a + i + 32)));
+        __m512i vb_lo = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i)));
+        __m512i vb_hi = _mm512_cvtepi8_epi16(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(b + i + 32)));
+        
+        biasAB = _mm512_dpwssd_epi32(biasAB, vb_lo, bias128);
+        biasAB = _mm512_dpwssd_epi32(biasAB, vb_hi, bias128);
+        biasA  = _mm512_dpwssd_epi32(biasA,  va_lo, bias128);
+        biasA  = _mm512_dpwssd_epi32(biasA,  va_hi, bias128);
+    }
+
+    // Apply bias corrections before scalar tail.
+    int64_t dotResult   = (int64_t)hsum_epi32(dot)   - (int64_t)hsum_epi32(biasAB);
+    int64_t normAResult = (int64_t)hsum_epi32(normA) - (int64_t)hsum_epi32(biasA);
+    int64_t normBResult = (int64_t)hsum_epi32(normB) - (int64_t)hsum_epi32(biasAB);
+
+    // Scalar tail.
+    for (; i < length; i++) {
+        int32_t ai = a[i], bi = b[i];
+        dotResult   += (int64_t)ai * bi;
+        normAResult += (int64_t)ai * ai;
+        normBResult += (int64_t)bi * bi;
+    }
+
+    return (float)(dotResult / sqrt((double)normAResult * (double)normBResult));
+}
 
 } // namespace AVX3_DL

--- a/jvector-native/src/main/native/src/jvector_simd.cpp
+++ b/jvector-native/src/main/native/src/jvector_simd.cpp
@@ -82,11 +82,14 @@ static const KernelVTable AVX3_vtable = {
 };
 #undef KERNEL_ENTRY
 
-// AVX3_DL (Ice Lake) inherits all slots from AVX3 unchanged for now.
-// To override a slot: t.kernel_name = AVX3_DL::kernel_name;
-// The implementation must exist in jvector_avx3_dl_kernels.cpp.
+// AVX3_DL (Ice Lake) inherits all slots from AVX3, then overrides the three
+// int8 similarity kernels with VNNI-accelerated versions from
+// jvector_avx3_dl_kernels.cpp.
 static const KernelVTable AVX3_DL_vtable = []() {
     KernelVTable t = AVX3_vtable;
+    t.dot_product_i8 = AVX3_DL::dot_product_i8;
+    t.euclidean_i8   = AVX3_DL::euclidean_i8;
+    t.cosine_i8      = AVX3_DL::cosine_i8;
     return t;
 }();
 

--- a/jvector-native/src/main/native/src/jvector_simd_kernel_list.h
+++ b/jvector-native/src/main/native/src/jvector_simd_kernel_list.h
@@ -58,7 +58,11 @@
     KERNEL_ENTRY(float, nvq_square_l2_distance_8bit, (const float *vector, const unsigned char *quantized, size_t length, float alpha, float x0, float minValue, float maxValue), (vector, quantized, length, alpha, x0, minValue, maxValue)) \
     KERNEL_ENTRY(float, nvq_dot_product_8bit, (const float *vector, const unsigned char *quantized, size_t length, float alpha, float x0, float minValue, float maxValue), (vector, quantized, length, alpha, x0, minValue, maxValue)) \
     KERNEL_ENTRY(int64_t, nvq_cosine_8bit_packed, (const float *vector, const unsigned char *quantized, size_t length, float alpha, float x0, float minValue, float maxValue, const float *centroid), (vector, quantized, length, alpha, x0, minValue, maxValue, centroid)) \
-    KERNEL_ENTRY(void, nvq_shuffle_query_in_place_8bit, (float *vector, size_t length), (vector, length))
+    KERNEL_ENTRY(void, nvq_shuffle_query_in_place_8bit, (float *vector, size_t length), (vector, length)) \
+    /* Int8 byte-vector similarity (VNNI-accelerated on AVX3_DL+) */ \
+    KERNEL_ENTRY(float, dot_product_i8, (const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length), (a, aoffset, b, boffset, length)) \
+    KERNEL_ENTRY(float, euclidean_i8, (const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length), (a, aoffset, b, boffset, length)) \
+    KERNEL_ENTRY(float, cosine_i8, (const int8_t *a, size_t aoffset, const int8_t *b, size_t boffset, size_t length), (a, aoffset, b, boffset, length))
     /* ── ADD NEW KERNEL_ENTRY LINES ABOVE THIS LINE ── */
 // clang-format on
 

--- a/jvector-native/src/main/native/src/jvector_simd_kernels.cpp
+++ b/jvector-native/src/main/native/src/jvector_simd_kernels.cpp
@@ -1640,4 +1640,173 @@ HWY_FLATTEN int64_t nvq_cosine_8bit_packed(const float   *HWY_RESTRICT vector,
     return ((int64_t)bmag_bits << 32) | (int64_t)(uint32_t)sum_bits;
 }
 
+// =============================================================================
+// Int8 byte-vector similarity kernels
+// =============================================================================
+//
+// These kernels operate on signed int8 (int8_t) vectors — e.g. the output of
+// scalar quantization.  The generic path here (compiled for SSE4.2, AVX2, AVX3)
+// widens i8→i16 using ReorderWidenMulAccumulate, then accumulates into i32.
+//
+// On the AVX3_DL (Ice Lake+) tier these implementations are overridden in
+// jvector_avx3_dl_kernels.cpp with raw AVX-512 VNNI intrinsics — processing
+// 64 bytes per VPDPBUSD clock in a single instruction.
+// =============================================================================
+
+// Horizontal dot product of two signed int8 vectors.
+HWY_FLATTEN float dot_product_i8(const int8_t *HWY_RESTRICT a, size_t aoffset,
+                                  const int8_t *HWY_RESTRICT b, size_t boffset,
+                                  size_t length)
+{
+    a += aoffset;
+    b += boffset;
+    const hn::ScalableTag<int8_t>                     d8;
+    const hn::RepartitionToWideX2<decltype(d8)>       d32; // int32, lanes = len(d8)/4
+    const hn::Repartition<int16_t, decltype(d32)>     d16; // int16
+    const size_t lanes8 = hn::Lanes(d8);
+
+    // Four independent accumulators hide the multi-cycle MADD latency.
+    auto acc0 = hn::Zero(d32), acc1 = hn::Zero(d32);
+    auto acc2 = hn::Zero(d32), acc3 = hn::Zero(d32);
+    auto dummy0 = hn::Zero(d32), dummy1 = hn::Zero(d32);
+    auto dummy2 = hn::Zero(d32), dummy3 = hn::Zero(d32);
+    size_t i = 0;
+    for (; i + 4 * lanes8 <= length; i += 4 * lanes8) {
+        auto va0 = hn::LoadU(d8, a + i);
+        auto vb0 = hn::LoadU(d8, b + i);
+        auto va1 = hn::LoadU(d8, a + i + lanes8);
+        auto vb1 = hn::LoadU(d8, b + i + lanes8);
+        auto va2 = hn::LoadU(d8, a + i + 2*lanes8);
+        auto vb2 = hn::LoadU(d8, b + i + 2*lanes8);
+        auto va3 = hn::LoadU(d8, a + i + 3*lanes8);
+        auto vb3 = hn::LoadU(d8, b + i + 3*lanes8);
+        
+        // Promote to i16 and accumulate using ReorderWidenMulAccumulate (2 i16s -> 1 i32)
+        acc0 = hn::ReorderWidenMulAccumulate(d32, hn::PromoteLowerTo(d16, va0), hn::PromoteLowerTo(d16, vb0), acc0, dummy0);
+        acc0 = hn::ReorderWidenMulAccumulate(d32, hn::PromoteUpperTo(d16, va0), hn::PromoteUpperTo(d16, vb0), acc0, dummy0);
+        acc1 = hn::ReorderWidenMulAccumulate(d32, hn::PromoteLowerTo(d16, va1), hn::PromoteLowerTo(d16, vb1), acc1, dummy1);
+        acc1 = hn::ReorderWidenMulAccumulate(d32, hn::PromoteUpperTo(d16, va1), hn::PromoteUpperTo(d16, vb1), acc1, dummy1);
+        acc2 = hn::ReorderWidenMulAccumulate(d32, hn::PromoteLowerTo(d16, va2), hn::PromoteLowerTo(d16, vb2), acc2, dummy2);
+        acc2 = hn::ReorderWidenMulAccumulate(d32, hn::PromoteUpperTo(d16, va2), hn::PromoteUpperTo(d16, vb2), acc2, dummy2);
+        acc3 = hn::ReorderWidenMulAccumulate(d32, hn::PromoteLowerTo(d16, va3), hn::PromoteLowerTo(d16, vb3), acc3, dummy3);
+        acc3 = hn::ReorderWidenMulAccumulate(d32, hn::PromoteUpperTo(d16, va3), hn::PromoteUpperTo(d16, vb3), acc3, dummy3);
+    }
+    auto acc = hn::Add(hn::Add(acc0, acc1), hn::Add(acc2, acc3));
+    auto dummy = hn::Zero(d32);
+    
+    for (; i + lanes8 <= length; i += lanes8) {
+        auto va = hn::LoadU(d8, a + i);
+        auto vb = hn::LoadU(d8, b + i);
+        acc = hn::ReorderWidenMulAccumulate(d32, hn::PromoteLowerTo(d16, va), hn::PromoteLowerTo(d16, vb), acc, dummy);
+        acc = hn::ReorderWidenMulAccumulate(d32, hn::PromoteUpperTo(d16, va), hn::PromoteUpperTo(d16, vb), acc, dummy);
+    }
+    int32_t result = hn::ReduceSum(d32, acc);
+    for (; i < length; i++) result += (int32_t)a[i] * (int32_t)b[i];
+    return (float)result;
+}
+
+// Sum of squared differences of two signed int8 vectors.
+// Promote i8→i16, subtract in i16, then ReorderWidenMulAccumulate into i32.
+HWY_FLATTEN float euclidean_i8(const int8_t *HWY_RESTRICT a, size_t aoffset,
+                                const int8_t *HWY_RESTRICT b, size_t boffset,
+                                size_t length)
+{
+    a += aoffset;
+    b += boffset;
+    const hn::ScalableTag<int8_t>                     d8;
+    const hn::RepartitionToWideX2<decltype(d8)>       d32; // int32, lanes = len(d8)/4
+    const size_t lanes8 = hn::Lanes(d8);
+
+    auto acc0 = hn::Zero(d32), acc0h = hn::Zero(d32);
+    auto acc1 = hn::Zero(d32), acc1h = hn::Zero(d32);
+    auto acc2 = hn::Zero(d32), acc2h = hn::Zero(d32);
+    auto acc3 = hn::Zero(d32), acc3h = hn::Zero(d32);
+    size_t i = 0;
+    for (; i + 4 * lanes8 <= length; i += 4 * lanes8) {
+#define DO_EUCL_BLOCK(off, lo_var, hi_var)                                                   \
+        {                                                                                    \
+            const hn::RepartitionToWide<decltype(d8)> _d16;                                 \
+            auto _va8     = hn::LoadU(d8, a + i + (off));                                   \
+            auto _vb8     = hn::LoadU(d8, b + i + (off));                                   \
+            auto _diff_lo = hn::Sub(hn::PromoteLowerTo(_d16, _va8),                         \
+                                    hn::PromoteLowerTo(_d16, _vb8));                         \
+            auto _diff_hi = hn::Sub(hn::PromoteUpperTo(_d16, _va8),                         \
+                                    hn::PromoteUpperTo(_d16, _vb8));                         \
+            lo_var = hn::ReorderWidenMulAccumulate(d32, _diff_lo, _diff_lo, lo_var, hi_var); \
+            lo_var = hn::ReorderWidenMulAccumulate(d32, _diff_hi, _diff_hi, lo_var, hi_var); \
+        }
+        DO_EUCL_BLOCK(0,          acc0, acc0h)
+        DO_EUCL_BLOCK(lanes8,     acc1, acc1h)
+        DO_EUCL_BLOCK(2*lanes8,   acc2, acc2h)
+        DO_EUCL_BLOCK(3*lanes8,   acc3, acc3h)
+#undef DO_EUCL_BLOCK
+    }
+    auto acc  = hn::Add(hn::Add(acc0,  acc1),  hn::Add(acc2,  acc3));
+    auto acch = hn::Add(hn::Add(acc0h, acc1h), hn::Add(acc2h, acc3h));
+    acc = hn::Add(acc, acch);
+    for (; i + lanes8 <= length; i += lanes8) {
+        const hn::RepartitionToWide<decltype(d8)> d16;
+        auto va8     = hn::LoadU(d8, a + i);
+        auto vb8     = hn::LoadU(d8, b + i);
+        auto diff_lo = hn::Sub(hn::PromoteLowerTo(d16, va8), hn::PromoteLowerTo(d16, vb8));
+        auto diff_hi = hn::Sub(hn::PromoteUpperTo(d16, va8), hn::PromoteUpperTo(d16, vb8));
+        auto dummy_hi = hn::Zero(d32);
+        acc = hn::ReorderWidenMulAccumulate(d32, diff_lo, diff_lo, acc, dummy_hi);
+        acc = hn::Add(acc, dummy_hi);
+        dummy_hi = hn::Zero(d32);
+        acc = hn::ReorderWidenMulAccumulate(d32, diff_hi, diff_hi, acc, dummy_hi);
+        acc = hn::Add(acc, dummy_hi);
+    }
+    int32_t result = hn::ReduceSum(d32, acc);
+    for (; i < length; i++) {
+        int32_t d = (int32_t)a[i] - (int32_t)b[i];
+        result += d * d;
+    }
+    return (float)result;
+}
+
+// Cosine similarity of two signed int8 vectors.
+// Computes dot(a,b), dot(a,a), dot(b,b) in parallel over a single pass.
+HWY_FLATTEN float cosine_i8(const int8_t *HWY_RESTRICT a, size_t aoffset,
+                             const int8_t *HWY_RESTRICT b, size_t boffset,
+                             size_t length)
+{
+    a += aoffset;
+    b += boffset;
+    const hn::ScalableTag<int8_t>                     d8;
+    const hn::RepartitionToWideX2<decltype(d8)>       d32;
+    const hn::Repartition<int16_t, decltype(d32)>     d16;
+    const size_t lanes8 = hn::Lanes(d8);
+
+    auto dot       = hn::Zero(d32);
+    auto normA     = hn::Zero(d32);
+    auto normB     = hn::Zero(d32);
+    auto dummy_acc = hn::Zero(d32);
+
+    size_t i = 0;
+    for (; i + lanes8 <= length; i += lanes8) {
+        auto va = hn::LoadU(d8, a + i);
+        auto vb = hn::LoadU(d8, b + i);
+        
+        dot   = hn::ReorderWidenMulAccumulate(d32, hn::PromoteLowerTo(d16, va), hn::PromoteLowerTo(d16, vb), dot, dummy_acc);
+        dot   = hn::ReorderWidenMulAccumulate(d32, hn::PromoteUpperTo(d16, va), hn::PromoteUpperTo(d16, vb), dot, dummy_acc);
+        normA = hn::ReorderWidenMulAccumulate(d32, hn::PromoteLowerTo(d16, va), hn::PromoteLowerTo(d16, va), normA, dummy_acc);
+        normA = hn::ReorderWidenMulAccumulate(d32, hn::PromoteUpperTo(d16, va), hn::PromoteUpperTo(d16, va), normA, dummy_acc);
+        normB = hn::ReorderWidenMulAccumulate(d32, hn::PromoteLowerTo(d16, vb), hn::PromoteLowerTo(d16, vb), normB, dummy_acc);
+        normB = hn::ReorderWidenMulAccumulate(d32, hn::PromoteUpperTo(d16, vb), hn::PromoteUpperTo(d16, vb), normB, dummy_acc);
+    }
+    
+    int64_t dotResult   = (int64_t)hn::ReduceSum(d32, dot);
+    int64_t normAResult = (int64_t)hn::ReduceSum(d32, normA);
+    int64_t normBResult = (int64_t)hn::ReduceSum(d32, normB);
+    
+    for (; i < length; i++) {
+        int32_t ai = a[i], bi = b[i];
+        dotResult   += ai * bi;
+        normAResult += ai * ai;
+        normBResult += bi * bi;
+    }
+    return (float)(dotResult / sqrt((double)normAResult * (double)normBResult));
+}
+
 }  // namespace JV_ISA

--- a/jvector-native/src/main/native/tests/test_helpers.cpp
+++ b/jvector-native/src/main/native/tests/test_helpers.cpp
@@ -73,6 +73,10 @@ const std::vector<KernelTestParam> kKernelTestParams = {
     {100, "large_mixed_tail"},
     {128, "large_power_of_2"},
     {255, "large_odd_tail_15"},
+    // ---- i8 VNNI 256-byte unroll boundaries (dot_product_i8/euclidean_i8) -
+    {256, "i8_vnni_4x_exact"},
+    {263, "i8_vnni_4x_tail_7"},
+    {135, "i8_vnni_2zmm_tail_7"},
 };
 
 std::vector<float> make_vec(size_t n, float seed)
@@ -82,6 +86,24 @@ std::vector<float> make_vec(size_t n, float seed)
         v[i] = seed * (1.0f + static_cast<float>(i % 7) * 0.13f);
         if (i % 3 == 0) v[i] = -v[i]; // mix of signs
         v[i] += 0.5f;                  // ensure non-zero even after sign flip
+    }
+    return v;
+}
+
+// Produces n int8_t values with a mix of signs and magnitudes.
+// The pattern ensures no element is zero (important for cosine tests).
+std::vector<int8_t> make_vec_i8(size_t n, int8_t seed)
+{
+    std::vector<int8_t> v(n);
+    for (size_t i = 0; i < n; ++i) {
+        // Scale seed by a small per-element factor to get variety,
+        // then clamp to [-100, 100] to keep products well within int16 range.
+        int val = static_cast<int>(seed) + static_cast<int>(i % 13) - 6;
+        if (i % 3 == 0) val = -val;   // mix of signs
+        if (val == 0)   val = 1;       // never zero
+        if (val >  100) val =  100;
+        if (val < -100) val = -100;
+        v[i] = static_cast<int8_t>(val);
     }
     return v;
 }

--- a/jvector-native/src/main/native/tests/test_helpers.h
+++ b/jvector-native/src/main/native/tests/test_helpers.h
@@ -35,7 +35,11 @@
 // so that no element is exactly zero (important for cosine tests).
 // ---------------------------------------------------------------------------
 
-std::vector<float> make_vec(size_t n, float seed);
+std::vector<float>   make_vec(size_t n, float seed);
+
+// make_vec_i8(n, seed) produces n int8_t values with a mix of signs
+// suitable for testing the i8 similarity kernels.
+std::vector<int8_t>  make_vec_i8(size_t n, int8_t seed);
 
 // ---------------------------------------------------------------------------
 // Shared test parameter — vector length + human-readable path description.

--- a/jvector-native/src/main/native/tests/test_similarity_i8.cpp
+++ b/jvector-native/src/main/native/tests/test_similarity_i8.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for int8 vector similarity kernels: dot_product_i8, euclidean_i8, cosine_i8.
+//
+// The kernels operate on signed int8_t vectors and return a float result:
+//   dot_product_i8  — (float) sum(a[i] * b[i])
+//   euclidean_i8    — (float) sum((a[i] - b[i])^2)   (squared L2 distance)
+//   cosine_i8       — (float) dot(a,b) / sqrt(||a||^2 * ||b||^2)
+//
+// On AVX3_DL (Ice Lake+) these are overridden with VNNI (VPDPBUSD/VPDPWSSD)
+// implementations; on all other tiers the generic Highway path is used.
+//
+// All tests are parametrised over kKernelTestParams (defined in test_helpers.cpp),
+// which covers every ISA-tier loop-boundary for both f32 and i8 kernels, including
+// the VNNI-specific 64/128/256-byte unroll boundaries added for the i8 suite.
+
+#include "test_helpers.h"
+
+// ---------------------------------------------------------------------------
+// Reference scalar implementations
+// ---------------------------------------------------------------------------
+
+static float ref_dot_i8(const std::vector<int8_t>& a, const std::vector<int8_t>& b)
+{
+    int64_t s = 0;
+    for (size_t i = 0; i < a.size(); ++i)
+        s += static_cast<int32_t>(a[i]) * static_cast<int32_t>(b[i]);
+    return static_cast<float>(s);
+}
+
+static float ref_euclidean_i8(const std::vector<int8_t>& a, const std::vector<int8_t>& b)
+{
+    int64_t s = 0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        int32_t d = static_cast<int32_t>(a[i]) - static_cast<int32_t>(b[i]);
+        s += d * d;
+    }
+    return static_cast<float>(s);
+}
+
+static float ref_cosine_i8(const std::vector<int8_t>& a, const std::vector<int8_t>& b)
+{
+    int64_t dot = 0, normA = 0, normB = 0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        int32_t ai = a[i], bi = b[i];
+        dot   += static_cast<int64_t>(ai) * bi;
+        normA += static_cast<int64_t>(ai) * ai;
+        normB += static_cast<int64_t>(bi) * bi;
+    }
+    return static_cast<float>(dot / std::sqrt(static_cast<double>(normA)
+                                              * static_cast<double>(normB)));
+}
+
+// ---------------------------------------------------------------------------
+// Parametrised test fixture
+// ---------------------------------------------------------------------------
+
+class SimilarityI8Test : public ::testing::TestWithParam<KernelTestParam> {};
+
+// ---------------------------------------------------------------------------
+// dot_product_i8 — SIMD result must match the scalar reference
+// ---------------------------------------------------------------------------
+
+TEST_P(SimilarityI8Test, DotProduct)
+{
+    const size_t n = GetParam().length;
+    auto a = make_vec_i8(n, 7);
+    auto b = make_vec_i8(n, 11);
+
+    const float want = ref_dot_i8(a, b);
+    const float got  = dot_product_i8(a.data(), 0, b.data(), 0, n);
+
+    // Integer accumulation with a single int64→float cast — result is exact.
+    EXPECT_EQ(got, want);
+}
+
+// ---------------------------------------------------------------------------
+// dot_product_i8 with non-zero offsets — exercises the aoffset/boffset path
+// ---------------------------------------------------------------------------
+
+TEST_P(SimilarityI8Test, DotProductWithOffset)
+{
+    const size_t n      = GetParam().length;
+    const size_t prefix = 5; // arbitrary prefix that must be ignored
+
+    std::vector<int8_t> a_pad(prefix + n, 0);
+    std::vector<int8_t> b_pad(prefix + n, 0);
+    auto a = make_vec_i8(n, 7);
+    auto b = make_vec_i8(n, 11);
+    std::copy(a.begin(), a.end(), a_pad.begin() + prefix);
+    std::copy(b.begin(), b.end(), b_pad.begin() + prefix);
+
+    const float want = ref_dot_i8(a, b);
+    const float got  = dot_product_i8(a_pad.data(), prefix, b_pad.data(), prefix, n);
+
+    EXPECT_EQ(got, want);
+}
+
+// ---------------------------------------------------------------------------
+// dot_product_i8 — zero vector gives exactly 0.0
+// ---------------------------------------------------------------------------
+
+TEST_P(SimilarityI8Test, DotProductZeroVector)
+{
+    const size_t n = GetParam().length;
+    auto a = make_vec_i8(n, 7);
+    std::vector<int8_t> z(n, 0);
+
+    EXPECT_EQ(dot_product_i8(a.data(), 0, z.data(), 0, n), 0.0f);
+}
+
+// ---------------------------------------------------------------------------
+// euclidean_i8 — SIMD result must match the scalar reference
+// ---------------------------------------------------------------------------
+
+TEST_P(SimilarityI8Test, Euclidean)
+{
+    const size_t n = GetParam().length;
+    auto a = make_vec_i8(n, 7);
+    auto b = make_vec_i8(n, 11);
+
+    const float want = ref_euclidean_i8(a, b);
+    const float got  = euclidean_i8(a.data(), 0, b.data(), 0, n);
+
+    // Integer accumulation with a single int64→float cast — result is exact.
+    EXPECT_EQ(got, want);
+}
+
+// ---------------------------------------------------------------------------
+// euclidean_i8 — identical vectors must give exactly 0
+// ---------------------------------------------------------------------------
+
+TEST_P(SimilarityI8Test, EuclideanSameVector)
+{
+    const size_t n = GetParam().length;
+    auto a = make_vec_i8(n, 9);
+
+    const float got = euclidean_i8(a.data(), 0, a.data(), 0, n);
+
+    EXPECT_EQ(got, 0.0f);
+}
+
+// ---------------------------------------------------------------------------
+// cosine_i8 — SIMD result must match the scalar reference
+// ---------------------------------------------------------------------------
+
+TEST_P(SimilarityI8Test, Cosine)
+{
+    const size_t n = GetParam().length;
+    auto a = make_vec_i8(n, 7);
+    auto b = make_vec_i8(n, 11);
+
+    const float want = ref_cosine_i8(a, b);
+    const float got  = cosine_i8(a.data(), 0, b.data(), 0, n);
+
+    EXPECT_NEAR(got, want, 1e-5f);
+}
+
+// ---------------------------------------------------------------------------
+// cosine_i8 — parallel vectors (b = k*a, k > 0) should give similarity ≈ 1.0
+// ---------------------------------------------------------------------------
+
+TEST_P(SimilarityI8Test, CosineParallelVectors)
+{
+    const size_t n = GetParam().length;
+    // Use small magnitudes so that 2*val stays within int8 range.
+    auto a = make_vec_i8(n, 3);
+    std::vector<int8_t> b(n);
+    for (size_t i = 0; i < n; ++i)
+        b[i] = static_cast<int8_t>(std::max(-127, std::min(127, 2 * static_cast<int>(a[i]))));
+
+    const float got = cosine_i8(a.data(), 0, b.data(), 0, n);
+
+    EXPECT_NEAR(got, 1.0f, 1e-5f);
+}
+
+// ---------------------------------------------------------------------------
+// cosine_i8 — orthogonal vectors should give similarity ≈ 0.0
+//
+// Same analytic construction as the f32 test: for even n,
+//   a = [+1, +1, +1, ...]
+//   b = [+1, -1, +1, -1, ...]  →  dot(a,b) = 0.
+// Odd n: the odd last element is zeroed out on b (unchanged on a) so the
+// dot product remains zero without affecting the norms materially.
+// ---------------------------------------------------------------------------
+
+TEST_P(SimilarityI8Test, CosineOrthogonalVectors)
+{
+    const size_t n = GetParam().length;
+    if (n < 2) GTEST_SKIP() << "need at least 2 elements for orthogonality";
+
+    const size_t even_n = n - (n % 2);
+
+    std::vector<int8_t> a(n, 0), b(n, 0);
+    for (size_t i = 0; i < even_n; ++i) {
+        a[i] = 1;
+        b[i] = (i % 2 == 0) ? 1 : -1;
+    }
+
+    const float got = cosine_i8(a.data(), 0, b.data(), 0, n);
+
+    EXPECT_NEAR(got, 0.0f, 1e-5f);
+}
+
+// ---------------------------------------------------------------------------
+// Instantiation — named using the description field
+// ---------------------------------------------------------------------------
+
+INSTANTIATE_TEST_SUITE_P(
+    AllSizes,
+    SimilarityI8Test,
+    ::testing::ValuesIn(kKernelTestParams),
+    [](const ::testing::TestParamInfo<KernelTestParam>& info) {
+        return info.param.description;
+    });

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestListRandomAccessByteVectorValues.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestListRandomAccessByteVectorValues.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.graph;
+
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class TestListRandomAccessByteVectorValues {
+
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private ByteSequence<?> seq(byte... values) {
+        return vts.createByteSequence(values);
+    }
+
+    @Test
+    public void testSizeAndDimension() {
+        int dim = 4;
+        List<ByteSequence<?>> vectors = List.of(seq((byte) 1, (byte) 2, (byte) 3, (byte) 4),
+                                                 seq((byte) 5, (byte) 6, (byte) 7, (byte) 8));
+        var rabvv = new ListRandomAccessByteVectorValues(vectors, dim);
+        assertEquals(2, rabvv.size());
+        assertEquals(dim, rabvv.dimension());
+    }
+
+    @Test
+    public void testGetVectorReturnsCorrectEntry() {
+        var v0 = seq((byte) 10, (byte) 20);
+        var v1 = seq((byte) -1, (byte) -2);
+        var v2 = seq((byte) 127, (byte) -128);
+        var rabvv = new ListRandomAccessByteVectorValues(List.of(v0, v1, v2), 2);
+
+        assertSame(v0, rabvv.getVector(0));
+        assertSame(v1, rabvv.getVector(1));
+        assertSame(v2, rabvv.getVector(2));
+    }
+
+    @Test
+    public void testIsValueShared() {
+        var rabvv = new ListRandomAccessByteVectorValues(List.of(seq((byte) 0)), 1);
+        assertFalse(rabvv.isValueShared());
+    }
+
+    @Test
+    public void testCopyReturnsSelf() {
+        var rabvv = new ListRandomAccessByteVectorValues(List.of(seq((byte) 1, (byte) 2)), 2);
+        assertSame(rabvv, rabvv.copy());
+    }
+
+    @Test
+    public void testMutableBackingListIsReflected() {
+        // ListRandomAccessByteVectorValues documents that additions to the backing list are visible
+        List<ByteSequence<?>> backing = new ArrayList<>();
+        backing.add(seq((byte) 1));
+        var rabvv = new ListRandomAccessByteVectorValues(backing, 1);
+        assertEquals(1, rabvv.size());
+
+        backing.add(seq((byte) 2));
+        assertEquals(2, rabvv.size());
+        assertSame(backing.get(1), rabvv.getVector(1));
+    }
+}

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
@@ -433,7 +433,7 @@ public class TestVectorGraph extends LuceneTestCase {
 
     public void testGraphIndexBuilderInvalid(boolean addHierarchy) {
         assertThrows(NullPointerException.class,
-                () -> new GraphIndexBuilder(null, null, 0, 0, 1.0f, 1.0f, addHierarchy));
+                () -> new GraphIndexBuilder((RandomAccessVectorValues) null, (VectorSimilarityFunction) null, 0, 0, 1.0f, 1.0f, addHierarchy));
         // M must be > 0
         assertThrows(IllegalArgumentException.class,
                 () -> {

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/TestVectorGraph.java
@@ -33,10 +33,13 @@ import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.util.BoundedLongHeap;
 import io.github.jbellis.jvector.util.FixedBitSet;
+import io.github.jbellis.jvector.vector.ByteVectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import io.github.jbellis.jvector.graph.VectorValues;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -799,5 +802,164 @@ public class TestVectorGraph extends LuceneTestCase {
             }
         }
         return bits;
+    }
+
+    // -----------------------------------------------------------------------
+    // Byte-vector (int8) graph construction tests
+    // -----------------------------------------------------------------------
+
+    /** Build a small int8 graph using every similarity function and verify it is navigable. */
+    @Test
+    public void testByteVectorBuildAllSimilarityFunctions() {
+        for (var bvsf : ByteVectorSimilarityFunction.values()) {
+            testByteVectorBuild(bvsf, false);
+            testByteVectorBuild(bvsf, true);
+        }
+    }
+
+    private void testByteVectorBuild(ByteVectorSimilarityFunction bvsf, boolean addHierarchy) {
+        int n = 50, dim = 8;
+        var rabvv = randomByteVectorValues(n, dim);
+        var builder = GraphIndexBuilder.builder(rabvv, bvsf, 8)
+                .withBeamWidth(20)
+                .withNeighborOverflow(1.2f)
+                .withAlpha(1.2f)
+                .build();
+        var graph = builder.build(rabvv);
+        validateIndex(graph);
+        assertNotNull("entry node must be set", graph.getView().entryNode());
+        assertEquals(n, graph.size(0));
+    }
+
+    /** addGraphNode(int, ByteSequence) inserts nodes one by one and yields the right count. */
+    @Test
+    public void testByteVectorAddGraphNodeOneByOne() {
+        int n = 30, dim = 4;
+        var rabvv = randomByteVectorValues(n, dim);
+        var builder = GraphIndexBuilder.builder(rabvv, ByteVectorSimilarityFunction.EUCLIDEAN, 4)
+                .withBeamWidth(10)
+                .withNeighborOverflow(1.2f)
+                .withAlpha(1.2f)
+                .build();
+        for (int i = 0; i < n; i++) {
+            builder.addGraphNode(i, rabvv.getVector(i));
+        }
+        builder.cleanup();
+        var graph = builder.getGraph();
+        validateIndex(graph);
+        assertEquals(n, graph.size(0));
+        // every node's neighbor count is within the declared degree
+        var view = graph.getView();
+        for (int i = 0; i < n; i++) {
+            assertTrue(view.getNeighborsIterator(0, i).size() <= graph.getDegree(0));
+        }
+    }
+
+    /**
+     * addGraphNode(int, ByteSequence) must throw when the builder was constructed with a
+     * float-vector score provider.
+     */
+    @Test
+    public void testByteAddGraphNodeThrowsOnFloatBuilder() {
+        var floatRavv = circularVectorValues(10);
+        var builder = new GraphIndexBuilder(floatRavv, VectorSimilarityFunction.EUCLIDEAN, 4, 10, 1.2f, 1.2f, false);
+        var bs = vectorTypeSupport.createByteSequence(4);
+        assertThrows(UnsupportedOperationException.class, () -> builder.addGraphNode(0, bs));
+    }
+
+    /**
+     * build(VectorValues<?>) dispatches correctly when given a RandomAccessByteVectorValues.
+     */
+    @Test
+    public void testByteVectorBuildViaGenericBuildMethod() {
+        int n = 40, dim = 6;
+        var rabvv = randomByteVectorValues(n, dim);
+        var builder = GraphIndexBuilder.builder(rabvv, ByteVectorSimilarityFunction.DOT_PRODUCT, 6)
+                .withBeamWidth(20)
+                .withNeighborOverflow(1.2f)
+                .withAlpha(1.2f)
+                .build();
+        // call the generic VectorValues<?> overload explicitly
+        var graph = builder.build((VectorValues<?>) rabvv);
+        validateIndex(graph);
+        assertEquals(n, graph.size(0));
+    }
+
+    /** refineFinalGraph=false and refineFinalGraph=true both produce valid graphs. */
+    @Test
+    public void testByteVectorRefineFinalGraphVariants() {
+        int n = 40, dim = 4;
+        for (boolean refine : new boolean[]{false, true}) {
+            var rabvv = randomByteVectorValues(n, dim);
+            // Use the 7-arg constructor (refineFinalGraph defaults to true); test both via the
+            // BSP constructor which exposes the refineFinalGraph knob
+            var bsp = io.github.jbellis.jvector.graph.similarity.BuildScoreProvider.byteVectorScoreProvider(
+                    rabvv, ByteVectorSimilarityFunction.EUCLIDEAN);
+            var builder = new GraphIndexBuilder(bsp, dim, 4, 20, 1.2f, 1.2f, false, refine);
+            var graph = builder.build(rabvv);
+            validateIndex(graph);
+            assertEquals(n, graph.size(0));
+            var view = graph.getView();
+            int ub = graph.getIdUpperBound();
+            for (int i = 0; i < n; i++) {
+                for (var it = view.getNeighborsIterator(0, i); it.hasNext(); ) {
+                    int nb = it.nextInt();
+                    assertTrue("neighbor " + nb + " out of bounds", nb >= 0 && nb < ub);
+                }
+            }
+        }
+    }
+
+    /** Smoke-test: a built byte-vector graph achieves reasonable top-5 recall. */
+    @Test
+    public void testByteVectorSearchRecall() {
+        int n = 200, dim = 16;
+        int topK = 5;
+        var rabvv  = randomByteVectorValues(n, dim);
+        var bvsf   = ByteVectorSimilarityFunction.EUCLIDEAN;
+        var builder = GraphIndexBuilder.builder(rabvv, bvsf, 16)
+                .withBeamWidth(50)
+                .withNeighborOverflow(1.2f)
+                .withAlpha(1.2f)
+                .build();
+        var graph  = builder.build(rabvv);
+
+        int totalMatches = 0;
+        int trials = 100;
+        for (int t = 0; t < trials; t++) {
+            byte[] rawQ = new byte[dim];
+            getRandom().nextBytes(rawQ);
+            ByteSequence<?> query = vectorTypeSupport.createByteSequence(rawQ);
+
+            // brute-force top-K
+            NodeQueue expected = new NodeQueue(new BoundedLongHeap(topK), NodeQueue.Order.MIN_HEAP);
+            for (int i = 0; i < n; i++) {
+                expected.push(i, bvsf.compare(query, rabvv.getVector(i)));
+            }
+
+            // graph search with efSearch = 100 (larger than topK to explore more candidates)
+            var ssp = new DefaultSearchScoreProvider(
+                    (io.github.jbellis.jvector.graph.similarity.ScoreFunction.ExactScoreFunction)
+                    node -> bvsf.compare(query, rabvv.getVector(node)));
+            var result = new GraphSearcher(graph).search(ssp, topK, 100, 0f, 0f, Bits.ALL);
+            var actualNodeIds = Arrays.stream(result.getNodes(), 0, topK)
+                    .mapToInt(ns -> ns.node).toArray();
+
+            totalMatches += computeOverlap(actualNodeIds, expected.nodesCopy());
+        }
+        // with efSearch=100 over a 200-node graph, we can visit most nodes; expect >=90% recall
+        double overlap = totalMatches / (double) (trials * topK);
+        assertTrue("byte-vector recall " + overlap + " is too low", overlap > 0.9);
+    }
+
+    /** Creates a list-backed RandomAccessByteVectorValues with random int8 vectors. */
+    private ListRandomAccessByteVectorValues randomByteVectorValues(int n, int dim) {
+        var list = new java.util.ArrayList<ByteSequence<?>>(n);
+        for (int i = 0; i < n; i++) {
+            byte[] raw = new byte[dim];
+            getRandom().nextBytes(raw);
+            list.add(vectorTypeSupport.createByteSequence(raw));
+        }
+        return new ListRandomAccessByteVectorValues(list, dim);
     }
 }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
@@ -340,7 +340,7 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
              var onDiskGraph = OnDiskGraphIndex.load(readerSupplier);
              var onDiskView = onDiskGraph.getView())
         {
-            assertEquals(88, onDiskGraph.ramBytesUsed()); // Current size of graph that hasn't been read from
+            assertEquals(96, onDiskGraph.ramBytesUsed()); // Current size of graph that hasn't been read from
             assertEquals(32, onDiskGraph.getDegree(0));
             assertEquals(2, onDiskGraph.version);
             assertEquals(100_000, onDiskGraph.size(0));

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/disk/TestOnDiskGraphIndex.java
@@ -23,6 +23,7 @@ import io.github.jbellis.jvector.disk.SimpleMappedReader;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
+import io.github.jbellis.jvector.graph.ListRandomAccessByteVectorValues;
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.NodesIterator;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
@@ -30,6 +31,7 @@ import io.github.jbellis.jvector.graph.TestVectorGraph;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.FusedPQ;
+import io.github.jbellis.jvector.graph.disk.feature.InlineByteVectors;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.disk.feature.SeparatedNVQ;
@@ -38,7 +40,13 @@ import io.github.jbellis.jvector.quantization.NVQuantization;
 import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
+import io.github.jbellis.jvector.vector.ByteVectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -526,6 +534,218 @@ public class TestOnDiskGraphIndex extends RandomizedTest {
             validateVectors(incrementalView, ravv); // inline vectors should be the same
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // InlineByteVectors (int8) tests
+    // -----------------------------------------------------------------------
+
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    /** Builds a list of n random int8 vectors of the given dimension. */
+    private List<ByteSequence<?>> randomByteVectors(int n, int dim) {
+        var list = new ArrayList<ByteSequence<?>>(n);
+        for (int i = 0; i < n; i++) {
+            byte[] raw = new byte[dim];
+            getRandom().nextBytes(raw);
+            list.add(vts.createByteSequence(raw));
+        }
+        return list;
+    }
+
+    /**
+     * Full round-trip: build with InlineByteVectors, write, reload, verify
+     * getByteVector() returns the original bytes for every node.
+     */
+    @Test
+    public void testInlineByteVectorsRoundTrip() throws IOException {
+        int n = 50, dim = 8;
+        var vectors = randomByteVectors(n, dim);
+        var rabvv   = new ListRandomAccessByteVectorValues(vectors, dim);
+
+        // Build a graph
+        var builder = GraphIndexBuilder.builder(rabvv, ByteVectorSimilarityFunction.EUCLIDEAN, 8)
+                .withBeamWidth(20)
+                .withNeighborOverflow(1.2f)
+                .withAlpha(1.2f)
+                .build();
+        var graph   = builder.build(rabvv);
+
+        // Write with InlineByteVectors feature
+        var outputPath = testDirectory.resolve("byte_vectors_roundtrip");
+        try (var writer = new OnDiskGraphIndexWriter.Builder(graph, outputPath)
+                .with(new InlineByteVectors(dim))
+                .build())
+        {
+            writer.write(Feature.singleStateFactory(FeatureId.INLINE_BYTE_VECTORS,
+                    nodeId -> new InlineByteVectors.State(rabvv.getVector(nodeId))));
+        }
+
+        // Reload and verify every vector
+        try (var rs = new SimpleMappedReader.Supplier(outputPath.toAbsolutePath());
+             var onDisk = OnDiskGraphIndex.load(rs);
+             var view   = onDisk.getView())
+        {
+            assertTrue("INLINE_BYTE_VECTORS feature missing",
+                    onDisk.getFeatureSet().contains(FeatureId.INLINE_BYTE_VECTORS));
+            assertEquals(dim, onDisk.dimension);
+
+            for (int i = 0; i < n; i++) {
+                var expected = rabvv.getVector(i);
+                var actual   = view.getByteVector(i);
+                assertEquals("byte vector length mismatch at node " + i, expected.length(), actual.length());
+                for (int d = 0; d < dim; d++) {
+                    assertEquals("byte mismatch at node " + i + " dim " + d,
+                            expected.get(d), actual.get(d));
+                }
+            }
+        }
+    }
+
+    /**
+     * featureSize() of InlineByteVectors must equal the dimension (1 byte per component),
+     * confirming 4× compression vs float32 InlineVectors.
+     */
+    @Test
+    public void testInlineByteVectorsFeatureSize() {
+        for (int dim : new int[]{1, 8, 128, 256}) {
+            var ibv = new InlineByteVectors(dim);
+            assertEquals("featureSize should equal dimension", dim, ibv.featureSize());
+            // float32 InlineVectors uses 4 * dim bytes
+            assertEquals("byte feature 4x smaller than float32",
+                    new InlineVectors(dim).featureSize(), 4 * ibv.featureSize());
+        }
+    }
+
+    /**
+     * getByteVector throws UnsupportedOperationException when the graph has no INLINE_BYTE_VECTORS feature.
+     */
+    @Test
+    public void testGetByteVectorThrowsWithoutFeature() throws IOException {
+        // Build and write a float-vector graph (no INLINE_BYTE_VECTORS)
+        var graph = new TestUtil.RandomlyConnectedGraphIndex(10, 4, getRandom());
+        var ravv  = new TestVectorGraph.CircularFloatVectorValues(10);
+        var outputPath = testDirectory.resolve("float_graph_no_bytes");
+        TestUtil.writeGraph(graph, ravv, outputPath);
+
+        try (var rs = new SimpleMappedReader.Supplier(outputPath.toAbsolutePath());
+             var onDisk = OnDiskGraphIndex.load(rs);
+             var view   = onDisk.getView())
+        {
+            assertFalse(onDisk.getFeatureSet().contains(FeatureId.INLINE_BYTE_VECTORS));
+            assertThrows(UnsupportedOperationException.class, () -> view.getByteVector(0));
+        }
+    }
+
+    /**
+     * byteVectorRerankerFor throws UnsupportedOperationException when the graph has no INLINE_BYTE_VECTORS feature.
+     */
+    @Test
+    public void testByteVectorRerankerThrowsWithoutFeature() throws IOException {
+        var graph = new TestUtil.RandomlyConnectedGraphIndex(10, 4, getRandom());
+        var ravv  = new TestVectorGraph.CircularFloatVectorValues(10);
+        var outputPath = testDirectory.resolve("float_graph_reranker");
+        TestUtil.writeGraph(graph, ravv, outputPath);
+
+        try (var rs = new SimpleMappedReader.Supplier(outputPath.toAbsolutePath());
+             var onDisk = OnDiskGraphIndex.load(rs);
+             var view   = onDisk.getView())
+        {
+            var qb = vts.createByteSequence(2);
+            assertThrows(UnsupportedOperationException.class,
+                    () -> view.byteVectorRerankerFor(qb, ByteVectorSimilarityFunction.EUCLIDEAN));
+        }
+    }
+
+    /**
+     * byteVectorRerankerFor returns scores consistent with a direct bvsf.compare() call.
+     */
+    @Test
+    public void testByteVectorRerankerScoresMatchDirectCompare() throws IOException {
+        int n = 30, dim = 4;
+        var vectors = randomByteVectors(n, dim);
+        var rabvv   = new ListRandomAccessByteVectorValues(vectors, dim);
+        var bvsf    = ByteVectorSimilarityFunction.EUCLIDEAN;
+
+        var builder = GraphIndexBuilder.builder(rabvv, bvsf, 8)
+                .withBeamWidth(20)
+                .withNeighborOverflow(1.2f)
+                .withAlpha(1.2f)
+                .build();
+        var graph   = builder.build(rabvv);
+
+        var outputPath = testDirectory.resolve("byte_reranker_test");
+        try (var writer = new OnDiskGraphIndexWriter.Builder(graph, outputPath)
+                .with(new InlineByteVectors(dim))
+                .build())
+        {
+            writer.write(Feature.singleStateFactory(FeatureId.INLINE_BYTE_VECTORS,
+                    nodeId -> new InlineByteVectors.State(rabvv.getVector(nodeId))));
+        }
+
+        try (var rs = new SimpleMappedReader.Supplier(outputPath.toAbsolutePath());
+             var onDisk = OnDiskGraphIndex.load(rs);
+             var view   = onDisk.getView())
+        {
+            byte[] rawQ = new byte[dim];
+            getRandom().nextBytes(rawQ);
+            var query    = vts.createByteSequence(rawQ);
+            var reranker = view.byteVectorRerankerFor(query, bvsf);
+
+            for (int i = 0; i < n; i++) {
+                float expected = bvsf.compare(query, rabvv.getVector(i));
+                float actual   = reranker.similarityTo(i);
+                assertEquals("reranker score mismatch at node " + i, expected, actual, 1e-5f);
+            }
+        }
+    }
+
+    /**
+     * All three byte-vector similarity functions produce results in [0, 1] for all nodes
+     * after a full int8 end-to-end write/search cycle.
+     */
+    @Test
+    public void testByteVectorEndToEndAllSimilarityFunctions() throws IOException {
+        int n = 40, dim = 8;
+
+        for (var bvsf : ByteVectorSimilarityFunction.values()) {
+            var vectors = randomByteVectors(n, dim);
+            var rabvv   = new ListRandomAccessByteVectorValues(vectors, dim);
+
+            var builder = GraphIndexBuilder.builder(rabvv, bvsf, 8)
+                    .withBeamWidth(20)
+                    .withNeighborOverflow(1.2f)
+                    .withAlpha(1.2f)
+                    .build();
+            var graph   = builder.build(rabvv);
+
+            var outputPath = testDirectory.resolve("byte_e2e_" + bvsf.name());
+            try (var writer = new OnDiskGraphIndexWriter.Builder(graph, outputPath)
+                    .with(new InlineByteVectors(dim))
+                    .build())
+            {
+                writer.write(Feature.singleStateFactory(FeatureId.INLINE_BYTE_VECTORS,
+                        nodeId -> new InlineByteVectors.State(rabvv.getVector(nodeId))));
+            }
+
+            try (var rs = new SimpleMappedReader.Supplier(outputPath.toAbsolutePath());
+                 var onDisk = OnDiskGraphIndex.load(rs);
+                 var view   = onDisk.getView())
+            {
+                byte[] rawQ = new byte[dim];
+                getRandom().nextBytes(rawQ);
+                var query    = vts.createByteSequence(rawQ);
+                var reranker = view.byteVectorRerankerFor(query, bvsf);
+                var ssp      = new DefaultSearchScoreProvider(reranker);
+                var result   = new GraphSearcher(onDisk).search(ssp, 5, Bits.ALL);
+
+                for (var ns : result.getNodes()) {
+                    float score = ns.score;
+                    assertTrue(bvsf + " score out of [0,1] for node " + ns.node + ": " + score,
+                            score >= 0f && score <= 1.0f);
+                }
+            }
         }
     }
 }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProviderTest.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/graph/similarity/BuildScoreProviderTest.java
@@ -16,9 +16,12 @@
 
 package io.github.jbellis.jvector.graph.similarity;
 
+import io.github.jbellis.jvector.graph.ListRandomAccessByteVectorValues;
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.vector.ByteVectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.junit.Test;
@@ -26,7 +29,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertThrows;
 
 public class BuildScoreProviderTest {
     private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
@@ -68,5 +72,99 @@ public class BuildScoreProviderTest {
         // Test diversityProviderFor uses same mapping, Graph node 0 (vector 2:[-1, 0]) vs graph node 1 (vector 0:[1, 0])
         var dsp0 = bsp.diversityProviderFor(0);
         assertEquals(vsf.compare(vectors.get(2), vectors.get(0)), dsp0.exactScoreFunction().similarityTo(1), 1e-6f);
+    }
+
+    // -----------------------------------------------------------------------
+    // byteVectorScoreProvider tests
+    // -----------------------------------------------------------------------
+
+    private ByteSequence<?> bseq(byte... values) {
+        return vts.createByteSequence(values);
+    }
+
+    /** Helper: build a small RABVV with three 2-D signed-byte vectors. */
+    private ListRandomAccessByteVectorValues byteRavv() {
+        return new ListRandomAccessByteVectorValues(
+                List.of(bseq((byte) 10, (byte) 0),    // node 0
+                        bseq((byte) 0,  (byte) 10),   // node 1
+                        bseq((byte) -10, (byte) 0)),  // node 2
+                2);
+    }
+
+    @Test
+    public void testByteVectorIsExact() {
+        var bsp = BuildScoreProvider.byteVectorScoreProvider(byteRavv(), ByteVectorSimilarityFunction.EUCLIDEAN);
+        assertTrue(bsp.isExact());
+    }
+
+    @Test
+    public void testByteVectorSearchProviderForByteSequence() {
+        var bvsf = ByteVectorSimilarityFunction.EUCLIDEAN;
+        var rabvv = byteRavv();
+        var bsp = BuildScoreProvider.byteVectorScoreProvider(rabvv, bvsf);
+
+        // searchProviderFor(ByteSequence) scores all nodes against the given query
+        ByteSequence<?> query = bseq((byte) 10, (byte) 0); // identical to node 0
+        var ssp = bsp.searchProviderFor(query);
+
+        // node 0 should be self-similar (score = 1.0 for EUCLIDEAN with zero distance)
+        assertEquals(1.0f, ssp.exactScoreFunction().similarityTo(0), 1e-5f);
+        // node 2 = [-10, 0], distance vs [10,0] = 400, not 1.0
+        assertTrue(ssp.exactScoreFunction().similarityTo(2) < 1.0f);
+    }
+
+    @Test
+    public void testByteVectorSearchProviderForNode() {
+        var bvsf = ByteVectorSimilarityFunction.DOT_PRODUCT;
+        var rabvv = byteRavv();
+        var bsp = BuildScoreProvider.byteVectorScoreProvider(rabvv, bvsf);
+
+        // searchProviderFor(int) should delegate to searchProviderFor(ByteSequence)
+        var sspByNode = bsp.searchProviderFor(0);
+        ByteSequence<?> v0 = rabvv.getVector(0);
+        var sspBySeq  = bsp.searchProviderFor(v0);
+        assertEquals(sspByNode.exactScoreFunction().similarityTo(1),
+                     sspBySeq.exactScoreFunction().similarityTo(1), 1e-6f);
+    }
+
+    @Test
+    public void testByteVectorDiversityProviderMatchesSearch() {
+        var bvsf = ByteVectorSimilarityFunction.COSINE;
+        var bsp  = BuildScoreProvider.byteVectorScoreProvider(byteRavv(), bvsf);
+
+        // diversityProviderFor delegates to searchProviderFor(int)
+        var search    = bsp.searchProviderFor(1);
+        var diversity = bsp.diversityProviderFor(1);
+        assertEquals(search.exactScoreFunction().similarityTo(0),
+                     diversity.exactScoreFunction().similarityTo(0), 1e-6f);
+    }
+
+    @Test
+    public void testByteVectorDiversityScoreFunction() {
+        var bvsf  = ByteVectorSimilarityFunction.EUCLIDEAN;
+        var rabvv = byteRavv();
+        var bsp   = BuildScoreProvider.byteVectorScoreProvider(rabvv, bvsf);
+
+        // diversityScoreFunctionFor(n1).similarityTo(n2) == bvsf.compare(v_n1, v_n2)
+        var dsf = bsp.diversityScoreFunctionFor(0);
+        assertEquals(bvsf.compare(rabvv.getVector(0), rabvv.getVector(2)),
+                     dsf.similarityTo(2), 1e-6f);
+    }
+
+    @Test
+    public void testByteVectorApproximateCentroid() {
+        // centroid of [10,0], [0,10], [-10,0] should be [0, 10/3]
+        var bsp      = BuildScoreProvider.byteVectorScoreProvider(byteRavv(), ByteVectorSimilarityFunction.EUCLIDEAN);
+        var centroid = bsp.approximateCentroid();
+        assertEquals(2, centroid.length());
+        assertEquals(0.0f, centroid.get(0), 1e-5f);
+        assertEquals(10.0f / 3.0f, centroid.get(1), 1e-5f);
+    }
+
+    @Test
+    public void testByteVectorThrowsForFloatQuery() {
+        var bsp = BuildScoreProvider.byteVectorScoreProvider(byteRavv(), ByteVectorSimilarityFunction.EUCLIDEAN);
+        VectorFloat<?> floatQuery = vts.createFloatVector(new float[]{1.0f, 0.0f});
+        assertThrows(UnsupportedOperationException.class, () -> bsp.searchProviderFor(floatQuery));
     }
 }

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestByteVectorSimilarityFunction.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestByteVectorSimilarityFunction.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.vector;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TestByteVectorSimilarityFunction extends RandomizedTest {
+
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private ByteSequence<?> seq(byte... values) {
+        return vts.createByteSequence(values);
+    }
+
+    // -----------------------------------------------------------------------
+    // EUCLIDEAN
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testEuclideanKnownValue() {
+        // v1=[1,0], v2=[0,1]  squared-L2 = 1+1 = 2
+        // maxSquaredDist = 2 * 255^2 = 130050
+        // expected = 1 / (1 + 2/130050)
+        var v1 = seq((byte) 1, (byte) 0);
+        var v2 = seq((byte) 0, (byte) 1);
+        float squaredL2 = 2.0f;
+        float max = 2 * 255.0f * 255.0f;
+        float expected = 1.0f / (1.0f + squaredL2 / max);
+        assertEquals(expected, ByteVectorSimilarityFunction.EUCLIDEAN.compare(v1, v2), 1e-6f);
+    }
+
+    @Test
+    public void testEuclideanIdenticalVectors() {
+        var v = seq((byte) 42, (byte) -7, (byte) 100);
+        // squaredL2 = 0, so score = 1/(1+0) = 1.0
+        assertEquals(1.0f, ByteVectorSimilarityFunction.EUCLIDEAN.compare(v, v), 1e-6f);
+    }
+
+    @Test
+    public void testEuclideanResultInRange() {
+        for (int trial = 0; trial < 50; trial++) {
+            byte[] raw1 = new byte[32];
+            byte[] raw2 = new byte[32];
+            getRandom().nextBytes(raw1);
+            getRandom().nextBytes(raw2);
+            float score = ByteVectorSimilarityFunction.EUCLIDEAN.compare(seq(raw1), seq(raw2));
+            assertTrue("EUCLIDEAN score out of (0,1]: " + score, score > 0f && score <= 1.0f);
+        }
+    }
+
+    @Test
+    public void testEuclideanSymmetry() {
+        byte[] raw1 = new byte[16];
+        byte[] raw2 = new byte[16];
+        getRandom().nextBytes(raw1);
+        getRandom().nextBytes(raw2);
+        assertEquals(
+                ByteVectorSimilarityFunction.EUCLIDEAN.compare(seq(raw1), seq(raw2)),
+                ByteVectorSimilarityFunction.EUCLIDEAN.compare(seq(raw2), seq(raw1)),
+                1e-6f);
+    }
+
+    // -----------------------------------------------------------------------
+    // DOT_PRODUCT
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testDotProductKnownValue() {
+        // v1=[1,0], v2=[0,1]  dot = 0
+        // maxMag = 2 * 127^2 = 32258
+        // expected = (1 + 0/32258) / 2 = 0.5
+        var v1 = seq((byte) 1, (byte) 0);
+        var v2 = seq((byte) 0, (byte) 1);
+        assertEquals(0.5f, ByteVectorSimilarityFunction.DOT_PRODUCT.compare(v1, v2), 1e-6f);
+    }
+
+    @Test
+    public void testDotProductResultInRange() {
+        for (int trial = 0; trial < 50; trial++) {
+            byte[] raw1 = new byte[32];
+            byte[] raw2 = new byte[32];
+            getRandom().nextBytes(raw1);
+            getRandom().nextBytes(raw2);
+            float score = ByteVectorSimilarityFunction.DOT_PRODUCT.compare(seq(raw1), seq(raw2));
+            assertTrue("DOT_PRODUCT score out of [0,1]: " + score, score >= 0f && score <= 1.0f);
+        }
+    }
+
+    @Test
+    public void testDotProductSymmetry() {
+        byte[] raw1 = new byte[16];
+        byte[] raw2 = new byte[16];
+        getRandom().nextBytes(raw1);
+        getRandom().nextBytes(raw2);
+        assertEquals(
+                ByteVectorSimilarityFunction.DOT_PRODUCT.compare(seq(raw1), seq(raw2)),
+                ByteVectorSimilarityFunction.DOT_PRODUCT.compare(seq(raw2), seq(raw1)),
+                1e-6f);
+    }
+
+    // -----------------------------------------------------------------------
+    // COSINE
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCosineParallelVectors() {
+        // v1 == v2 → cosine = 1.0, score = (1+1)/2 = 1.0
+        var v = seq((byte) 3, (byte) 4);
+        assertEquals(1.0f, ByteVectorSimilarityFunction.COSINE.compare(v, v), 1e-5f);
+    }
+
+    @Test
+    public void testCosineOrthogonalVectors() {
+        // [1,0] · [0,1] = 0, cosine = 0, score = (1+0)/2 = 0.5
+        var v1 = seq((byte) 1, (byte) 0);
+        var v2 = seq((byte) 0, (byte) 1);
+        assertEquals(0.5f, ByteVectorSimilarityFunction.COSINE.compare(v1, v2), 1e-5f);
+    }
+
+    @Test
+    public void testCosineResultInRange() {
+        for (int trial = 0; trial < 50; trial++) {
+            byte[] raw1 = new byte[32];
+            byte[] raw2 = new byte[32];
+            getRandom().nextBytes(raw1);
+            getRandom().nextBytes(raw2);
+            float score = ByteVectorSimilarityFunction.COSINE.compare(seq(raw1), seq(raw2));
+            assertTrue("COSINE score out of [0,1]: " + score, score >= 0f && score <= 1.0f);
+        }
+    }
+
+    @Test
+    public void testCosineSymmetry() {
+        byte[] raw1 = new byte[16];
+        byte[] raw2 = new byte[16];
+        getRandom().nextBytes(raw1);
+        getRandom().nextBytes(raw2);
+        assertEquals(
+                ByteVectorSimilarityFunction.COSINE.compare(seq(raw1), seq(raw2)),
+                ByteVectorSimilarityFunction.COSINE.compare(seq(raw2), seq(raw1)),
+                1e-5f);
+    }
+
+    // -----------------------------------------------------------------------
+    // Boundary values
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testAllMaxValues() {
+        // All 127 vectors — EUCLIDEAN identity = 1, DOT_PRODUCT = 1, COSINE = 1
+        byte[] raw = new byte[8];
+        java.util.Arrays.fill(raw, (byte) 127);
+        var v = seq(raw);
+        assertEquals(1.0f, ByteVectorSimilarityFunction.EUCLIDEAN.compare(v, v), 1e-5f);
+        assertEquals(1.0f, ByteVectorSimilarityFunction.DOT_PRODUCT.compare(v, v), 1e-5f);
+        assertEquals(1.0f, ByteVectorSimilarityFunction.COSINE.compare(v, v), 1e-5f);
+    }
+}

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestVectorizationProvider.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestVectorizationProvider.java
@@ -19,6 +19,7 @@ package io.github.jbellis.jvector.vector;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 import io.github.jbellis.jvector.TestUtil;
+import io.github.jbellis.jvector.vector.types.ByteSequence;
 import io.github.jbellis.jvector.vector.types.FloatArray;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
@@ -58,6 +59,39 @@ public class TestVectorizationProvider extends RandomizedTest {
         Assert.assertEquals(a.getVectorUtilSupport().dotProduct(v1a,v2a), b.getVectorUtilSupport().dotProduct(v1b, v2b), 0.0001f);
         Assert.assertEquals(a.getVectorUtilSupport().cosine(v1a,v2a), b.getVectorUtilSupport().cosine(v1b, v2b), 0.0001f);
         Assert.assertEquals(a.getVectorUtilSupport().squareDistance(v1a, v2a), b.getVectorUtilSupport().squareDistance(v1b, v2b), 0.0001f);
+    }
+
+    @Test
+    public void testSimilarityMetricsByte() {
+        Assume.assumeTrue(hasSimd);
+
+        VectorizationProvider a = new DefaultVectorizationProvider();
+        VectorizationProvider b = VectorizationProvider.getInstance();
+
+        // Use a prime-length vector that is not a multiple of 8 or 16
+        int dim = 107;
+        byte[] rawA = new byte[dim];
+        byte[] rawB = new byte[dim];
+        getRandom().nextBytes(rawA);
+        getRandom().nextBytes(rawB);
+
+        ByteSequence<?> bsA_scalar = a.getVectorTypeSupport().createByteSequence(rawA);
+        ByteSequence<?> bsB_scalar = a.getVectorTypeSupport().createByteSequence(rawB);
+        ByteSequence<?> bsA_simd   = b.getVectorTypeSupport().createByteSequence(rawA);
+        ByteSequence<?> bsB_simd   = b.getVectorTypeSupport().createByteSequence(rawB);
+
+        Assert.assertEquals(
+                a.getVectorUtilSupport().dotProduct(bsA_scalar, bsB_scalar),
+                b.getVectorUtilSupport().dotProduct(bsA_simd, bsB_simd),
+                0.0001f);
+        Assert.assertEquals(
+                a.getVectorUtilSupport().squareDistance(bsA_scalar, bsB_scalar),
+                b.getVectorUtilSupport().squareDistance(bsA_simd, bsB_simd),
+                0.0001f);
+        Assert.assertEquals(
+                a.getVectorUtilSupport().cosine(bsA_scalar, bsB_scalar),
+                b.getVectorUtilSupport().cosine(bsA_simd, bsB_simd),
+                0.0001f);
     }
 
     @Test

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestVectorizationProvider.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/vector/TestVectorizationProvider.java
@@ -94,6 +94,88 @@ public class TestVectorizationProvider extends RandomizedTest {
                 0.0001f);
     }
 
+    /**
+     * Verifies that the SIMD byte-vector kernels agree with the scalar baseline for
+     * several dimensions that stress boundary conditions in the vectorised loops:
+     * <ul>
+     *   <li>dim=1       — the absolute minimum case</li>
+     *   <li>dim=8       — exact multiple of the smallest SIMD lane width</li>
+     *   <li>dim=128     — exact multiple of larger lane widths</li>
+     *   <li>dim=256     — exact multiple of AVX2/AVX512 lane widths</li>
+     *   <li>dim=255     — one less than 256, exposes tail-loop handling</li>
+     * </ul>
+     */
+    @Test
+    public void testSimilarityMetricsByteEdgeDimensions() {
+        Assume.assumeTrue(hasSimd);
+
+        VectorizationProvider scalar = new DefaultVectorizationProvider();
+        VectorizationProvider simd   = VectorizationProvider.getInstance();
+
+        for (int dim : new int[]{1, 8, 128, 255, 256}) {
+            byte[] rawA = new byte[dim];
+            byte[] rawB = new byte[dim];
+            getRandom().nextBytes(rawA);
+            getRandom().nextBytes(rawB);
+
+            ByteSequence<?> sA = scalar.getVectorTypeSupport().createByteSequence(rawA);
+            ByteSequence<?> sB = scalar.getVectorTypeSupport().createByteSequence(rawB);
+            ByteSequence<?> vA = simd.getVectorTypeSupport().createByteSequence(rawA);
+            ByteSequence<?> vB = simd.getVectorTypeSupport().createByteSequence(rawB);
+
+            Assert.assertEquals("dotProduct dim=" + dim,
+                    scalar.getVectorUtilSupport().dotProduct(sA, sB),
+                    simd.getVectorUtilSupport().dotProduct(vA, vB),
+                    0.0001f);
+            Assert.assertEquals("squareDistance dim=" + dim,
+                    scalar.getVectorUtilSupport().squareDistance(sA, sB),
+                    simd.getVectorUtilSupport().squareDistance(vA, vB),
+                    0.0001f);
+            Assert.assertEquals("cosine dim=" + dim,
+                    scalar.getVectorUtilSupport().cosine(sA, sB),
+                    simd.getVectorUtilSupport().cosine(vA, vB),
+                    0.0001f);
+        }
+    }
+
+    /**
+     * SIMD kernels must treat bytes as signed. This test uses vectors whose
+     * correct result depends on negative byte values to catch sign-extension bugs.
+     */
+    @Test
+    public void testSimilarityMetricsByteSignHandling() {
+        Assume.assumeTrue(hasSimd);
+
+        VectorizationProvider scalar = new DefaultVectorizationProvider();
+        VectorizationProvider simd   = VectorizationProvider.getInstance();
+
+        // mix of extreme signed values: max positive 127, min negative -128
+        byte[] rawA = new byte[16];
+        byte[] rawB = new byte[16];
+        for (int i = 0; i < 16; i++) {
+            rawA[i] = (i % 2 == 0) ? (byte)  127 : (byte) -128;
+            rawB[i] = (i % 2 == 0) ? (byte) -128 : (byte)  127;
+        }
+
+        ByteSequence<?> sA = scalar.getVectorTypeSupport().createByteSequence(rawA);
+        ByteSequence<?> sB = scalar.getVectorTypeSupport().createByteSequence(rawB);
+        ByteSequence<?> vA = simd.getVectorTypeSupport().createByteSequence(rawA);
+        ByteSequence<?> vB = simd.getVectorTypeSupport().createByteSequence(rawB);
+
+        Assert.assertEquals("signed dotProduct",
+                scalar.getVectorUtilSupport().dotProduct(sA, sB),
+                simd.getVectorUtilSupport().dotProduct(vA, vB),
+                0.0001f);
+        Assert.assertEquals("signed squareDistance",
+                scalar.getVectorUtilSupport().squareDistance(sA, sB),
+                simd.getVectorUtilSupport().squareDistance(vA, vB),
+                0.0001f);
+        Assert.assertEquals("signed cosine",
+                scalar.getVectorUtilSupport().cosine(sA, sB),
+                simd.getVectorUtilSupport().cosine(vA, vB),
+                0.0001f);
+    }
+
     @Test
     public void testAssembleAndSum() {
         Assume.assumeTrue(hasSimd);

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -985,6 +985,37 @@ class PanamaVectorUtilSupport implements VectorUtilSupport {
      * @return The Hamming distance
      */
     @Override
+    public float dotProduct(ByteSequence<?> a, ByteSequence<?> b) {
+        float sum = 0;
+        for (int i = 0; i < a.length(); i++) {
+            sum += (int) a.get(i) * (int) b.get(i);
+        }
+        return sum;
+    }
+
+    @Override
+    public float squareDistance(ByteSequence<?> a, ByteSequence<?> b) {
+        float sum = 0;
+        for (int i = 0; i < a.length(); i++) {
+            float diff = a.get(i) - b.get(i);
+            sum += diff * diff;
+        }
+        return sum;
+    }
+
+    @Override
+    public float cosine(ByteSequence<?> a, ByteSequence<?> b) {
+        float dot = 0, normA = 0, normB = 0;
+        for (int i = 0; i < a.length(); i++) {
+            float ai = a.get(i), bi = b.get(i);
+            dot   += ai * bi;
+            normA += ai * ai;
+            normB += bi * bi;
+        }
+        return (float) (dot / Math.sqrt(normA * normB));
+    }
+
+    @Override
     public int hammingDistance(long[] a, long[] b) {
         var sum = LongVector.zero(LongVector.SPECIES_PREFERRED);
         int vectorizedLength = LongVector.SPECIES_PREFERRED.loopBound(a.length);

--- a/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
+++ b/jvector-twenty/src/main/java/io/github/jbellis/jvector/vector/PanamaVectorUtilSupport.java
@@ -976,43 +976,266 @@ class PanamaVectorUtilSupport implements VectorUtilSupport {
         return res;
     }
 
+    // -----------------------------------------------------------------------
+    // ByteSequence similarity metrics – Panama SIMD implementations
+    //
+    // Strategy: widen signed bytes to int32 via B2I (no AND-mask needed for
+    // signed arithmetic), accumulate products in IntVector lanes, then reduce.
+    // The byte-vector species is 1/4 the width of the int species:
+    //   512-bit int (16 lanes) <- SPECIES_128 bytes
+    //   256-bit int  (8 lanes) <- SPECIES_64  bytes
+    //   128-bit preferred      <- scalar (ByteVector.SPECIES_32 does not exist;
+    //                             128-bit SIMD shows no benefit for this workload)
+    // -----------------------------------------------------------------------
+
     /**
-     * Vectorized calculation of Hamming distance for two arrays of long integers.
-     * Both arrays should have the same length.
-     *
-     * @param a The first array
-     * @param b The second array
-     * @return The Hamming distance
+     * Vectorized dot product of two signed int8 byte vectors.
      */
     @Override
     public float dotProduct(ByteSequence<?> a, ByteSequence<?> b) {
-        float sum = 0;
-        for (int i = 0; i < a.length(); i++) {
-            sum += (int) a.get(i) * (int) b.get(i);
-        }
-        return sum;
+        return switch (PREFERRED_BIT_SIZE) {
+            case 512 -> dotProductBytes512(a, b);
+            case 256 -> dotProductBytes256(a, b);
+            default  -> dotProductBytes128(a, b);
+        };
     }
 
+    float dotProductBytes512(ByteSequence<?> a, ByteSequence<?> b) {
+        final int length = a.length();
+        final int aOff   = a.offset();
+        final int bOff   = b.offset();
+        final int step   = ByteVector.SPECIES_128.length(); // 16
+        final int limit  = ByteVector.SPECIES_128.loopBound(length);
+        IntVector acc    = IntVector.zero(IntVector.SPECIES_512);
+
+        for (int i = 0; i < limit; i += step) {
+            IntVector va = fromByteSequence(ByteVector.SPECIES_128, a, aOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
+                    .reinterpretAsInts();
+            IntVector vb = fromByteSequence(ByteVector.SPECIES_128, b, bOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
+                    .reinterpretAsInts();
+            acc = acc.add(va.mul(vb));
+        }
+
+        int result = acc.reduceLanes(VectorOperators.ADD);
+        for (int i = limit; i < length; i++) {
+            result += a.get(aOff + i) * b.get(bOff + i);
+        }
+        return result;
+    }
+
+    float dotProductBytes256(ByteSequence<?> a, ByteSequence<?> b) {
+        final int length = a.length();
+        final int aOff   = a.offset();
+        final int bOff   = b.offset();
+        final int step   = ByteVector.SPECIES_64.length(); // 8
+        final int limit  = ByteVector.SPECIES_64.loopBound(length);
+        IntVector acc    = IntVector.zero(IntVector.SPECIES_256);
+
+        for (int i = 0; i < limit; i += step) {
+            IntVector va = fromByteSequence(ByteVector.SPECIES_64, a, aOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
+                    .reinterpretAsInts();
+            IntVector vb = fromByteSequence(ByteVector.SPECIES_64, b, bOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
+                    .reinterpretAsInts();
+            acc = acc.add(va.mul(vb));
+        }
+
+        int result = acc.reduceLanes(VectorOperators.ADD);
+        for (int i = limit; i < length; i++) {
+            result += a.get(aOff + i) * b.get(bOff + i);
+        }
+        return result;
+    }
+
+    float dotProductBytes128(ByteSequence<?> a, ByteSequence<?> b) {
+        // ByteVector.SPECIES_32 does not exist; scalar is fastest at 128-bit width
+        final int length = a.length();
+        final int aOff   = a.offset();
+        final int bOff   = b.offset();
+        int result = 0;
+        for (int i = 0; i < length; i++) {
+            result += a.get(aOff + i) * b.get(bOff + i);
+        }
+        return result;
+    }
+
+    /**
+     * Vectorized sum of squared differences between two signed int8 byte vectors.
+     */
     @Override
     public float squareDistance(ByteSequence<?> a, ByteSequence<?> b) {
-        float sum = 0;
-        for (int i = 0; i < a.length(); i++) {
-            float diff = a.get(i) - b.get(i);
-            sum += diff * diff;
-        }
-        return sum;
+        return switch (PREFERRED_BIT_SIZE) {
+            case 512 -> squareDistanceBytes512(a, b);
+            case 256 -> squareDistanceBytes256(a, b);
+            default  -> squareDistanceBytes128(a, b);
+        };
     }
 
+    float squareDistanceBytes512(ByteSequence<?> a, ByteSequence<?> b) {
+        final int length = a.length();
+        final int aOff   = a.offset();
+        final int bOff   = b.offset();
+        final int step   = ByteVector.SPECIES_128.length();
+        final int limit  = ByteVector.SPECIES_128.loopBound(length);
+        IntVector acc    = IntVector.zero(IntVector.SPECIES_512);
+
+        for (int i = 0; i < limit; i += step) {
+            IntVector va   = fromByteSequence(ByteVector.SPECIES_128, a, aOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
+                    .reinterpretAsInts();
+            IntVector vb   = fromByteSequence(ByteVector.SPECIES_128, b, bOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
+                    .reinterpretAsInts();
+            IntVector diff = va.sub(vb);
+            acc = acc.add(diff.mul(diff));
+        }
+
+        int result = acc.reduceLanes(VectorOperators.ADD);
+        for (int i = limit; i < length; i++) {
+            int diff = a.get(aOff + i) - b.get(bOff + i);
+            result += diff * diff;
+        }
+        return result;
+    }
+
+    float squareDistanceBytes256(ByteSequence<?> a, ByteSequence<?> b) {
+        final int length = a.length();
+        final int aOff   = a.offset();
+        final int bOff   = b.offset();
+        final int step   = ByteVector.SPECIES_64.length();
+        final int limit  = ByteVector.SPECIES_64.loopBound(length);
+        IntVector acc    = IntVector.zero(IntVector.SPECIES_256);
+
+        for (int i = 0; i < limit; i += step) {
+            IntVector va   = fromByteSequence(ByteVector.SPECIES_64, a, aOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
+                    .reinterpretAsInts();
+            IntVector vb   = fromByteSequence(ByteVector.SPECIES_64, b, bOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
+                    .reinterpretAsInts();
+            IntVector diff = va.sub(vb);
+            acc = acc.add(diff.mul(diff));
+        }
+
+        int result = acc.reduceLanes(VectorOperators.ADD);
+        for (int i = limit; i < length; i++) {
+            int diff = a.get(aOff + i) - b.get(bOff + i);
+            result += diff * diff;
+        }
+        return result;
+    }
+
+    float squareDistanceBytes128(ByteSequence<?> a, ByteSequence<?> b) {
+        // ByteVector.SPECIES_32 does not exist; scalar is fastest at 128-bit width
+        final int length = a.length();
+        final int aOff   = a.offset();
+        final int bOff   = b.offset();
+        int result = 0;
+        for (int i = 0; i < length; i++) {
+            int diff = a.get(aOff + i) - b.get(bOff + i);
+            result += diff * diff;
+        }
+        return result;
+    }
+
+    /**
+     * Vectorized cosine similarity between two signed int8 byte vectors.
+     */
     @Override
     public float cosine(ByteSequence<?> a, ByteSequence<?> b) {
-        float dot = 0, normA = 0, normB = 0;
-        for (int i = 0; i < a.length(); i++) {
-            float ai = a.get(i), bi = b.get(i);
-            dot   += ai * bi;
-            normA += ai * ai;
-            normB += bi * bi;
+        return switch (PREFERRED_BIT_SIZE) {
+            case 512 -> cosineBytes512(a, b);
+            case 256 -> cosineBytes256(a, b);
+            default  -> cosineBytes128(a, b);
+        };
+    }
+
+    float cosineBytes512(ByteSequence<?> a, ByteSequence<?> b) {
+        final int length = a.length();
+        final int aOff   = a.offset();
+        final int bOff   = b.offset();
+        final int step   = ByteVector.SPECIES_128.length();
+        final int limit  = ByteVector.SPECIES_128.loopBound(length);
+        IntVector dot    = IntVector.zero(IntVector.SPECIES_512);
+        IntVector normA  = IntVector.zero(IntVector.SPECIES_512);
+        IntVector normB  = IntVector.zero(IntVector.SPECIES_512);
+
+        for (int i = 0; i < limit; i += step) {
+            IntVector va = fromByteSequence(ByteVector.SPECIES_128, a, aOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
+                    .reinterpretAsInts();
+            IntVector vb = fromByteSequence(ByteVector.SPECIES_128, b, bOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0)
+                    .reinterpretAsInts();
+            dot   = dot.add(va.mul(vb));
+            normA = normA.add(va.mul(va));
+            normB = normB.add(vb.mul(vb));
         }
-        return (float) (dot / Math.sqrt(normA * normB));
+
+        long dotResult   = dot.reduceLanes(VectorOperators.ADD);
+        long normAResult = normA.reduceLanes(VectorOperators.ADD);
+        long normBResult = normB.reduceLanes(VectorOperators.ADD);
+
+        for (int i = limit; i < length; i++) {
+            int ai = a.get(aOff + i), bi = b.get(bOff + i);
+            dotResult   += ai * bi;
+            normAResult += ai * ai;
+            normBResult += bi * bi;
+        }
+        return (float) (dotResult / Math.sqrt((double) normAResult * normBResult));
+    }
+
+    float cosineBytes256(ByteSequence<?> a, ByteSequence<?> b) {
+        final int length = a.length();
+        final int aOff   = a.offset();
+        final int bOff   = b.offset();
+        final int step   = ByteVector.SPECIES_64.length();
+        final int limit  = ByteVector.SPECIES_64.loopBound(length);
+        IntVector dot    = IntVector.zero(IntVector.SPECIES_256);
+        IntVector normA  = IntVector.zero(IntVector.SPECIES_256);
+        IntVector normB  = IntVector.zero(IntVector.SPECIES_256);
+
+        for (int i = 0; i < limit; i += step) {
+            IntVector va = fromByteSequence(ByteVector.SPECIES_64, a, aOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
+                    .reinterpretAsInts();
+            IntVector vb = fromByteSequence(ByteVector.SPECIES_64, b, bOff + i)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0)
+                    .reinterpretAsInts();
+            dot   = dot.add(va.mul(vb));
+            normA = normA.add(va.mul(va));
+            normB = normB.add(vb.mul(vb));
+        }
+
+        long dotResult   = dot.reduceLanes(VectorOperators.ADD);
+        long normAResult = normA.reduceLanes(VectorOperators.ADD);
+        long normBResult = normB.reduceLanes(VectorOperators.ADD);
+
+        for (int i = limit; i < length; i++) {
+            int ai = a.get(aOff + i), bi = b.get(bOff + i);
+            dotResult   += ai * bi;
+            normAResult += ai * ai;
+            normBResult += bi * bi;
+        }
+        return (float) (dotResult / Math.sqrt((double) normAResult * normBResult));
+    }
+
+    float cosineBytes128(ByteSequence<?> a, ByteSequence<?> b) {
+        // ByteVector.SPECIES_32 does not exist; scalar is fastest at 128-bit width
+        final int length = a.length();
+        final int aOff   = a.offset();
+        final int bOff   = b.offset();
+        long dotResult = 0, normAResult = 0, normBResult = 0;
+        for (int i = 0; i < length; i++) {
+            int ai = a.get(aOff + i), bi = b.get(bOff + i);
+            dotResult   += ai * bi;
+            normAResult += ai * ai;
+            normBResult += bi * bi;
+        }
+        return (float) (dotResult / Math.sqrt((double) normAResult * normBResult));
     }
 
     @Override


### PR DESCRIPTION
## INT8 (Byte-Vector) Support for JVector

### Overview
This branch adds full **INT8 (byte-vector) support** to JVector — from the math primitives all the way through graph building, on-disk storage, SIMD acceleration, and end-to-end tests.

---

### Commits

#### 1. fd131a7 — Add random-access int8 vector value support
Introduces a new `VectorValues` super-interface that captures shared random-access behavior, then refactors `RandomAccessVectorValues` (float) to extend it, and adds `RandomAccessByteVectorValues` and its list-backed implementation `ListRandomAccessByteVectorValues` as the byte-vector counterpart. Also updates `BuildScoreProvider` to use the generalized thread-local supplier.

#### 2. c55574c — Add byte-similarity methods to VectorUtilSupport / VectorUtil / DefaultVectorUtilSupport
Adds `dotProduct`, `squaredL2`, and `cosine` for `byte[]` / `ByteSequence` to the vector utility stack.

#### 3. 9ba737a — Add ByteVectorSimilarityFunction enum
Mirrors the float `VectorSimilarityFunction` enum; wraps the three byte similarity metrics with a `compare()` API and score normalization.

#### 4. 5652b46 — Add BuildScoreProvider.byteVectorScoreProvider and searchProviderFor(ByteSequence)
Adds `byteVectorScoreProvider()` factory and `searchProviderFor(ByteSequence)` so the graph builder can score byte-vector candidates.

#### 5. 389c391 — Wire byteVectorScoreProvider into GraphIndexBuilder
`GraphIndexBuilder` now accepts `RandomAccessByteVectorValues` and routes to the byte score provider, enabling full graph construction over int8 data.

#### 6. c6dfea0 — Vectorize ByteSequence similarity metrics with SIMD
Panama SIMD and AVX-512 native kernels for int8 dot-product, L2, and cosine; adds native benchmarks and C++ unit tests.

#### 7. 3d4dada — Add InlineByteVectors feature for native int8 on-disk storage
New `FeatureId` and `InlineByteVectors` class for serializing byte vectors into the graph index file format, plus `OnDiskGraphIndex` reader support.

#### 8. 974f508 — Add INT8 end-to-end tutorial (Int8Example)
End-to-end walkthrough showing how to build, serialize, and query a byte-vector graph index; registered in `TutorialRunner`.

#### 9. b0ad5cd — Add int8 test coverage for byte-vector similarity, RABVV, BSP, SIMD, graph build, and disk round-trip
Unit tests for `ByteVectorSimilarityFunction`, `BuildScoreProvider`, `TestVectorizationProvider` (SIMD), `TestVectorGraph` (build), `TestOnDiskGraphIndex` (round-trip), and `ListRandomAccessByteVectorValues`.
