### PR TITLE
disk: host-owned streaming output contract

### DIFF
--- a/docs/embedded-io-contract.md
+++ b/docs/embedded-io-contract.md
@@ -1,0 +1,350 @@
+# Embedded IO contract (draft)
+
+> **Status:** draft for review. Implemented in `jvector-base` (package
+> `io.github.jbellis.jvector.disk`) with tests in `jvector-tests`; the consumer changes in
+> section 6 are not. Motivated by [#722](https://github.com/datastax/jvector/issues/722) and the
+> review threads on [#710](https://github.com/datastax/jvector/pull/710). Every claim about
+> current behaviour is cross-referenced as `path:line` against `origin/main` @ `098d131c`.
+
+## 1. Problem
+
+jvector is embedded by systems that own their storage: Cassandra SAI and CNDB (a graph is one
+region of a component file, wrapped in an SAI header and footer), OpenSearch via Lucene (a graph
+is a codec file whose `IndexOutput` is sequential, append-only, with an incremental checksum),
+and standalone users (a graph is a file). Today the compactor and the parallel writer only know
+how to talk to a `Path`, and even the random-access writer assumes it owns a whole file. The
+result, as described on #722, is that hosts copy and re-copy jvector's bytes to fit them into
+their own containers, or cannot use the compactor at all.
+
+The contract below lets a host say **where** jvector's bytes go and **when** they become real,
+without any host resource type (`Path`, `File`, `FileChannel`, `IndexOutput`) appearing in the
+embedded view, and without slowing down the plain-file case.
+
+### 1.1 Scope
+
+**In:** a host-owned location, possibly interior to a host file; strictly sequential
+(append-only) writes; more than one artifact per operation; a per-artifact completion point
+and a per-operation commit-or-abort boundary.
+
+**Out, deliberately:** positional writes, read-back of the output while it is being written,
+and scratch space. Section 6 shows why none of them is needed: nothing in the format or in the
+compactor's algorithm requires out-of-order writes; the only in-place rewrite is the optional
+post-compaction refinement, which is off by default. Should a host ever want to offer
+positional access as an optimization, it can be added later as an optional capability without
+changing the shapes here.
+
+## 2. Concerns catalog
+
+Everything raised on #722, on the #710 threads, and by the code, with where it lands.
+
+| # | Concern | Evidence | Raised by | Lands in |
+|---|---|---|---|---|
+| C1 | Output location must be host-owned, possibly a region inside a host file | `CompactWriter` opens its own file: `graph/disk/CompactWriter.java:96` | #722; #710 | `IndexDestination`, `OutputReservation.stream()` with region-relative positions |
+| C2 | No `Path`/`File`/channel type may leak into the embedded view | `OutputReservation.file()` on #710 | reta on #722 | no host type on any vended interface; `Path` only in the file-backed static factories |
+| C3 | Lucene `IndexOutput` is sequential-only with an incremental CRC; random writes were declined upstream ([lucene#15420](https://github.com/apache/lucene/issues/15420)) | the OpenSearch plugin adapts `IndexOutput` as a plain `IndexWriter` (`JVectorIndexWriter`) | reta on #722 | the contract is sequential by construction |
+| C4 | The compactor writes level-0 records positionally from a second handle on the same file | `graph/disk/OnDiskGraphIndexCompactor.java:908-931` | code | section 6: in-order emission with a reorder buffer |
+| C5 | The compactor reads its own output back during refinement and rewrites records in place | `OnDiskGraphIndexCompactor.java:497-503`, `:728-731` | code | section 6: refinement as a second pass, or off (its default) |
+| C6 | The fused-PQ pre-encode cache is mapped past the projected EOF of the output file and truncated away | `graph/disk/FusedCompactionStrategy.java:208-216`, `:190` | code | out of scope: a placement question for adoption |
+| C7 | One operation can produce several artifacts (graph plus compressed-vectors sidecar) placed differently by each host | `compact(Path, Path)` at `OnDiskGraphIndexCompactor.java:333`; `graph/disk/SidecarCompactionStrategy.java:98` | code; host code | `OutputArtifact`, one reservation per artifact, session-level commit |
+| C8 | Transactional boundary: commit at most once, close exactly once, close-without-commit aborts and discards partial output | #710 `Target` thread | jshook | the state machines in 3.3 |
+| C9 | Configuration (where) stays separate from the operation (one live, single-use handle) | same thread | ashkrisk asked; jshook answered | `IndexDestination` (config) vs `OutputSession` / `OutputReservation` (operation) |
+| C10 | The offsets a graph stores are relative to the writer's coordinate origin; a reader must use the same origin | `graph/disk/OnDiskGraphIndex.java:305` (footer search relative to `length()`); `AbstractGraphIndexWriter.writeFooter` stores `out.position()` | #710 memory-safety commit | 3.4: positions start at `0` at the region start; hosts read back from the same origin |
+| C11 | Durability and checksums are host policy | Cassandra re-reads the range for its footer CRC (`graph/disk/RandomAccessOnDiskGraphIndexWriter.java:210-212`); Lucene computes its CRC incrementally | host code | `complete()` is where the host finalizes; jvector never forces or checksums the host's stream |
+| C12 | Long operations must report progress, accept throttling in bytes, and honour cancellation | `util/work/ProgressTracker.java`, `util/work/WorkLimiter.java` on #710 | #710 | 3.5: existing seams, applied to output IO; abort on interrupt |
+| C13 | No work may escape to pools the host does not own | `graph/ParallelExecutor.java` on #710 | #710 threads | unchanged: execution seams carry that; this contract carries IO only |
+| C14 | The plain-file path must stay as fast as today | requirement | this task | 3.6 |
+| C15 | The build-path writers need the same seam; the parallel writer hard-requires a `Path` | `graph/disk/OnDiskGraphIndexWriter.java:172`; `OnDiskParallelGraphIndexWriter.java:123-126` | code; Cassandra | `OnDiskSequentialGraphIndexWriter.Builder(graph, reservation.stream())` works today |
+
+## 3. Contract
+
+### 3.1 Shape
+
+```
+IndexDestination            stateless "where", built once by the host, held
+   open() ----------------> OutputSession                 one write operation; the transactional unit
+                              reserve(GRAPH) ----------> OutputReservation   one artifact's output
+                                                             stream()      IndexWriter, append-only
+                                                             complete() / close()
+                              reserve(COMPRESSED_VECTORS) -> OutputReservation
+                              commit() / close()
+```
+
+Two levels of "done" mirror what every host already has: each artifact is **completed** (Lucene
+writes its file footer here, SAI writes its component footer here), and the session is
+**committed** once as a set (Lucene's segment commit, SAI's component completion, the standalone
+rename into place). Close without commit is an abort at either level, so try-with-resources is
+the whole error-handling story.
+
+The only IO type jvector sees is the existing `IndexWriter`: a `DataOutput` with `position()`.
+The contract adds lifecycle around it, not a new IO primitive.
+
+### 3.2 Interfaces
+
+All in `io.github.jbellis.jvector.disk`, `@Experimental`, JDK 11. Shown here without javadoc;
+the sources carry the full contract.
+
+```java
+@FunctionalInterface
+public interface IndexDestination {
+    OutputSession open() throws IOException;
+
+    static IndexDestination toFile(Path path);                         // standalone: temp file + rename on commit
+    static IndexDestination toFiles(Map<OutputArtifact, Path> paths);  // one standalone file per artifact
+    static IndexDestination inFile(Path path, long offset);            // a region inside a caller-owned file
+}
+
+public interface OutputSession extends AutoCloseable {
+    OutputReservation reserve(OutputArtifact artifact) throws IOException;  // at most once per artifact
+    void commit() throws IOException;    // all reservations completed and closed; at most once
+    @Override void close() throws IOException;   // idempotent; no commit => abort, partial output discarded
+}
+
+public interface OutputReservation extends AutoCloseable {
+    OutputArtifact artifact();
+    IndexWriter stream() throws IOException;   // append-only; same instance each call; position() starts at 0
+    void complete() throws IOException;        // flushes the stream; host finalizes (footer, checksum, durability)
+    @Override void close() throws IOException; // idempotent; no complete => artifact discarded
+}
+
+public enum OutputArtifact { GRAPH, COMPRESSED_VECTORS }
+```
+
+### 3.3 Lifecycle state machines
+
+`OutputSession`
+
+| From | Call | To | Notes |
+|---|---|---|---|
+| OPEN | `reserve(a)` | OPEN | at most once per artifact; `IllegalArgumentException` if the destination has no placement for `a` |
+| OPEN | `commit()` ok | COMMITTED | requires every reservation completed and closed |
+| OPEN | `commit()` throws | ABORTED | partial artifacts discarded on `close()` |
+| OPEN | `close()` | ABORTED | discard everything |
+| COMMITTED | `close()` | CLOSED | release handles only |
+| ABORTED / CLOSED | `close()` | same | idempotent |
+| any non-open state | anything else | `IllegalStateException` | |
+
+`OutputReservation`
+
+| From | Call | To | Notes |
+|---|---|---|---|
+| OPEN | `stream()` | OPEN | returns the same instance every time |
+| OPEN | `complete()` ok | COMPLETED | flushes the stream; host finalizes |
+| OPEN | `complete()` throws | OPEN (not completed) | session cannot commit |
+| OPEN | `close()` | DISCARDED | session cannot commit |
+| COMPLETED | `close()` | CLOSED | release the stream |
+| DISCARDED / CLOSED | `close()` | same | idempotent |
+| COMPLETED / DISCARDED / CLOSED | `stream`, `complete` | `IllegalStateException` | |
+
+### 3.4 Coordinates, threading, failure
+
+- **Positions start at 0 at the region start, and the format stores offsets in those
+  coordinates.** The footer's header offset and any separated-feature offsets are relative to
+  the first byte jvector wrote. A host therefore reads the artifact back with a reader whose
+  origin is the same place: a slice or window starting at the region, or, for a whole-container
+  reader, `OnDiskGraphIndex.load(supplier, regionStart, false)`, which reads the header at the
+  region start instead of trusting the container's end. Graphs written today with
+  `withStartOffset(base)` over an absolute writer store absolute offsets and keep their
+  absolute-origin reader; the origin is a property of the written artifact, so a host that
+  migrates changes its writer and its reader together.
+- The stream is single-threaded. jvector may compute in parallel but writes through one thread.
+- Lifecycle calls (`complete`, `commit`, `close`) happen on the owning thread after every worker
+  has finished. jvector drains its executors before completing, so a host never has to defend
+  `close()` against in-flight writes.
+- Any `IOException` or `InterruptedException` propagates unchanged; the try-with-resources unwind
+  closes reservations and the session without completing or committing, which is the abort.
+  Cancellation (C12) is the same path.
+- Abort-time `close()` must succeed from any state. If it throws anyway, jvector attaches that
+  exception as suppressed on the original cause and rethrows the original.
+- `complete` or `commit` failing is an abort, never a partial success. Hosts must not publish
+  anything before `commit` returns.
+- No consumer truncates, deletes, or renames a host resource. What it may touch is exactly the
+  bytes it streams.
+
+### 3.5 Instrumentation
+
+- Every byte jvector writes goes through an `IndexWriter` the host provided, so metering is
+  decoration on the host side with zero cost when absent. No counters live in the contract.
+- jvector reports phases through the `ProgressTracker`/`WorkStage` seam and asks
+  `WorkLimiter.acquire(bytes)` before each block it streams, so a host's byte-rate throttle
+  applies to output IO.
+
+### 3.6 Performance
+
+- The contract adds no IO layer: the host's stream is the only thing between jvector's writer
+  and storage. Standalone, that is one buffered channel writer plus one `rename` at commit.
+- Streaming is sequential IO, which every storage tier prefers, and it is the only IO shape
+  cloud-backed hosts (Lucene directories, CNDB staging) can give without a local copy.
+- The compactor's cost of emitting in order is a bounded reorder buffer (section 6), not extra IO.
+
+## 4. Reference implementation: `FileIndexDestination` (the fast path)
+
+Package-private, backs the three static factories. This is the normative Java IO mapping and
+the standalone fast path; it uses nothing a host could not also use.
+
+| Element | Standalone (`toFile`, `toFiles`) | In-file region (`inFile`) |
+|---|---|---|
+| `reserve(a)` | create `<name>.<random>.tmp` beside the target, open it for writing | open `path` (`WRITE, CREATE`, no truncate) |
+| `stream()` | buffered append-only `IndexWriter` over the channel from position `0` | same, from `offset`; `position()` still starts at `0` |
+| `complete()` | flush the stream, `channel.force(false)` | same |
+| `commit()` | for each artifact: `Files.move(tmp, path, ATOMIC_MOVE, REPLACE_EXISTING)` (a rename on POSIX) | no-op; the caller writes its footer through its own handle after commit |
+| abort | delete every temp file; `path` is untouched | nothing to undo beyond releasing the channel; the region's bytes are the caller's to ignore |
+
+Compared with `FileCompactionDestination` on #710 (which wrote the final path directly and
+deleted it on abort), the standalone default gains a real transactional boundary: a reader of
+`path` never observes a partial graph, and a failed compaction leaves the previous file intact.
+
+## 5. Host mappings
+
+### 5.1 Standalone
+
+```java
+compactor.compact(IndexDestination.toFile(Path.of("compacted.index")));
+compactor.compact(IndexDestination.toFiles(Map.of(
+        OutputArtifact.GRAPH, graphPath,
+        OutputArtifact.COMPRESSED_VECTORS, pqPath)));
+```
+
+`compact(Path)` and `compact(Path, Path)` remain as one-line delegations to these.
+
+### 5.2 Cassandra SAI
+
+Today `CompactionGraph` builds `new OnDiskGraphIndexWriter.Builder(graph, path).withStartOffset(termsOffset)`,
+seeks the writer's output to the end of the terms file to write the SAI header, and after the
+graph writes an SAI footer with `writer.checksum()`. PQ goes to a separate component through
+`pqOutput.asSequentialWriter()`.
+
+| Call | Host behaviour |
+|---|---|
+| `open()` | one session per index build or compaction |
+| `reserve(GRAPH)` | write the SAI header through its own writer, then vend the terms component's `SequentialWriter` adapted as `IndexWriter`, with `position()` counting from the region start |
+| `complete()` | CRC over the region (re-read, as today), write the SAI footer |
+| `reserve(COMPRESSED_VECTORS)` | open the PQ component output, write its SAI header, vend it as `IndexWriter`; `complete()` writes the PQ footer |
+| `commit()` | mark the components complete |
+| abort | mark the components failed |
+
+Because the format stores offsets in the stream's coordinates (3.4), the SAI reader side
+changes with the writer: the graph is loaded from `termsOffset` with header-first loading, or
+through a reader whose origin is `termsOffset`, rather than through a whole-component footer
+search. Files written before the migration keep their absolute-origin reader; the component
+metadata can record which convention a file uses.
+
+### 5.3 CNDB
+
+Same as SAI at the stream level. Where the container is remotely backed, the host's stream
+writes a local staging file and `commit()` is where the upload or publish happens; abort
+discards the staging file. The commit boundary is exactly the point CNDB needs to make the
+change visible, and nothing in jvector observes the difference.
+
+### 5.4 OpenSearch / Lucene
+
+Today `JVectorWriter` builds with `OnDiskSequentialGraphIndexWriter` over `JVectorIndexWriter`
+(an `IndexWriter` adapter on `IndexOutput` with `position()` but no seek), wraps it in
+`CodecUtil.writeIndexHeader`/`writeFooter`, and writes PQ as a blob after the graph in the same
+file, recording lengths in its metadata. Merges rebuild with `GraphIndexBuilder`.
+
+| Call | Host behaviour |
+|---|---|
+| `reserve(GRAPH)` | `directory.createOutput(name)`, `CodecUtil.writeIndexHeader`, then `JVectorIndexWriter` positioned so that region position `0` is the byte after the codec header |
+| `complete()` | record the length for the metadata file, `CodecUtil.writeFooter(out)`, close the output |
+| `reserve(COMPRESSED_VECTORS)` | either a second codec file, or a second region in the same file after the graph (the plugin's current layout) |
+| `commit()` | nothing more: the segment commit is Lucene's |
+| abort | `IOUtils.deleteFilesIgnoringExceptions` on the created outputs |
+
+The `IndexOutput` only ever sees sequential writes, so Lucene's incremental checksum and its
+`IndexOutput` contract are both respected without any change on the Lucene side, and without a
+temporary file or a copy. This answers the question reta left open on #722 about whether two
+API flavours are needed: one contract, sequential.
+
+## 6. Consumer changes (separate PR)
+
+Nothing here is part of the contract PR; it shows the contract is sufficient. The key fact,
+verified against the code, is that nothing fundamental prevents jvector from writing index data
+in order.
+
+**Build path.** `OnDiskSequentialGraphIndexWriter` already writes header, records and footer in
+order with no seeks (`graph/disk/OnDiskSequentialGraphIndexWriter.java:103-160`) and is what
+the OpenSearch plugin uses. `new Builder(graph, reservation.stream())` works with no new
+constructor. The random-access writer's only backward seek rewrites the header at the start so
+that separated-feature offsets are correct for readers that ignore the footer
+(`RandomAccessOnDiskGraphIndexWriter.java:172-173`); footer-based readers do not need it.
+
+**Compactor.** Its output depends only on its inputs, all known before the first byte:
+
+- The header is complete up front: layer sizes and degrees come from the sources, the entry node
+  is resolved, the retrained codebook exists, and only inline features are supported
+  (`OnDiskGraphIndexCompactor.java:420-450`).
+- Level-0 batches are contiguous slices of each source's node list, submitted in order through
+  a bounded window and consumed in completion order (`:1315-1345`); each batch reads only the
+  source graphs (`:1010-1070`) and yields fully materialized records with their final offsets.
+  Emitting in order means holding finished batches until their predecessors finish. The memory
+  bound is the window already in flight today, since the bytes are materialized before the
+  write; the cost is head-of-line latency on a slow batch.
+- With the offset mapper used in practice, source order is output-ordinal order. With an
+  arbitrary mapper, records are produced by iterating new ordinals and resolving back to the
+  source, as the sidecar strategy already does (`SidecarCompactionStrategy.java:161`).
+- Dead ordinal slots are skipped today and left as zero pages in a sparse file; a stream writes
+  them explicitly. Same file size, more bytes through the stream.
+- Upper layers, the level-1 PQ records, and the footer are already appended in order.
+- Refinement (`refineAfterCompaction`, default `false`, `:87`) is the only in-place rewrite. In
+  a streaming world it becomes a second pass producing a new stream, or stays off.
+- The sidecar is already written sequentially (`SidecarCompactionStrategy.java:98`); it moves
+  from a `Path` to `reserve(COMPRESSED_VECTORS).stream()`.
+- Where the fused-PQ pre-encode cache lives when the output is not a jvector-owned file is an
+  adoption question (C6), outside this contract.
+
+```java
+public void compact(IndexDestination destination) throws IOException {
+    try (OutputSession session = destination.open()) {
+        try (OutputReservation out = session.reserve(OutputArtifact.GRAPH)) {
+            writeGraphInOrder(out.stream());          // header, L0 in ordinal order, upper layers, footer
+            out.complete();
+        }
+        if (sidecarStrategy.writesCodesSidecar()) {
+            try (OutputReservation out = session.reserve(OutputArtifact.COMPRESSED_VECTORS)) {
+                sidecarStrategy.writeSidecar(out.stream());
+                out.complete();
+            }
+        }
+        session.commit();
+    }
+}
+```
+
+## 7. What the reviewers asked, and where it landed
+
+| Thread | Resolution in this draft |
+|---|---|
+| ashkrisk: does `SeekableSink` duplicate the reader/writer interfaces? | `SeekableSink` is gone. The contract vends the existing `IndexWriter` and adds lifecycle around it; nothing is duplicated. |
+| ashkrisk: why `destination.open()` rather than passing the target? | Section 3.3: the destination is stateless configuration; the session and reservation carry single-use state with an enforced state machine. The split is what makes commit-at-most-once and close-exactly-once checkable. |
+| MarkWolters: what does `readAt` return at the end? | Moot: there is no positional read in the contract. |
+| reta: `OutputReservation` is still path-biased | No `Path` on any vended type; the output is an `IndexWriter`. `Path` survives only in the file-backed static factories. |
+| reta: Lucene has no random IO | The contract is sequential by construction (3.1, 5.4); the compactor emits in order (6). |
+| ashkrisk: split the memory-safety edits from the interfaces | This contract is its own PR, per jshook's note on #722. The `OnDiskGraphIndex`/`ReaderSupplier` edits stay on #710. |
+
+## 8. Migration from the #710 types
+
+| #710 | This draft |
+|---|---|
+| `graph.disk.CompactionDestination` | `disk.IndexDestination` (generic: also serves the build-path writers) |
+| `CompactionDestination.reserve()` -> `OutputReservation` | `IndexDestination.open()` -> `OutputSession.reserve(artifact)` -> `OutputReservation` |
+| `OutputReservation.file()`, `startOffset()` | removed; `stream()` |
+| `OutputReservation.commit(bodyLength)` | `OutputReservation.complete()` per artifact plus `OutputSession.commit()` per operation |
+| `CompactionDestination.toFile(path)` | `IndexDestination.toFile(path)` with temp-file-and-rename; `toFiles`, `inFile` added |
+| `SeekableSink`, `FileChannelSeekableSink`, `TestSeekableSink` | dropped: positional IO is out of scope |
+| `FileCompactionDestination` | `FileIndexDestination` |
+
+## 9. Open questions
+
+1. **Size hint.** `reserve(artifact)` carries no projected size. A host doing space accounting
+   (CNDB) may want one; it is an additive parameter when a host asks.
+2. **Completion payload.** `complete()` carries nothing. Every host computes its own length from
+   its stream and its own checksum; if one wants jvector's view for a cross-check, a length or a
+   CRC can be added without changing the lifecycle.
+3. **Positional access as an optional capability.** If a host wants to let the compactor skip
+   the reorder buffer, a capability-gated positional view can be added later. Nothing here
+   precludes it.
+4. **Refinement.** Off by default; as a second pass it costs one extra copy. Whether it stays a
+   positional-only feature or becomes a two-pass streaming feature is an adoption decision.
+5. **`Builder(graph, OutputReservation)` convenience** for the build-path writers, and whether
+   `OnDiskParallelGraphIndexWriter` should be folded into the sequential writer with a reorder
+   buffer once its `Path` requirement is gone.

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/FileIndexDestination.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/FileIndexDestination.java
@@ -1,0 +1,474 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.disk;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * File-backed {@link IndexDestination}: the normative Java IO mapping of the contract and the
+ * standalone fast path. Backs {@link IndexDestination#toFile}, {@link IndexDestination#toFiles}
+ * and {@link IndexDestination#inFile}.
+ * <p>
+ * Standalone mode streams each artifact into a sibling temporary file and renames it over the
+ * target at {@link OutputSession#commit()}, so a reader of the target never observes a partial
+ * artifact and an abort leaves any previous file intact. Region mode streams into a caller-owned
+ * file from a fixed offset and never truncates, deletes or renames it.
+ * <p>
+ * Limitation: with several standalone artifacts, a failure part-way through the renames of
+ * {@code commit()} leaves the artifacts already renamed in place; plain files offer no
+ * multi-file atomic publish.
+ */
+final class FileIndexDestination implements IndexDestination {
+    private final Map<OutputArtifact, Path> targets;
+    /** Region start within the single target, or {@code -1} in standalone mode. */
+    private final long regionOffset;
+
+    static FileIndexDestination standalone(Map<OutputArtifact, Path> paths) {
+        Objects.requireNonNull(paths, "paths");
+        if (paths.isEmpty()) {
+            throw new IllegalArgumentException("at least one artifact path is required");
+        }
+        paths.forEach((artifact, path) -> {
+            Objects.requireNonNull(artifact, "artifact");
+            Objects.requireNonNull(path, "path for " + artifact);
+        });
+        return new FileIndexDestination(paths, -1L);
+    }
+
+    static FileIndexDestination region(Path path, long offset) {
+        Objects.requireNonNull(path, "path");
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset must be >= 0, got " + offset);
+        }
+        return new FileIndexDestination(Collections.singletonMap(OutputArtifact.GRAPH, path), offset);
+    }
+
+    private FileIndexDestination(Map<OutputArtifact, Path> targets, long regionOffset) {
+        EnumMap<OutputArtifact, Path> absolute = new EnumMap<>(OutputArtifact.class);
+        targets.forEach((artifact, path) -> absolute.put(artifact, path.toAbsolutePath()));
+        this.targets = Collections.unmodifiableMap(absolute);
+        this.regionOffset = regionOffset;
+    }
+
+    private boolean standalone() {
+        return regionOffset < 0;
+    }
+
+    @Override
+    public OutputSession open() {
+        return new Session();
+    }
+
+    @Override
+    public String toString() {
+        return standalone()
+                ? "IndexDestination.toFiles" + targets
+                : "IndexDestination.inFile[" + targets.get(OutputArtifact.GRAPH) + " @ " + regionOffset + "]";
+    }
+
+    private static Path parentOf(Path absolutePath) {
+        Path parent = absolutePath.getParent();
+        return parent != null ? parent : absolutePath.getRoot();
+    }
+
+    private static IOException suppress(IOException first, IOException next) {
+        if (first == null) {
+            return next;
+        }
+        first.addSuppressed(next);
+        return first;
+    }
+
+    private enum SessionState { OPEN, COMMITTED, ABORTED, CLOSED }
+
+    /** One write operation: lazily opens one file per reserved artifact, publishes on commit. */
+    private final class Session implements OutputSession {
+        private final EnumMap<OutputArtifact, Reservation> reservations = new EnumMap<>(OutputArtifact.class);
+        private SessionState state = SessionState.OPEN;
+
+        @Override
+        public OutputReservation reserve(OutputArtifact artifact) throws IOException {
+            checkOpen();
+            Objects.requireNonNull(artifact, "artifact");
+            Path target = targets.get(artifact);
+            if (target == null) {
+                throw new IllegalArgumentException(FileIndexDestination.this + " has no placement for " + artifact);
+            }
+            if (reservations.containsKey(artifact)) {
+                throw new IllegalStateException(artifact + " is already reserved in this session");
+            }
+            Reservation reservation;
+            if (standalone()) {
+                Path tmp = Files.createTempFile(parentOf(target), target.getFileName() + ".", ".tmp");
+                FileChannel channel;
+                try {
+                    channel = FileChannel.open(tmp, StandardOpenOption.WRITE);
+                } catch (IOException e) {
+                    Files.deleteIfExists(tmp);
+                    throw e;
+                }
+                reservation = new Reservation(artifact, target, tmp, channel, 0L);
+            } else {
+                FileChannel channel = FileChannel.open(target, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+                reservation = new Reservation(artifact, target, null, channel, regionOffset);
+            }
+            reservations.put(artifact, reservation);
+            return reservation;
+        }
+
+        @Override
+        public void commit() throws IOException {
+            checkOpen();
+            for (Reservation r : reservations.values()) {
+                if (!r.completed) {
+                    throw new IllegalStateException(r.artifact + " was reserved but never completed");
+                }
+                if (!r.closed) {
+                    throw new IllegalStateException("the reservation for " + r.artifact + " is still open");
+                }
+            }
+            if (standalone()) {
+                try {
+                    for (Reservation r : reservations.values()) {
+                        r.publish();
+                    }
+                } catch (IOException e) {
+                    state = SessionState.ABORTED;
+                    throw e;
+                }
+            }
+            state = SessionState.COMMITTED;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (state == SessionState.CLOSED) {
+                return;
+            }
+            boolean committed = state == SessionState.COMMITTED;
+            state = SessionState.CLOSED;
+            IOException first = null;
+            for (Reservation r : reservations.values()) {
+                try {
+                    r.close();
+                } catch (IOException e) {
+                    first = suppress(first, e);
+                }
+                if (!committed && r.tmp != null) {
+                    // Completed but never published: the temporary file is a discarded artifact.
+                    try {
+                        Files.deleteIfExists(r.tmp);
+                    } catch (IOException e) {
+                        first = suppress(first, e);
+                    }
+                }
+            }
+            if (first != null) {
+                throw first;
+            }
+        }
+
+        private void checkOpen() {
+            if (state != SessionState.OPEN) {
+                throw new IllegalStateException("session is " + state.name().toLowerCase(Locale.ROOT));
+            }
+        }
+    }
+
+    /** One artifact's output: an append-only stream into a channel from {@code base}. */
+    private final class Reservation implements OutputReservation {
+        final OutputArtifact artifact;
+        final Path target;
+        /** The temporary file in standalone mode; {@code null} in region mode. */
+        final Path tmp;
+        final FileChannel channel;
+        final long base;
+        private ChannelStream stream;
+        boolean completed;
+        boolean closed;
+
+        Reservation(OutputArtifact artifact, Path target, Path tmp, FileChannel channel, long base) {
+            this.artifact = artifact;
+            this.target = target;
+            this.tmp = tmp;
+            this.channel = channel;
+            this.base = base;
+        }
+
+        @Override
+        public OutputArtifact artifact() {
+            return artifact;
+        }
+
+        @Override
+        public IndexWriter stream() {
+            checkOpen();
+            if (stream == null) {
+                stream = new ChannelStream(channel, base);
+            }
+            return stream;
+        }
+
+        @Override
+        public void complete() throws IOException {
+            checkOpen();
+            if (stream != null) {
+                stream.flush();
+            }
+            channel.force(false);
+            completed = true;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            IOException first = null;
+            if (stream != null) {
+                stream.abandon();
+            }
+            try {
+                channel.close();
+            } catch (IOException e) {
+                first = suppress(first, e);
+            }
+            if (tmp != null && !completed) {
+                try {
+                    Files.deleteIfExists(tmp);
+                } catch (IOException e) {
+                    first = suppress(first, e);
+                }
+            }
+            if (first != null) {
+                throw first;
+            }
+        }
+
+        /** Standalone only: renames the completed temporary file over the target. */
+        void publish() throws IOException {
+            try {
+                Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+
+        private void checkOpen() {
+            if (closed) {
+                throw new IllegalStateException("the reservation for " + artifact + " is closed");
+            }
+            if (completed) {
+                throw new IllegalStateException(artifact + " is already completed");
+            }
+        }
+    }
+
+    /**
+     * Buffered append-only {@link IndexWriter} over a channel region: byte {@code i} of the
+     * stream lands at channel position {@code base + i}, in write order. {@link #position()} is
+     * the number of bytes written so far. {@link #close()} flushes and never closes the channel;
+     * {@link #abandon()} drops buffered bytes on an abort.
+     */
+    private static final class ChannelStream implements IndexWriter {
+        private static final int BUFFER_SIZE = 1 << 16;
+
+        private final FileChannel channel;
+        private final long base;
+        private final ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE).order(ByteOrder.BIG_ENDIAN);
+        private long flushed;
+        private boolean closed;
+
+        ChannelStream(FileChannel channel, long base) {
+            this.channel = channel;
+            this.base = base;
+        }
+
+        @Override
+        public long position() {
+            return flushed + buffer.position();
+        }
+
+        void flush() throws IOException {
+            if (buffer.position() == 0) {
+                return;
+            }
+            buffer.flip();
+            long abs = base + flushed;
+            int n = buffer.remaining();
+            while (buffer.hasRemaining()) {
+                abs += channel.write(buffer, abs);
+            }
+            buffer.clear();
+            flushed += n;
+        }
+
+        void abandon() {
+            closed = true;
+            buffer.clear();
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            try {
+                flush();
+            } finally {
+                closed = true;
+            }
+        }
+
+        private void ensure(int n) throws IOException {
+            if (closed) {
+                throw new IOException("stream is closed");
+            }
+            if (buffer.remaining() < n) {
+                flush();
+            }
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            ensure(1);
+            buffer.put((byte) b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            write(b, 0, b.length);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            ensure(0);
+            if (len >= buffer.capacity()) {
+                // Larger than the buffer: flush what is pending, then write straight through.
+                flush();
+                ByteBuffer src = ByteBuffer.wrap(b, off, len);
+                long abs = base + flushed;
+                while (src.hasRemaining()) {
+                    abs += channel.write(src, abs);
+                }
+                flushed += len;
+                return;
+            }
+            ensure(len);
+            buffer.put(b, off, len);
+        }
+
+        @Override
+        public void writeBoolean(boolean v) throws IOException {
+            write(v ? 1 : 0);
+        }
+
+        @Override
+        public void writeByte(int v) throws IOException {
+            write(v);
+        }
+
+        @Override
+        public void writeShort(int v) throws IOException {
+            ensure(Short.BYTES);
+            buffer.putShort((short) v);
+        }
+
+        @Override
+        public void writeChar(int v) throws IOException {
+            ensure(Character.BYTES);
+            buffer.putChar((char) v);
+        }
+
+        @Override
+        public void writeInt(int v) throws IOException {
+            ensure(Integer.BYTES);
+            buffer.putInt(v);
+        }
+
+        @Override
+        public void writeLong(long v) throws IOException {
+            ensure(Long.BYTES);
+            buffer.putLong(v);
+        }
+
+        @Override
+        public void writeFloat(float v) throws IOException {
+            ensure(Float.BYTES);
+            buffer.putFloat(v);
+        }
+
+        @Override
+        public void writeDouble(double v) throws IOException {
+            ensure(Double.BYTES);
+            buffer.putDouble(v);
+        }
+
+        @Override
+        public void writeBytes(String s) throws IOException {
+            int len = s.length();
+            for (int i = 0; i < len; i++) {
+                write((byte) s.charAt(i));
+            }
+        }
+
+        @Override
+        public void writeChars(String s) throws IOException {
+            int len = s.length();
+            for (int i = 0; i < len; i++) {
+                writeChar(s.charAt(i));
+            }
+        }
+
+        /** Modified UTF-8 with a two-byte length prefix, byte-identical to {@link DataOutputStream#writeUTF}. */
+        @Override
+        public void writeUTF(String s) throws IOException {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream(s.length() + 2);
+            new DataOutputStream(bytes).writeUTF(s);
+            write(bytes.toByteArray());
+        }
+
+        @Override
+        public void writeFloats(float[] floats, int offset, int count) throws IOException {
+            int i = offset;
+            int end = offset + count;
+            while (i < end) {
+                ensure(Float.BYTES);
+                int n = Math.min(end - i, buffer.remaining() / Float.BYTES);
+                buffer.asFloatBuffer().put(floats, i, n);
+                buffer.position(buffer.position() + n * Float.BYTES);
+                i += n;
+            }
+        }
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexDestination.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/IndexDestination.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.disk;
+
+import io.github.jbellis.jvector.annotations.Experimental;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Where a host lets jvector put index bytes. Stateless configuration: a host builds one, holds
+ * it, and jvector calls {@link #open()} once per write operation. Nothing here or in anything it
+ * vends names a path, file, channel or host stream type; the host keeps those.
+ * <p>
+ * The contract in one picture:
+ * <pre>
+ *   IndexDestination                    stateless "where", built once by the host
+ *      open() ---------> OutputSession               one write operation; the transactional unit
+ *                          reserve(artifact) --> OutputReservation   one artifact's output
+ *                                                  stream()    IndexWriter, append-only
+ *                                                  complete() / close()
+ *                          commit() / close()
+ * </pre>
+ * jvector writes every artifact strictly sequentially through its reservation's
+ * {@link OutputReservation#stream() stream}. Two levels of "done" mirror what every host already
+ * has: each artifact is {@link OutputReservation#complete completed} (where a host writes its
+ * per-file footer and checksum), and the session is {@link OutputSession#commit committed} once
+ * as a set (where a host publishes). A close without the matching commit is an abort at either
+ * level, so try-with-resources is the whole error-handling story.
+ * <p>
+ * The file-backed factories below are the normative reference implementation and the fast path
+ * for standalone use; every other host implements this interface over its own storage.
+ */
+@Experimental
+@FunctionalInterface
+public interface IndexDestination {
+
+    /**
+     * Begins one write operation. The returned session is the transactional unit: it is
+     * committed at most once and closed exactly once, normally with try-with-resources.
+     */
+    OutputSession open() throws IOException;
+
+    /**
+     * Standalone, jvector-owned file. The session writes a sibling temporary file and renames it
+     * over {@code path} on commit; an abort deletes the temporary file and leaves any pre-existing
+     * {@code path} untouched. Places the {@link OutputArtifact#GRAPH} artifact only.
+     */
+    static IndexDestination toFile(Path path) {
+        return FileIndexDestination.standalone(Collections.singletonMap(OutputArtifact.GRAPH, path));
+    }
+
+    /**
+     * Standalone files, one per artifact (for example the graph plus a compressed-vectors
+     * sidecar), each with the same temporary-file-and-rename lifecycle applied at commit.
+     */
+    static IndexDestination toFiles(Map<OutputArtifact, Path> paths) {
+        return FileIndexDestination.standalone(paths);
+    }
+
+    /**
+     * A region inside a caller-owned file, starting at {@code offset}. The file is never
+     * truncated, deleted or renamed, and nothing before {@code offset} is written; the caller
+     * owns whatever precedes and follows the region (its own header and footer). Intended for
+     * tests and simple embedders; real hosts implement the interface directly so that
+     * {@link OutputReservation#complete} can write their footer.
+     */
+    static IndexDestination inFile(Path path, long offset) {
+        return FileIndexDestination.region(path, offset);
+    }
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/OutputArtifact.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/OutputArtifact.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.disk;
+
+import io.github.jbellis.jvector.annotations.Experimental;
+
+/**
+ * The kinds of output one write operation can produce. Hosts map each to their own placement: a
+ * component file, a codec file, or a section after the graph in the same file.
+ */
+@Experimental
+public enum OutputArtifact {
+    /** The graph index: header, records and footer, as read by {@code OnDiskGraphIndex.load}. */
+    GRAPH,
+    /**
+     * A non-fused compressed-vectors sidecar (for example {@code PQVectors}), as read by
+     * {@code CompressedVectors.load}.
+     */
+    COMPRESSED_VECTORS
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/OutputReservation.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/OutputReservation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.disk;
+
+import io.github.jbellis.jvector.annotations.Experimental;
+
+import java.io.IOException;
+
+/**
+ * One artifact's reserved output plus its completion lifecycle: live, single-use state made
+ * against an {@link OutputSession}, fulfilled by {@link #complete()} or released by a
+ * {@link #close()} without one.
+ * <p>
+ * The artifact is written strictly sequentially through {@link #stream()}. After
+ * {@link #complete} or {@link #close}, every other call fails with {@link IllegalStateException}.
+ */
+@Experimental
+public interface OutputReservation extends AutoCloseable {
+
+    /** The artifact this reservation holds. */
+    OutputArtifact artifact();
+
+    /**
+     * The append-only output for this artifact; the same instance on every call. Its
+     * {@code position()} counts the bytes written through it, starting at {@code 0}. Every offset
+     * jvector stores inside the artifact (the footer's header offset, separated-feature offsets)
+     * is relative to that origin, so a host reads the artifact back with a reader whose origin is
+     * the same place. Single-threaded. Closing it flushes and does not close the reservation, so
+     * a jvector writer that takes ownership of its output may close it freely.
+     */
+    IndexWriter stream() throws IOException;
+
+    /**
+     * Marks the artifact final: flushes anything still buffered in {@link #stream()} and hands
+     * the artifact to the host, which finalizes it here (footer, checksum, durability). At most
+     * once; a failure leaves the reservation not completed, which prevents the session from
+     * committing.
+     *
+     * @throws IllegalStateException if already completed or closed
+     */
+    void complete() throws IOException;
+
+    /**
+     * Idempotent. Releases the stream. Without a prior successful {@link #complete}, the artifact
+     * is discarded and the owning session can no longer commit.
+     */
+    @Override
+    void close() throws IOException;
+}

--- a/jvector-base/src/main/java/io/github/jbellis/jvector/disk/OutputSession.java
+++ b/jvector-base/src/main/java/io/github/jbellis/jvector/disk/OutputSession.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.disk;
+
+import io.github.jbellis.jvector.annotations.Experimental;
+
+import java.io.IOException;
+
+/**
+ * One write operation against an {@link IndexDestination}: reserves the output for each
+ * artifact it produces and ends in exactly one of {@link #commit()} or an abort (a
+ * {@link #close()} without a prior successful commit).
+ * <p>
+ * Lifecycle calls ({@code reserve}, {@code commit}, {@code close}) are made by the thread that
+ * owns the operation, after any worker threads using the vended streams have finished. Streams
+ * vended by this session are released by their reservation's {@code close()} or, at the latest,
+ * by this session's {@code close()}.
+ * <p>
+ * State machine: {@code OPEN} until {@code commit()} succeeds ({@code COMMITTED}) or fails
+ * ({@code ABORTED}) or {@code close()} runs first ({@code ABORTED}); {@code close()} is idempotent
+ * and every other call on a non-open session fails with {@link IllegalStateException}.
+ */
+@Experimental
+public interface OutputSession extends AutoCloseable {
+
+    /**
+     * Reserves the output for one artifact. Each artifact may be reserved at most once per
+     * session; a second request fails with {@link IllegalStateException}.
+     *
+     * @throws IllegalArgumentException if this destination has no placement for {@code artifact}
+     */
+    OutputReservation reserve(OutputArtifact artifact) throws IOException;
+
+    /**
+     * Publishes every completed artifact as one consistent unit, as atomically as the host can
+     * (rename into place, register components, mark a segment's file set). Precondition: every
+     * reservation made in this session has been completed and closed. At most once; if it
+     * throws, the session is aborted.
+     *
+     * @throws IllegalStateException if a reservation is still open, or a reserved artifact was
+     *                               never completed
+     */
+    void commit() throws IOException;
+
+    /**
+     * Idempotent. Without a prior successful {@link #commit()} this is an abort: every stream
+     * still open is released and every partial artifact is discarded. Must succeed from any
+     * state, including before the first reservation and after a failed commit. An
+     * {@link IOException} raised here during an abort is attached as suppressed to the failure
+     * that caused the abort.
+     */
+    @Override
+    void close() throws IOException;
+}

--- a/jvector-tests/src/test/java/io/github/jbellis/jvector/disk/TestFileIndexDestination.java
+++ b/jvector-tests/src/test/java/io/github/jbellis/jvector/disk/TestFileIndexDestination.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.jbellis.jvector.disk;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import io.github.jbellis.jvector.TestUtil;
+import io.github.jbellis.jvector.graph.GraphIndexBuilder;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
+import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.disk.OnDiskSequentialGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.feature.Feature;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class TestFileIndexDestination extends RandomizedTest {
+    private Path dir;
+    private Path target;
+
+    @Before
+    public void setup() throws IOException {
+        dir = Files.createTempDirectory(getClass().getSimpleName());
+        target = dir.resolve("graph.index");
+        Files.write(target, bytes("OLD"));
+    }
+
+    @After
+    public void tearDown() {
+        TestUtil.deleteQuietly(dir);
+    }
+
+    private static byte[] bytes(String s) {
+        return s.getBytes(StandardCharsets.US_ASCII);
+    }
+
+    private static String text(Path p) throws IOException {
+        return new String(Files.readAllBytes(p), StandardCharsets.US_ASCII);
+    }
+
+    /** Files in the test directory other than the named ones. */
+    private List<String> strayFiles(String... expected) throws IOException {
+        List<String> keep = List.of(expected);
+        try (Stream<Path> s = Files.list(dir)) {
+            return s.map(p -> p.getFileName().toString())
+                    .filter(n -> !keep.contains(n))
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private static ImmutableGraphIndex buildGraph(RandomAccessVectorValues ravv) throws IOException {
+        GraphIndexBuilder builder = new GraphIndexBuilder(ravv, VectorSimilarityFunction.EUCLIDEAN, 8, 32, 1.2f, 1.2f, false);
+        ImmutableGraphIndex graph = TestUtil.buildSequentially(builder, ravv);
+        builder.close();
+        return graph;
+    }
+
+    private static RandomAccessVectorValues randomVectors(int size, int dimension, long seed) {
+        List<VectorFloat<?>> vectors = new ArrayList<>(size);
+        Random random = new Random(seed);
+        for (int i = 0; i < size; i++) {
+            vectors.add(TestUtil.randomVector(random, dimension));
+        }
+        return new ListRandomAccessVectorValues(vectors, dimension);
+    }
+
+    private static void streamGraph(ImmutableGraphIndex graph, RandomAccessVectorValues ravv, OutputReservation r) throws IOException {
+        // The existing sequential writer runs unchanged over the reservation's stream and closes
+        // it when done; the reservation stays open for complete().
+        try (OnDiskSequentialGraphIndexWriter writer = new OnDiskSequentialGraphIndexWriter.Builder(graph, r.stream())
+                .with(new InlineVectors(ravv.dimension()))
+                .build()) {
+            writer.write(Feature.singleStateFactory(FeatureId.INLINE_VECTORS,
+                    i -> new InlineVectors.State(ravv.getVector(i))));
+        }
+    }
+
+    @Test
+    public void standaloneCommitPublishesAtomically() throws IOException {
+        IndexDestination dest = IndexDestination.toFile(target);
+        try (OutputSession session = dest.open()) {
+            try (OutputReservation r = session.reserve(OutputArtifact.GRAPH)) {
+                assertEquals(OutputArtifact.GRAPH, r.artifact());
+                IndexWriter out = r.stream();
+                assertSame("one stream per reservation", out, r.stream());
+                out.write(bytes("NEW-"));
+                out.write(bytes("BODY"));
+                assertEquals(8, out.position());
+                assertEquals("target untouched while the session is open", "OLD", text(target));
+                assertEquals(1, strayFiles("graph.index").size());
+                r.complete();
+            }
+            assertEquals("target untouched until commit", "OLD", text(target));
+            session.commit();
+            assertEquals("NEW-BODY", text(target));
+        }
+        assertEquals(List.of(), strayFiles("graph.index"));
+    }
+
+    @Test
+    public void abortLeavesTheTargetUntouched() throws IOException {
+        IndexDestination dest = IndexDestination.toFile(target);
+        try (OutputSession session = dest.open()) {
+            try (OutputReservation r = session.reserve(OutputArtifact.GRAPH)) {
+                r.stream().write(bytes("PARTIAL"));
+                // no complete(): abort
+            }
+        }
+        assertEquals("OLD", text(target));
+        assertEquals(List.of(), strayFiles("graph.index"));
+    }
+
+    @Test
+    public void completedButUncommittedIsDiscarded() throws IOException {
+        IndexDestination dest = IndexDestination.toFile(target);
+        try (OutputSession session = dest.open()) {
+            try (OutputReservation r = session.reserve(OutputArtifact.GRAPH)) {
+                r.stream().write(bytes("DONE"));
+                r.complete();
+            }
+            // no commit(): abort
+        }
+        assertEquals("OLD", text(target));
+        assertEquals(List.of(), strayFiles("graph.index"));
+    }
+
+    @Test
+    public void lifecycleIsEnforced() throws IOException {
+        IndexDestination dest = IndexDestination.toFile(target);
+        OutputSession session = dest.open();
+        try { session.reserve(OutputArtifact.COMPRESSED_VECTORS); fail("no placement"); } catch (IllegalArgumentException expected) { }
+
+        OutputReservation r = session.reserve(OutputArtifact.GRAPH);
+        try { session.reserve(OutputArtifact.GRAPH); fail("double reserve"); } catch (IllegalStateException expected) { }
+        try { session.commit(); fail("commit with an open reservation"); } catch (IllegalStateException expected) { }
+
+        r.stream().write(bytes("abc"));
+        r.complete();
+        try { r.complete(); fail("double complete"); } catch (IllegalStateException expected) { }
+        try { r.stream(); fail("stream after complete"); } catch (IllegalStateException expected) { }
+        try { session.commit(); fail("commit with a completed but unclosed reservation"); } catch (IllegalStateException expected) { }
+        r.close();
+        r.close(); // idempotent
+        try { r.stream(); fail("stream after close"); } catch (IllegalStateException expected) { }
+
+        session.commit();
+        try { session.commit(); fail("double commit"); } catch (IllegalStateException expected) { }
+        try { session.reserve(OutputArtifact.GRAPH); fail("reserve after commit"); } catch (IllegalStateException expected) { }
+        session.close();
+        session.close(); // idempotent
+        try { session.commit(); fail("commit after close"); } catch (IllegalStateException expected) { }
+        assertEquals("abc", text(target));
+        assertEquals(List.of(), strayFiles("graph.index"));
+    }
+
+    @Test
+    public void streamEncodesLikeDataOutputStream() throws IOException {
+        float[] floats = {1.5f, -2.25f, 3e10f, Float.NaN};
+        byte[] big = new byte[100_000];
+        new Random(7).nextBytes(big);
+        IndexDestination dest = IndexDestination.toFile(target);
+        try (OutputSession session = dest.open()) {
+            try (OutputReservation r = session.reserve(OutputArtifact.GRAPH)) {
+                IndexWriter w = r.stream();
+                w.writeInt(0x01020304);
+                w.writeLong(-1L);
+                w.writeFloat(2.5f);
+                w.writeDouble(Math.PI);
+                w.writeShort(-2);
+                w.writeChar('x');
+                w.writeByte(7);
+                w.writeBoolean(true);
+                w.writeUTF("héllo wörld");
+                w.writeBytes("abc");
+                w.writeChars("de");
+                w.writeFloats(floats, 1, 2);
+                w.write(big, 100, 5000);       // smaller than the buffer
+                w.write(big);                  // larger than the buffer: written straight through
+                w.write(new byte[]{9, 8, 7});
+                assertEquals(4 + 8 + 4 + 8 + 2 + 2 + 1 + 1 + (2 + 13) + 3 + 4 + 8 + 5000 + big.length + 3, w.position());
+                r.complete();
+            }
+            session.commit();
+        }
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(Files.readAllBytes(target)));
+        assertEquals(0x01020304, in.readInt());
+        assertEquals(-1L, in.readLong());
+        assertEquals(2.5f, in.readFloat(), 0f);
+        assertEquals(Math.PI, in.readDouble(), 0d);
+        assertEquals(-2, in.readShort());
+        assertEquals('x', in.readChar());
+        assertEquals(7, in.readByte());
+        assertTrue(in.readBoolean());
+        assertEquals("héllo wörld", in.readUTF());
+        byte[] abc = new byte[3];
+        in.readFully(abc);
+        assertArrayEquals(new byte[]{'a', 'b', 'c'}, abc);
+        assertEquals('d', in.readChar());
+        assertEquals('e', in.readChar());
+        assertEquals(-2.25f, in.readFloat(), 0f);
+        assertEquals(3e10f, in.readFloat(), 0f);
+        byte[] middle = new byte[5000];
+        in.readFully(middle);
+        assertArrayEquals(Arrays.copyOfRange(big, 100, 5100), middle);
+        byte[] whole = new byte[big.length];
+        in.readFully(whole);
+        assertArrayEquals(big, whole);
+        byte[] tail = new byte[3];
+        in.readFully(tail);
+        assertArrayEquals(new byte[]{9, 8, 7}, tail);
+        assertEquals(-1, in.read());
+    }
+
+    @Test
+    public void regionModeWritesOnlyItsRegion() throws IOException {
+        Path container = dir.resolve("container.bin");
+        byte[] original = new byte[96];
+        new Random(1).nextBytes(original);
+        Files.write(container, original);
+
+        IndexDestination dest = IndexDestination.inFile(container, 64);
+        try (OutputSession session = dest.open()) {
+            try (OutputReservation r = session.reserve(OutputArtifact.GRAPH)) {
+                IndexWriter out = r.stream();
+                assertEquals("positions are region-relative", 0, out.position());
+                out.write(bytes("REGION-BYTES"));
+                assertEquals(12, out.position());
+                r.complete();
+            }
+            session.commit();
+        }
+        byte[] after = Files.readAllBytes(container);
+        assertEquals("region mode never truncates", original.length, after.length);
+        assertArrayEquals(Arrays.copyOfRange(original, 0, 64), Arrays.copyOfRange(after, 0, 64));
+        assertArrayEquals(bytes("REGION-BYTES"), Arrays.copyOfRange(after, 64, 76));
+        assertArrayEquals(Arrays.copyOfRange(original, 76, 96), Arrays.copyOfRange(after, 76, 96));
+
+        // Abort in region mode leaves the file in place as well.
+        try (OutputSession session = dest.open()) {
+            try (OutputReservation r = session.reserve(OutputArtifact.GRAPH)) {
+                r.stream().write(bytes("XX"));
+            }
+        }
+        assertTrue(Files.exists(container));
+        assertEquals(List.of(), strayFiles("graph.index", "container.bin"));
+    }
+
+    @Test
+    public void multipleArtifactsPublishTogether() throws IOException {
+        Path pq = dir.resolve("graph.pq");
+        Map<OutputArtifact, Path> paths = new EnumMap<>(OutputArtifact.class);
+        paths.put(OutputArtifact.GRAPH, target);
+        paths.put(OutputArtifact.COMPRESSED_VECTORS, pq);
+        IndexDestination dest = IndexDestination.toFiles(paths);
+        try (OutputSession session = dest.open()) {
+            try (OutputReservation g = session.reserve(OutputArtifact.GRAPH)) {
+                g.stream().write(bytes("GRAPH"));
+                g.complete();
+            }
+            try (OutputReservation c = session.reserve(OutputArtifact.COMPRESSED_VECTORS)) {
+                c.stream().write(bytes("CODES"));
+                c.complete();
+            }
+            assertFalse(Files.exists(pq));
+            session.commit();
+        }
+        assertEquals("GRAPH", text(target));
+        assertEquals("CODES", text(pq));
+        assertEquals(List.of(), strayFiles("graph.index", "graph.pq"));
+
+        // The destination is reusable: a second session replaces what it reserves.
+        try (OutputSession session = dest.open()) {
+            try (OutputReservation g = session.reserve(OutputArtifact.GRAPH)) {
+                g.stream().write(bytes("G2"));
+                g.complete();
+            }
+            session.commit();
+        }
+        assertEquals("G2", text(target));
+        assertEquals("CODES", text(pq));
+    }
+
+    @Test
+    public void graphStreamedIntoAStandaloneFileLoads() throws IOException {
+        int dimension = 16;
+        RandomAccessVectorValues ravv = randomVectors(200, dimension, 99);
+        ImmutableGraphIndex graph = buildGraph(ravv);
+
+        IndexDestination dest = IndexDestination.toFile(target);
+        try (OutputSession session = dest.open()) {
+            try (OutputReservation r = session.reserve(OutputArtifact.GRAPH)) {
+                streamGraph(graph, ravv, r);
+                r.complete();
+            }
+            session.commit();
+        }
+        try (SimpleMappedReader.Supplier supplier = new SimpleMappedReader.Supplier(target);
+             OnDiskGraphIndex loaded = OnDiskGraphIndex.load(supplier)) {
+            TestUtil.assertGraphEquals(graph, loaded);
+        }
+        assertEquals(List.of(), strayFiles("graph.index"));
+    }
+
+    @Test
+    public void graphStreamedIntoAContainerRegionLoads() throws IOException {
+        int dimension = 8;
+        int prefix = 128;
+        RandomAccessVectorValues ravv = randomVectors(60, dimension, 42);
+        ImmutableGraphIndex graph = buildGraph(ravv);
+
+        // A host container: its own header, then the graph, then its own trailer.
+        Path container = dir.resolve("container.bin");
+        byte[] header = new byte[prefix];
+        new Random(8).nextBytes(header);
+        Files.write(container, header);
+
+        IndexDestination dest = IndexDestination.inFile(container, prefix);
+        try (OutputSession session = dest.open()) {
+            try (OutputReservation r = session.reserve(OutputArtifact.GRAPH)) {
+                streamGraph(graph, ravv, r);
+                r.complete();
+            }
+            session.commit();
+        }
+        long graphEnd = Files.size(container);
+        assertTrue(graphEnd > prefix);
+        Files.write(container, new byte[64], java.nio.file.StandardOpenOption.APPEND);
+
+        byte[] after = Files.readAllBytes(container);
+        assertArrayEquals("host header untouched", header, Arrays.copyOfRange(after, 0, prefix));
+
+        // The host reads the graph back from the known offset. The stream's positions started at
+        // 0 at the region start, so the offsets the footer stores are relative to that origin;
+        // a whole-file reader therefore loads header-first from the offset rather than trusting
+        // the container's end.
+        try (SimpleMappedReader.Supplier supplier = new SimpleMappedReader.Supplier(container);
+             OnDiskGraphIndex loaded = OnDiskGraphIndex.load(supplier, prefix, false)) {
+            TestUtil.assertGraphEquals(graph, loaded);
+        }
+    }
+}


### PR DESCRIPTION
# Context / Background

I had originally thought that forcing a streaming interface for compacted indexes would be detrimental to jvector IO efficiency. It might be in some way, but that ended up being beside the point. OpenSearch, for example, doesn't budge on this, since it wants to do a running checksum on index segments.

I studied the capability for jvector to provide streaming segments for compaction, and it appears feasible. The key area we might need to amend jvector-side code to support this is where we go back and update header data after streaming out the rest of a file and writing an equivalent footer. I propose we absorb this change by doing what nearly every other system does when faced with this constraint: Simply make it footer based. There is no real downside for jvector on this given a footer is just as definitive as a header, and jvector should be marshaling any such reads anyway.

But given that jvector does need to do random IO in other places, like it does in some updates to graphs being built (distinct from compaction and output streaming) this is set aside as a separate concern, as compaction streaming output is fundamentally a different mechanical motion than dynamic graph building. The truth is that aligning our compaction capabilities to be more efficient has put us in a place where these are distinct IO patterns, and we should treat them as such. Acknowledging that, this PR is scoped _ONLY_ around writing streaming output like compactions.

There is more downstream work from this to make jvector compactions conform, but it is manageable. Further, this does not preclude jvector from doing random IO as needed upstream, even for compactions, since this is merely a degenerate case which is like what is already done. This API merely provides the contract boundary needed to push the jvector IO patterns for streamable data to where the need to be _for the purposes of writing compacted indexes specifically_ here. It should also provide the type-safe infrastructure needed for any other system like OpenSearch or Cassandra to manage the physical storage and transactional scope for safe one-shot pass or fail writing.

# Synopsis
  
A small, host-agnostic contract that tells jvector **where** to stream index output and **when** it becomes real, so a compacted graph (and later any written index) lands directly inside the embedding system's own storage instead of a jvector-owned file that the host then copies. Scoped to sequential streaming; motivated by #722 and the review of #710.
  
## Why
  
`OnDiskGraphIndexCompactor` only knows how to write to a `Path`, and it does so with random-access and memory-mapped IO on a file it assumes it owns. Every embedder pays for that assumption:
  
  - OpenSearch (Lucene) cannot use the compactor at all: `IndexOutput` is sequential, append-only, with an incremental checksum, and Lucene has declined to add random writes (lucene#15420).
  - Cassandra SAI and CNDB have to wrap jvector's file in their own container, which today means writing, then copying, then checksumming.
  - Standalone users get a partial file on failure and no atomic publish.
  
#722 asks for a streaming API flavour. The review of #710 established that the host's view should win over jvector's conventions, that configuration must stay separate from the live operation, and that no `Path` may leak into the embedded view. This PR is the contract that follows from those three points.

## What it is 
  
Four types in `io.github.jbellis.jvector.disk`, all `@Experimental`, JDK 11, plus a package-private file-backed default:
  
  
```mermaid
flowchart TD
    H["Embedding system<br/>owns the storage and implements the four types"]
    D["<b>IndexDestination</b><br/>stateless <i>where</i>: built once by the host, held"]
    S["<b>OutputSession</b><br/>one write operation: the transactional unit"]
    RG["<b>OutputReservation</b><br/>GRAPH"]
    RC["<b>OutputReservation</b><br/>COMPRESSED_VECTORS"]
    WG["<b>IndexWriter</b><br/>append-only, position() starts at 0"]
    WC["<b>IndexWriter</b><br/>append-only, position() starts at 0"]

    H --> D
    D -- "open()" --> S
    S -- "reserve(GRAPH)" --> RG
    S -- "reserve(COMPRESSED_VECTORS)" --> RC
    RG -- "stream()" --> WG
    RC -- "stream()" --> WC
    RG -. "complete(), then close()" .-> S
    RC -. "complete(), then close()" .-> S
    S -. "commit(), then close()" .-> H
```
                                
The only IO type jvector sees is the existing `IndexWriter` (`DataOutput` plus `position()`). The contract adds lifecycle around it; it does not introduce a new IO primitive.

## How it works
                                
- **Two levels of done.** Each artifact is `complete()`d: the reservation flushes its stream and the host finalizes that artifact (Lucene writes its file footer, SAI writes its component footer). The session is `commit()`ed once as a set: the host publishes (segment commit, component completion, rename into place).
- **Abort is the absence of commit.** Closing a reservation without `complete()` discards that artifact; closing a session without `commit()` discards everything. try-with-resources is the whole error-handling story, and interruption takes the same path.
- **State machines are enforced.** Reserve at most once per artifact, complete at most once, commit at most once, close idempotent; anything else is an `IllegalStateException` rather than silent misuse.
- **Coordinates are the stream's.** `position()` starts at 0 at the region start, and every offset the format stores (the footer's header offset, separated-feature offsets) is relative to it. A host reads the artifact back from that origin, which is exactly what makes a graph inside a container loadable. 
- **Hosts own durability, checksums and placement.** jvector never forces, truncates, deletes or renames a host resource; it streams bytes and reports completion.
- **The file default is the fast path.** `IndexDestination.toFile(path)` streams into a sibling temporary file and renames it into place on commit, so a reader never observes a partial graph and a failed compaction leaves the previous file intact. `toFiles(...)` does the same per artifact; `inFile(path, offset)` streams into a region of a caller-owned file without touching anything else in it. 
  
## Embedding-system-agnostic goals

- No host resource type in the embedded view. `Path` appears only in the file-backed static factories.
- Sequential by construction, so every host can implement it over what it already has: Lucene's `IndexOutput`, SAI's `SequentialWriter`, a CNDB staging file. No host has to offer seek, read-back or mapping.
- One contract for every host and for both the build-path writers and the compactor; the existing `OnDiskSequentialGraphIndexWriter.Builder(graph, reservation.stream())` works today with no new constructor.
- Zero overhead: the host's stream is the only thing between jvector's writer and storage. Metering and throttling are host-side decoration of that stream plus the existing progress and work-limiter seams.
- Additive and opt-in: no existing public signature changes; nothing in jvector consumes this yet.

## Why streaming is enough for compaction 
  
Verified against the compactor: the header is fully known before the first byte (layer sizes, entry node, retrained codebook); level-0 batches read only the source graphs and carry their final offsets, so completion order can be restored with a reorder buffer bounded by the window already in flight; dead ordinal slots become explicit zero records; upper layers and the footer are already appended in order. The only in-place rewrite is post-compaction refinement, which is off by default and becomes a second pass if wanted. Details and line references are in `docs/embedded-io-contract.md`, section 6.
  
## Deliberately not here

- Compactor and writer adoption (in-order emission). Follow-up PR.
- Positional writes, read-back during the write, scratch space. Each can be added later as an optional capability without changing these shapes.
- The memory-safety checks and `ReaderSupplier` documentation on #710; they stay there.
  
## Relationship to #710

Supersedes `CompactionDestination` / `OutputReservation` from #710 (path-bound `file()` and `startOffset()` are gone) and answers the review threads there: no overlap with the reader/writer interfaces, configuration kept separate from the operation, and no `Path` in the
embedded view. The execution, progress and work-limiting seams on #710 are untouched.

## Testing
  
`TestFileIndexDestination` (9 tests): session and reservation state machines, abort and commit behaviour, `DataOutput` encoding of the stream, region mode, multi-artifact publish, and graphs written through `OnDiskSequentialGraphIndexWriter` over a reservation into a
standalone file and into a container region, loaded back after commit.

```
mvn test -pl jvector-tests -am -Dtest=TestFileIndexDestination -Dsurefire.failIfNoSpecifiedTests=false
```
  
